### PR TITLE
refactor(theme): work around to ensure frontmatter fields are created in the GraphQL schema

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -83,6 +83,14 @@ module.exports = (themeOptions = {}) => {
           path: path.resolve(`./src/content`),
         },
       },
+      // Internal content pages (.mdx)
+      {
+        resolve: 'gatsby-source-filesystem',
+        options: {
+          name: 'internalContent',
+          path: path.join(__dirname, `./src/content`),
+        },
+      },
 
       /**
        * Transformers for making content available in graphql queries

--- a/packages/gatsby-theme-docs/src/content/index.mdx
+++ b/packages/gatsby-theme-docs/src/content/index.mdx
@@ -1,0 +1,13 @@
+---
+title: This is a title
+beta: false
+---
+
+This file is used as a workaround to ensure that all available frontmatter fields are created in the GraphQL schema.
+
+For more info (related issues):
+
+- https://www.gatsbyjs.org/docs/schema-customization/
+- https://github.com/gatsbyjs/gatsby/issues/16529
+- https://github.com/gatsbyjs/gatsby/pull/16928
+- https://spectrum.chat/gatsby-js/general/schema-customization-question~aa89299f-fdf1-432c-b54a-3f431986ae41


### PR DESCRIPTION
Fixes #70 
