### PR TITLE
feat(theme): export some of the things needed in the appkit website

### DIFF
--- a/packages/gatsby-theme-docs/index.js
+++ b/packages/gatsby-theme-docs/index.js
@@ -1,1 +1,12 @@
-// no-op file required for loading the plugin inside the private workspace
+import * as designSystem from './src/design-system';
+
+export { designSystem };
+export { Card, SEO, Spacings, IconButton, Markdown } from './src/components';
+export {
+  default as LayoutApplication,
+} from './src/layouts/internals/layout-application';
+export { default as LayoutHeader } from './src/layouts/internals/layout-header';
+export { default as LayoutFooter } from './src/layouts/internals/layout-footer';
+export { default as LayoutMain } from './src/layouts/internals/layout-main';
+export { default as Globals } from './src/layouts/internals/globals';
+export { default as createStyledIcon } from './src/utils/create-styled-icon';


### PR DESCRIPTION
Those exports are currently what is needed for the appkit website, to avoid having the imports reaching into the internal folders.

Eventually we can move some of those things into a separate package that contains ui components.