### PR TITLE
fix: remove page slug trailing slash

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -53,7 +53,7 @@ exports.onCreateNode = ({ node, getNode, actions }, pluginOptions) => {
     actions.createNodeField({
       node,
       name: 'slug',
-      value: slug,
+      value: trimTrailingSlash(slug) || '/',
     });
   }
 };

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -143,10 +143,10 @@ const Sidebar = props => {
           </SidebarLinkItem>
           <Spacings.Stack scale="s">
             {node.pages &&
-              node.pages.map(pageLink => (
+              node.pages.map((pageLink, pageIndex) => (
                 <SidebarLink
                   to={pageLink.path}
-                  key={pageLink.path}
+                  key={`${index}-${pageIndex}-${pageLink.path}`}
                   onClick={props.onLinkClick}
                 >
                   <SidebarLinkSubtitle>{pageLink.title}</SidebarLinkSubtitle>


### PR DESCRIPTION
Leftover of #29 

TL;DR: the generated page slug should also not have a trailing slash. I noticed this as Gatsby was throwing some warnings of hot reloads.

```
warn Attempting to create page "/views/empty/", but page "/views/empty" already exists. This could lead to non-deterministic routing behavior
```