### PR TITLE
feat(theme): allow to configure robots noindex

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -17,6 +17,7 @@ proxyEnvironmentVariables.forEach(envName => {
 const defaultOptions = {
   websiteKey: '',
   gaTrackingId: undefined,
+  excludeFromSearchIndex: true,
   createNodeSlug: undefined,
 };
 const requiredOptions = ['websiteKey'];

--- a/packages/gatsby-theme-docs/src/components/seo.js
+++ b/packages/gatsby-theme-docs/src/components/seo.js
@@ -10,69 +10,70 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { useSiteData } from '../hooks/use-site-data';
 
-const SEO = ({ description, lang, meta, keywords, title }) => {
+const SEO = props => {
   const siteData = useSiteData();
-  const metaDescription = description || siteData.siteMetadata.description;
+  const metaDescription =
+    props.description || siteData.siteMetadata.description;
 
   return (
     <Helmet
       htmlAttributes={{
-        lang,
+        lang: props.lang,
       }}
-      title={title}
+      title={props.title}
       titleTemplate={`%s | ${siteData.siteMetadata.title} | commercetools`}
       meta={[
         {
-          name: `description`,
+          name: 'description',
+          content: metaDescription,
+        },
+        props.keywords.length > 0 && {
+          name: 'keywords',
+          content: props.keywords.join(', '),
+        },
+        {
+          property: 'og:title',
+          content: props.title,
+        },
+        {
+          property: 'og:description',
           content: metaDescription,
         },
         {
-          property: `og:title`,
-          content: title,
+          property: 'og:type',
+          content: 'website',
         },
         {
-          property: `og:description`,
-          content: metaDescription,
+          name: 'twitter:card',
+          content: 'summary',
         },
         {
-          property: `og:type`,
-          content: `website`,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary`,
-        },
-        {
-          name: `twitter:creator`,
+          name: 'twitter:creator',
           content: siteData.siteMetadata.author,
         },
         {
-          name: `twitter:title`,
-          content: title,
+          name: 'twitter:title',
+          content: props.title,
         },
         {
-          name: `twitter:description`,
+          name: 'twitter:description',
           content: metaDescription,
         },
-      ]
-        .concat(
-          keywords.length > 0
-            ? {
-                name: `keywords`,
-                content: keywords.join(`, `),
-              }
-            : []
-        )
-        .concat(meta)}
+        props.excludeFromSearchIndex && {
+          name: 'robots',
+          content: 'noindex',
+        },
+        ...props.meta,
+      ].filter(Boolean)}
     />
   );
 };
 SEO.displayName = 'SEO';
 SEO.defaultProps = {
-  lang: `en`,
+  lang: 'en',
   meta: [],
   keywords: [],
-  description: ``,
+  description: '',
 };
 SEO.propTypes = {
   description: PropTypes.string,
@@ -80,6 +81,7 @@ SEO.propTypes = {
   meta: PropTypes.arrayOf(PropTypes.object),
   keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,
+  excludeFromSearchIndex: PropTypes.bool.isRequired,
 };
 
 export default SEO;

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -85,22 +85,18 @@ const LayoutContent = props => {
           `}
         >
           <LayoutPageHeader>
-            <Markdown.H1>{props.pageData.frontmatter.title}</Markdown.H1>
+            <Markdown.H1>{props.pageContext.title}</Markdown.H1>
           </LayoutPageHeader>
           <LayoutPageHeaderSide>
             <PlaceholderPageHeaderSide />
           </LayoutPageHeaderSide>
           <LayoutPageContent>
-            {props.pageData.frontmatter.beta && (
-              <ContentNotifications.BetaInfo />
-            )}
+            {props.pageContext.beta && <ContentNotifications.BetaInfo />}
             {props.children}
             <ContentPagination slug={props.pageContext.slug} />
           </LayoutPageContent>
           <LayoutPageNavigation
-            pageTitle={
-              props.pageContext.shortTitle || props.pageData.frontmatter.title
-            }
+            pageTitle={props.pageContext.shortTitle || props.pageContext.title}
             tableOfContents={props.pageData.tableOfContents}
           />
         </div>
@@ -114,12 +110,10 @@ LayoutContent.propTypes = {
   pageContext: PropTypes.shape({
     slug: PropTypes.string.isRequired,
     shortTitle: PropTypes.string,
+    title: PropTypes.string.isRequired,
+    beta: PropTypes.bool,
   }).isRequired,
   pageData: PropTypes.shape({
-    frontmatter: PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      beta: PropTypes.bool,
-    }).isRequired,
     tableOfContents: PropTypes.object.isRequired,
   }).isRequired,
   children: PropTypes.node.isRequired,

--- a/packages/gatsby-theme-docs/src/templates/page-content.js
+++ b/packages/gatsby-theme-docs/src/templates/page-content.js
@@ -64,6 +64,7 @@ const PageContentTemplate = props => (
             title={
               props.pageContext.shortTitle || props.data.mdx.frontmatter.title
             }
+            excludeFromSearchIndex={props.pageContext.excludeFromSearchIndex}
           />
           {/* This wrapper div is important to ensure the vertical space */}
           <div>
@@ -80,6 +81,7 @@ PageContentTemplate.propTypes = {
   pageContext: PropTypes.shape({
     slug: PropTypes.string.isRequired,
     shortTitle: PropTypes.string,
+    excludeFromSearchIndex: PropTypes.bool.isRequired,
   }).isRequired,
   data: PropTypes.shape({
     mdx: PropTypes.shape({

--- a/packages/gatsby-theme-docs/src/templates/page-content.js
+++ b/packages/gatsby-theme-docs/src/templates/page-content.js
@@ -18,8 +18,7 @@ const components = {
   p: Markdown.Paragraph,
   // NOTE: we want to ensure that only one h1 exists on each page.
   // Therefore, we map the markdown header elements starting from h2.
-  // The h1 header will be automatically rendered based on the frontmatter
-  // page values.
+  // The h1 header will be automatically rendered based on the page title.
   h1: Markdown.withAnchorLink(Markdown.H2),
   h2: Markdown.withAnchorLink(Markdown.H3),
   h3: Markdown.withAnchorLink(Markdown.H4),
@@ -61,9 +60,7 @@ const PageContentTemplate = props => (
       <MDXProvider components={components}>
         <Markdown.TypographyPage>
           <SEO
-            title={
-              props.pageContext.shortTitle || props.data.mdx.frontmatter.title
-            }
+            title={props.pageContext.shortTitle || props.pageContext.title}
             excludeFromSearchIndex={props.pageContext.excludeFromSearchIndex}
           />
           {/* This wrapper div is important to ensure the vertical space */}
@@ -81,13 +78,12 @@ PageContentTemplate.propTypes = {
   pageContext: PropTypes.shape({
     slug: PropTypes.string.isRequired,
     shortTitle: PropTypes.string,
+    title: PropTypes.string.isRequired,
+    beta: PropTypes.bool.isRequired,
     excludeFromSearchIndex: PropTypes.bool.isRequired,
   }).isRequired,
   data: PropTypes.shape({
     mdx: PropTypes.shape({
-      frontmatter: PropTypes.shape({
-        title: PropTypes.string.isRequired,
-      }).isRequired,
       body: PropTypes.string.isRequired,
       tableOfContents: PropTypes.object.isRequired,
     }).isRequired,
@@ -98,10 +94,6 @@ export default PageContentTemplate;
 export const query = graphql`
   query QueryMarkdownPage($slug: String!) {
     mdx(fields: { slug: { eq: $slug } }) {
-      frontmatter {
-        title
-        beta
-      }
       body
       tableOfContents(maxDepth: 4)
     }

--- a/websites/docs-smoke-test/gatsby-config.js
+++ b/websites/docs-smoke-test/gatsby-config.js
@@ -9,6 +9,7 @@ module.exports = {
       resolve: '@commercetools-docs/gatsby-theme-docs',
       options: {
         websiteKey: 'docs-smoke-test',
+        excludeFromSearchIndex: true,
       },
     },
   ],

--- a/websites/site-template/gatsby-config.js
+++ b/websites/site-template/gatsby-config.js
@@ -3,14 +3,16 @@ module.exports = {
   siteMetadata: {
     title: 'CHANGE-ME',
     description: 'CHANGE-ME',
-    author: 'commercetools',
   },
   plugins: [
     {
       resolve: '@commercetools-docs/gatsby-theme-docs',
       options: {
         websiteKey: 'CHANGE-ME',
-        /* gaTrackingId: 'CHANGE-ME' */ // to enable trackign with Google Analytics, enter the site ID here
+        excludeFromSearchIndex: true,
+
+        // To enable tracking with Google Analytics, enter the site ID here
+        // gaTrackingId: 'CHANGE-ME',
       },
     },
   ],


### PR DESCRIPTION
Closes #88 

By default the option `excludeFromSearchIndex` is `false`, which means websites can be crawled. You need to explicitly opt-in to disable the crawling on the entire site or on a page level (only via the navigation.yaml)

<img width="507" alt="image" src="https://user-images.githubusercontent.com/1110551/69444745-4aff9f80-0d51-11ea-91fc-059568e8a523.png">
