### PR TITLE
fix: npm scope that actually exists

### DIFF
--- a/packages/gatsby-transformer-raml-legacy/README.md
+++ b/packages/gatsby-transformer-raml-legacy/README.md
@@ -34,7 +34,7 @@ module.exports = {
       },
     },
     {
-      resolve: `@commercetools-docs-kit/gatsby-transformer-raml-legacy`,
+      resolve: `@commercetools-docs/gatsby-transformer-raml-legacy`,
       options: {
         validate: true,
       },

--- a/packages/gatsby-transformer-raml-legacy/package.json
+++ b/packages/gatsby-transformer-raml-legacy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@commercetools-docs-kit/gatsby-transformer-raml-legacy",
+  "name": "@commercetools-docs/gatsby-transformer-raml-legacy",
   "version": "1.0.0-alpha.0",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
I messed up npm scope vs. repo name again, sorry.  Found out only after merging because the publish CI failed