### PR TITLE
feat(theme): expose theme provider for extending site metadata

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -17,6 +17,7 @@ proxyEnvironmentVariables.forEach(envName => {
 const defaultOptions = {
   websiteName: '',
   gaTrackingId: undefined,
+  createNodeSlug: undefined,
 };
 const requiredOptions = ['websiteName'];
 

--- a/packages/gatsby-theme-docs/index.js
+++ b/packages/gatsby-theme-docs/index.js
@@ -1,10 +1,17 @@
 import * as designSystem from './src/design-system';
 
 export { designSystem };
-export { Card, SEO, Spacings, IconButton, Markdown } from './src/components';
+export {
+  Card,
+  SEO,
+  Spacings,
+  IconButton,
+  Markdown,
+  ThemeProvider,
+} from './src/components';
 export { default as LayoutApplication } from './src/layouts/internals/layout-application';
 export { default as LayoutHeader } from './src/layouts/internals/layout-header';
 export { default as LayoutFooter } from './src/layouts/internals/layout-footer';
 export { default as LayoutMain } from './src/layouts/internals/layout-main';
-export { default as Globals } from './src/layouts/internals/globals';
 export { default as createStyledIcon } from './src/utils/create-styled-icon';
+export { useSiteData } from './src/hooks/use-site-data';

--- a/packages/gatsby-theme-docs/src/components/index.js
+++ b/packages/gatsby-theme-docs/src/components/index.js
@@ -10,4 +10,5 @@ export { default as SEO } from './seo';
 export { default as Spacings } from './spacings';
 export { default as Subtitle } from './subtitle';
 export { default as TextSmall } from './text-small';
+export { default as ThemeProvider } from './theme-provider';
 export { Markdown };

--- a/packages/gatsby-theme-docs/src/components/theme-provider.js
+++ b/packages/gatsby-theme-docs/src/components/theme-provider.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useStaticQuery, graphql } from 'gatsby';
+import { SiteDataContext } from '../hooks/use-site-data';
+import useAdditionalSiteData from '../overrides/use-additional-site-data';
+import Reset from '../layouts/internals/reset';
+import Globals from '../layouts/internals/globals';
+import ErrorBoundary from './error-boundary';
+
+const ThemeProvider = props => {
+  const data = useStaticQuery(graphql`
+    query GetSiteData {
+      site {
+        pathPrefix
+        siteMetadata {
+          title
+          description
+          author
+          productionHostname
+        }
+      }
+    }
+  `);
+  const additionalData = useAdditionalSiteData();
+  const siteData = {
+    pathPrefix: data.site.pathPrefix,
+    siteMetadata: { ...data.site.siteMetadata, ...additionalData },
+  };
+  return (
+    <ErrorBoundary>
+      <SiteDataContext.Provider value={siteData}>
+        <Reset />
+        <Globals />
+        {props.children}
+      </SiteDataContext.Provider>
+    </ErrorBoundary>
+  );
+};
+ThemeProvider.propTypes = {
+  additionalSiteData: PropTypes.object,
+  children: PropTypes.node.isRequired,
+};
+
+export default ThemeProvider;

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -1,28 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useStaticQuery, graphql } from 'gatsby';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import {
   ContentPagination,
   ContentNotifications,
   Markdown,
-  ErrorBoundary,
 } from '../components';
 import { dimensions, tokens } from '../design-system';
 import PlaceholderPageHeaderSide from '../overrides/page-header-side';
-import { SiteDataContext } from '../hooks/use-site-data';
 import LayoutApplication from './internals/layout-application';
 import LayoutHeader from './internals/layout-header';
 import LayoutSidebar from './internals/layout-sidebar';
 import LayoutMain from './internals/layout-main';
 import LayoutFooter from './internals/layout-footer';
-import Reset from './internals/reset';
-import Globals from './internals/globals';
 import LayoutPageHeader from './internals/layout-page-header';
 import LayoutPageHeaderSide from './internals/layout-page-header-side';
 import LayoutPageNavigation from './internals/layout-page-navigation';
 import LayoutPageContent from './internals/layout-page-content';
+import { useSiteData } from '../hooks/use-site-data';
 
 const GridArea = styled.div`
   grid-area: ${props => props.name};
@@ -44,103 +40,84 @@ const ResizableGrid = styled.div`
 
 const LayoutContent = props => {
   const [isMenuOpen, setMenuOpen] = React.useState(false);
-  const data = useStaticQuery(graphql`
-    query GetSiteData {
-      site {
-        pathPrefix
-        siteMetadata {
-          title
-          description
-          author
-          productionHostname
-        }
-      }
-    }
-  `);
+  const siteData = useSiteData();
   return (
-    <ErrorBoundary>
-      <SiteDataContext.Provider value={data.site}>
-        <Reset />
-        <Globals />
-        <LayoutApplication isMenuOpen={isMenuOpen}>
-          <LayoutHeader siteTitle={data.site.siteMetadata.title} />
-          <LayoutSidebar
-            isMenuOpen={isMenuOpen}
-            setMenuOpen={setMenuOpen}
-            slug={props.pageContext.slug}
-            siteTitle={data.site.siteMetadata.title}
-          />
-          <LayoutMain
+    <LayoutApplication isMenuOpen={isMenuOpen}>
+      <LayoutHeader siteTitle={siteData.siteMetadata.title} />
+      <LayoutSidebar
+        isMenuOpen={isMenuOpen}
+        setMenuOpen={setMenuOpen}
+        slug={props.pageContext.slug}
+        siteTitle={siteData.siteMetadata.title}
+      />
+      <LayoutMain
+        css={css`
+          grid-column: 2;
+          grid-row: 2;
+
+          div {
+            min-width: unset;
+          }
+
+          @media screen and (${dimensions.viewports.mobile}) {
+            grid-column: 1/3;
+            grid-row: ${isMenuOpen ? '3' : '2'};
+          }
+        `}
+      >
+        <ResizableGrid>
+          <GridArea name="left" />
+          <GridArea name="right" />
+          <GridArea
+            id="anchor-page-top"
+            name="center"
             css={css`
-              grid-column: 2;
-              grid-row: 2;
+              display: block;
 
-              div {
-                min-width: unset;
+              @media screen and (${dimensions.viewports.tablet}) {
+                display: grid;
+                grid-template-columns:
+                  calc(
+                    ${dimensions.widths.pageContent} + ${dimensions.spacings.xl} *
+                      2
+                  )
+                  0;
+                grid-template-rows: auto 1fr;
               }
-
-              @media screen and (${dimensions.viewports.mobile}) {
-                grid-column: 1/3;
-                grid-row: ${isMenuOpen ? '3' : '2'};
+              @media screen and (${dimensions.viewports.largeTablet}) {
+                grid-template-columns:
+                  calc(
+                    ${dimensions.widths.pageContent} + ${dimensions.spacings.xl} *
+                      2
+                  )
+                  ${dimensions.widths.pageNavigation};
               }
             `}
           >
-            <ResizableGrid>
-              <GridArea name="left" />
-              <GridArea name="right" />
-              <GridArea
-                id="anchor-page-top"
-                name="center"
-                css={css`
-                  display: block;
-
-                  @media screen and (${dimensions.viewports.tablet}) {
-                    display: grid;
-                    grid-template-columns:
-                      calc(
-                        ${dimensions.widths.pageContent} +
-                          ${dimensions.spacings.xl} * 2
-                      )
-                      0;
-                    grid-template-rows: auto 1fr;
-                  }
-                  @media screen and (${dimensions.viewports.largeTablet}) {
-                    grid-template-columns:
-                      calc(
-                        ${dimensions.widths.pageContent} +
-                          ${dimensions.spacings.xl} * 2
-                      )
-                      ${dimensions.widths.pageNavigation};
-                  }
-                `}
-              >
-                <LayoutPageHeader>
-                  <Markdown.H1>{props.pageData.frontmatter.title}</Markdown.H1>
-                </LayoutPageHeader>
-                <LayoutPageHeaderSide>
-                  <PlaceholderPageHeaderSide />
-                </LayoutPageHeaderSide>
-                <LayoutPageContent>
-                  {props.pageData.frontmatter.beta && (
-                    <ContentNotifications.BetaInfo />
-                  )}
-                  {props.children}
-                  <ContentPagination slug={props.pageContext.slug} />
-                </LayoutPageContent>
-                <LayoutPageNavigation
-                  pageTitle={
-                    props.pageContext.shortTitle ||
-                    props.pageData.frontmatter.title
-                  }
-                  tableOfContents={props.pageData.tableOfContents}
-                />
-              </GridArea>
-            </ResizableGrid>
-            <LayoutFooter />
-          </LayoutMain>
-        </LayoutApplication>
-      </SiteDataContext.Provider>
-    </ErrorBoundary>
+            <LayoutPageHeader>
+              <Markdown.H1>{props.pageData.frontmatter.title}</Markdown.H1>
+            </LayoutPageHeader>
+            <LayoutPageHeaderSide>
+              <PlaceholderPageHeaderSide />
+            </LayoutPageHeaderSide>
+            <LayoutPageContent>
+              {props.pageData.frontmatter.beta && (
+                <ContentNotifications.BetaInfo />
+              )}
+              {props.children}
+              <ContentPagination slug={props.pageContext.slug} />
+            </LayoutPageContent>
+            <LayoutPageNavigation
+              pageTitle={
+                props.pageContext.shortTitle || props.pageData.frontmatter.title
+              }
+              tableOfContents={props.pageData.tableOfContents}
+            />
+          </GridArea>
+        </ResizableGrid>
+        <LayoutFooter />
+      </LayoutMain>
+    </LayoutApplication>
   );
 };
 LayoutContent.displayName = 'LayoutContent';

--- a/packages/gatsby-theme-docs/src/overrides/README.md
+++ b/packages/gatsby-theme-docs/src/overrides/README.md
@@ -4,3 +4,4 @@ Overrides files using theme shadowing, in order to inject specific functionaliti
 
 - `markdown-components`: allows to pass React components to be injected in the MDX context
 - `page-header-side`: allows to render something in the top-right corner of a content page
+- `use-additional-site-data`: allows to return custom site metadata using React hooks

--- a/packages/gatsby-theme-docs/src/overrides/use-additional-site-data.js
+++ b/packages/gatsby-theme-docs/src/overrides/use-additional-site-data.js
@@ -1,0 +1,5 @@
+// A React hook that should be overriden in case the website needs to
+// extend the default `siteData`.
+const useAdditionalSiteData = () => {};
+
+export default useAdditionalSiteData;

--- a/packages/gatsby-theme-docs/src/templates/page-content.js
+++ b/packages/gatsby-theme-docs/src/templates/page-content.js
@@ -4,7 +4,13 @@ import { graphql } from 'gatsby';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 import { MDXProvider } from '@mdx-js/react';
 import LayoutContent from '../layouts/content';
-import { SEO, Markdown, Subtitle, ContentNotifications } from '../components';
+import {
+  SEO,
+  Markdown,
+  Subtitle,
+  ContentNotifications,
+  ThemeProvider,
+} from '../components';
 import PlaceholderMarkdownComponents from '../overrides/markdown-components';
 
 // See https://mdxjs.com/getting-started#table-of-components
@@ -50,21 +56,23 @@ const components = {
 };
 
 const PageContentTemplate = props => (
-  <LayoutContent pageContext={props.pageContext} pageData={props.data.mdx}>
-    <MDXProvider components={components}>
-      <Markdown.TypographyPage>
-        <SEO
-          title={
-            props.pageContext.shortTitle || props.data.mdx.frontmatter.title
-          }
-        />
-        {/* This wrapper div is important to ensure the vertical space */}
-        <div>
-          <MDXRenderer>{props.data.mdx.body}</MDXRenderer>
-        </div>
-      </Markdown.TypographyPage>
-    </MDXProvider>
-  </LayoutContent>
+  <ThemeProvider>
+    <LayoutContent pageContext={props.pageContext} pageData={props.data.mdx}>
+      <MDXProvider components={components}>
+        <Markdown.TypographyPage>
+          <SEO
+            title={
+              props.pageContext.shortTitle || props.data.mdx.frontmatter.title
+            }
+          />
+          {/* This wrapper div is important to ensure the vertical space */}
+          <div>
+            <MDXRenderer>{props.data.mdx.body}</MDXRenderer>
+          </div>
+        </Markdown.TypographyPage>
+      </MDXProvider>
+    </LayoutContent>
+  </ThemeProvider>
 );
 
 PageContentTemplate.displayName = 'PageContentTemplate';

--- a/websites/docs-smoke-test/gatsby-config.js
+++ b/websites/docs-smoke-test/gatsby-config.js
@@ -3,14 +3,12 @@ module.exports = {
   siteMetadata: {
     title: 'Docs Smoke Test',
     description: 'Documentation website for smoke tests',
-    author: 'commercetools',
   },
   plugins: [
     {
       resolve: '@commercetools-docs/gatsby-theme-docs',
       options: {
         websiteName: 'docs-smoke-test',
-        gaTrackingId: 'UA-38285631-3',
       },
     },
   ],


### PR DESCRIPTION
This PR adds a new extension point regarding custom site metadata that websites might use (e.g. appkit).
It also exposes a new component `ThemeProvider` that should be rendered by any page template so that the data is available in React context.