### PR TITLE
chore: use new setting syntax for vscode vale extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "vscode-vale.path": "node_modules/.bin/commercetools-vale"
+  "vscode-vale.path": "${workspaceFolder}/node_modules/.bin/commercetools-vale"
 }


### PR DESCRIPTION
Based on this: https://github.com/testthedocs/vscode-vale/pull/12