### PR TITLE
fix(theme): use div element for subtitle

### DIFF
--- a/packages/gatsby-theme-docs/src/components/subtitle.js
+++ b/packages/gatsby-theme-docs/src/components/subtitle.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { typography } from '../design-system';
 
-const Subtitle = styled.p`
+const Subtitle = styled.div`
   font-size: ${typography.fontSizes.h3};
 `;
 


### PR DESCRIPTION
Since `<Subtitle>` can contain/render markdown syntax, the wrapper element should be a `div`.
This avoids warnings where `<p>` only accepts a subset of child element types.