### PR TITLE
fix(theme): give more padding for page navigation scrollbar

### DIFF
--- a/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.js
@@ -76,9 +76,9 @@ const Indented = styled.div`
   padding: ${props => {
     switch (props.level) {
       case 3:
-        return `0 0 0 ${dimensions.spacings.xl}`;
+        return `0 ${dimensions.spacings.xl}`;
       default:
-        return `0 0 0 ${dimensions.spacings.m}`;
+        return `0 ${dimensions.spacings.m}`;
     }
   }};
 `;


### PR DESCRIPTION
Fixes #120 

<img width="218" alt="image" src="https://user-images.githubusercontent.com/1110551/70316909-f7935400-181c-11ea-8182-721ca924f5a4.png">
