### PR TITLE
chore: use vale local bin for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ public
 
 # Editor/IDE
 .idea
+-.vscode
+-!.vscode/settings.json
 
 # Cypress
 cypress/screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -73,8 +73,6 @@ public
 
 # Editor/IDE
 .idea
-.vscode
-!.vscode/settings.json
 
 # Cypress
 cypress/screenshots

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "vscode-vale.path": "node_modules/.bin/commercetools-vale"
+}


### PR DESCRIPTION
So our [PR](https://github.com/testthedocs/vscode-vale/pull/8) for make the extension configurable got merged and released yesterday. I tried this out now and it works!

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/1110551/68931359-a39ecd80-0790-11ea-8c36-736a84f885ca.png">

However, the `mdx` files are [being ignored by the extension](https://github.com/testthedocs/vscode-vale/blob/de4ab0bab73774f01d1ee3114bc84a806db0c3c5/src/extension.ts#L275). I'll open a new PR to add the `mdx` extension and maybe to also make it configurable.