### PR TITLE
fix(theme): use built-in image caption

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -88,7 +88,9 @@ module.exports = {
               // It's important to specify the maxWidth (in pixels) of
               // the content container as this plugin uses this as the
               // base for generating different widths of each image.
-              maxWidth: 770 - 8 - 8, // content width - padding left/right
+              // maxWidth: 770 - 8 - 8, // content width - padding left/right
+              maxWidth: 770, // content width - padding left/right
+              showCaptions: ['title'],
             },
           },
           {

--- a/packages/gatsby-theme-docs/src/components/markdown.js
+++ b/packages/gatsby-theme-docs/src/components/markdown.js
@@ -487,37 +487,6 @@ Link.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
 };
-const Img = props => (
-  <span
-    css={css`
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      > * + * {
-        margin: ${dimensions.spacings.s} 0 0;
-      }
-    `}
-  >
-    <img
-      {...props}
-      css={css`
-        background-color: ${colors.light.surfacePrimary};
-      `}
-    />
-    {/* eslint-disable-next-line react/prop-types */}
-    {props.title ? (
-      <span
-        css={css`
-          color: ${colors.light.textSecondary};
-          font-size: ${typography.fontSizes.small};
-        `}
-      >
-        {/* eslint-disable-next-line react/prop-types */}
-        {props.title}
-      </span>
-    ) : null}
-  </span>
-);
 
 /* eslint-disable react/display-name,react/prop-types */
 const withAnchorLink = Component => props => {
@@ -575,6 +544,5 @@ export {
   Delete,
   Hr,
   Link,
-  Img,
   withAnchorLink,
 };

--- a/packages/gatsby-theme-docs/src/layouts/internals/globals.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/globals.js
@@ -29,21 +29,48 @@ const Globals = () => (
         padding: 0 0 0 ${dimensions.spacings.l};
       }
 
+      /* Images */
+
       .gatsby-resp-image-wrapper {
         background-color: ${colors.light.surfaceSecondary1};
         border-radius: ${tokens.borderRadius6};
         margin: ${dimensions.spacings.m} 0;
         padding: ${dimensions.spacings.s};
       }
+      .gatsby-resp-image-figure {
+        background-color: ${colors.light.surfaceSecondary1};
+        border-radius: ${tokens.borderRadius6};
+        margin: 0;
+        padding: ${dimensions.spacings.s};
+      }
       .gatsby-resp-image-link {
         text-decoration: none;
       }
       .gatsby-resp-image-image {
+        background-color: ${colors.light.surfacePrimary};
         box-shadow: none !important;
         width: calc(100% - ${dimensions.spacings.s} * 2);
         height: auto;
         margin: ${dimensions.spacings.s};
       }
+      .gatsby-resp-image-figure .gatsby-resp-image-wrapper {
+        background-color: unset;
+        border-radius: unset;
+        margin: unset;
+        padding: unset;
+      }
+      .gatsby-resp-image-figure .gatsby-resp-image-image {
+        width: 100%;
+        height: unset;
+        margin: unset;
+      }
+      .gatsby-resp-image-figcaption {
+        color: ${colors.light.textSecondary};
+        font-size: ${typography.fontSizes.small};
+        margin: ${dimensions.spacings.xs} 0 0;
+      }
+
+      /* Code blocks syntax highlighting */
 
       .gatsby-highlight {
         background-color: ${colors.light.surfaceCode};

--- a/packages/gatsby-theme-docs/src/templates/page-content.js
+++ b/packages/gatsby-theme-docs/src/templates/page-content.js
@@ -36,7 +36,6 @@ const components = {
   delete: Markdown.Delete,
   hr: Markdown.Hr,
   a: Markdown.Link,
-  img: Markdown.Img,
   // eslint-disable-next-line react/display-name
   pre: Markdown.CodeBlock,
 

--- a/websites/docs-smoke-test/src/content/images/image-with-caption.mdx
+++ b/websites/docs-smoke-test/src/content/images/image-with-caption.mdx
@@ -3,7 +3,11 @@ title: Image With Caption Test Page
 ---
 
 Images can have a caption like the above. It's authored by setting the `title` using the markdown notation
-`![image of a cat](../../images/cat.png "Cats are a fully supported feature of the Scala programming language")`.
-The "image of a cat" `alt` text of the image is not used as a caption but remains what it's intended for - a fallback text for screen readers or if the image fails to load.
+
+```
+![the image alt text goes here](../../images/full-resolution-photo.jpg 'The image title goes here and should be rendered as the caption')
+```
+
+The "_the image alt text goes here_" `alt` text of the image is not used as a caption but remains what it's intended for - a fallback text for screen readers or if the image fails to load.
 
 ![the image alt text goes here](../../images/full-resolution-photo.jpg 'The image title goes here and should be rendered as the caption')

--- a/websites/docs-smoke-test/src/content/images/image.mdx
+++ b/websites/docs-smoke-test/src/content/images/image.mdx
@@ -6,4 +6,8 @@ The following image does not have a caption.
 
 It's a large high-resolution image and fills the full width.
 
+```
+![the image alt text goes here](../../images/full-resolution-photo.jpg)
+```
+
 ![the image alt text goes here](../../images/full-resolution-photo.jpg)

--- a/websites/docs-smoke-test/src/content/images/inline-image.mdx
+++ b/websites/docs-smoke-test/src/content/images/inline-image.mdx
@@ -4,4 +4,8 @@ title: Inline Image Test Page
 
 The following image is embedded into a body text paragraph. It will appear somehow on the page.
 
-The Image is after this text ![the image alt text goes here](../../images/full-resolution-photo.jpg) and before this text.
+```
+![the image alt text goes here](../../images/full-resolution-photo.jpg 'The image title goes here and should be rendered as the caption')
+```
+
+The Image is after this text ![the image alt text goes here](../../images/full-resolution-photo.jpg 'The image title goes here and should be rendered as the caption') and before this text.

--- a/websites/docs-smoke-test/src/content/images/svg-image.mdx
+++ b/websites/docs-smoke-test/src/content/images/svg-image.mdx
@@ -4,4 +4,8 @@ title: SVG Image Test Page
 
 SVG Images are not handled by the Gatsby Image Processing Pipeline but should still be rendered in an acceptably styled and positioned way.
 
+```
+![the image alt text goes here](../files/svg-with-transparent-background.svg 'this is the title')
+```
+
 ![the image alt text goes here](../files/svg-with-transparent-background.svg 'this is the title')

--- a/websites/docs-smoke-test/src/content/images/tall-image.mdx
+++ b/websites/docs-smoke-test/src/content/images/tall-image.mdx
@@ -4,4 +4,8 @@ title: Tall Image Test Page
 
 It's not a good idea to have such content but the image should not be made smaller by the implementation just because it's very tall.
 
+```
+![the image alt text goes here](../../images/tall-png-with-transparent-background.png)
+```
+
 ![the image alt text goes here](../../images/tall-png-with-transparent-background.png)

--- a/websites/docs-smoke-test/src/content/images/transparent-image.mdx
+++ b/websites/docs-smoke-test/src/content/images/transparent-image.mdx
@@ -4,4 +4,8 @@ title: Transparent Image Test Page
 
 The following image has a transparent area in the image source file. It must be rendered with a white background.
 
-![the image alt text goes here](/../../images/small-png-with-transparent-background.png)
+```
+![the image alt text goes here](../../images/small-png-with-transparent-background.png)
+```
+
+![the image alt text goes here](../../images/small-png-with-transparent-background.png)


### PR DESCRIPTION
Fixes #41 

<img width="814" alt="image" src="https://user-images.githubusercontent.com/1110551/68745766-8be01180-05f7-11ea-9ca2-8e949cf628fa.png">
