### PR TITLE
refactor(theme): to expose CodeBlock component with generic props (no mdx specific)

### DIFF
--- a/packages/gatsby-theme-docs/index.js
+++ b/packages/gatsby-theme-docs/index.js
@@ -1,7 +1,7 @@
 import * as designSystem from './src/design-system';
 
 export { designSystem };
-export { SEO, Markdown, ThemeProvider } from './src/components';
+export { CodeBlock, SEO, Markdown, ThemeProvider } from './src/components';
 export { default as LayoutApplication } from './src/layouts/internals/layout-application';
 export { default as LayoutHeader } from './src/layouts/internals/layout-header';
 export { default as LayoutMain } from './src/layouts/internals/layout-main';

--- a/packages/gatsby-theme-docs/src/components/code-block.js
+++ b/packages/gatsby-theme-docs/src/components/code-block.js
@@ -146,39 +146,29 @@ const TooltipBodyComponent = styled.div`
  * yarn start
  * ```
  */
+const languageAliases = {
+  sh: 'bash',
+  zsh: 'bash',
+  console: 'bash',
+  terminal: 'bash',
+  js: 'javascript',
+};
 const CodeBlock = props => {
-  const className = props.children.props ? props.children.props.className : '';
-  const languageToken = className || 'language-text';
-  const languageAliases = {
-    sh: 'bash',
-    zsh: 'bash',
-    console: 'bash',
-    terminal: 'bash',
-    js: 'javascript',
-  };
-  const [, languageCode] = languageToken.split('language-');
+  const languageCode = props.language || 'text';
   const language = languageAliases[languageCode] || languageCode;
-
-  const { title, highlightLines, noPromptLines } = codeBlockParseOptions(
-    props.children.props
-  );
   const useCommandLine = ['terminal', 'console'].includes(languageCode);
-  const content =
-    props.children.props && props.children.props.children
-      ? props.children.props.children
-      : props.children;
   const formattedContent = codeBlockHighlightCode({
     language,
-    code: content,
-    highlightLines,
-    noPromptLines,
+    code: props.content,
+    highlightLines: props.highlightLines,
+    noPromptLines: props.noPromptLines,
     useCommandLine,
   }).replace(/\n$/, '');
 
   // Copy to clipboard logic
   const [isCopiedToClipboard, setIsCopiedToClipboard] = React.useState(false);
   const handleCopyToClipboardClick = () => {
-    copyToClipboard(content);
+    copyToClipboard(props.content);
 
     setIsCopiedToClipboard(true);
     setTimeout(() => {
@@ -188,10 +178,10 @@ const CodeBlock = props => {
 
   return (
     <Container>
-      {title && (
+      {props.title && (
         <Header>
           <HeaderInner>
-            <HeaderText>{title}</HeaderText>
+            <HeaderText>{props.title}</HeaderText>
             <SpacingsInline
               scale="m"
               alignItems="center"
@@ -207,8 +197,8 @@ const CodeBlock = props => {
       <div
         className={[
           'gatsby-highlight',
-          highlightLines &&
-            highlightLines.length > 0 &&
+          props.highlightLines &&
+            props.highlightLines.length > 0 &&
             'has-highlighted-lines',
         ]
           .filter(Boolean)
@@ -242,7 +232,35 @@ const CodeBlock = props => {
   );
 };
 CodeBlock.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  language: PropTypes.string,
+  title: PropTypes.string,
+  highlightLines: PropTypes.arrayOf(PropTypes.number),
+  noPromptLines: PropTypes.arrayOf(PropTypes.number),
+  content: PropTypes.string.isRequired,
 };
 
 export default CodeBlock;
+
+/* eslint-disable react/display-name,react/prop-types */
+// Maps the props coming from MDX to the underlying <CodeBlock> component.
+export const CodeBlockMarkdownWrapper = props => {
+  const className = props.children.props ? props.children.props.className : '';
+  const languageToken = className || 'language-text';
+  const [, languageCode] = languageToken.split('language-');
+  const { title, highlightLines, noPromptLines } = codeBlockParseOptions(
+    props.children.props
+  );
+  const content =
+    props.children.props && props.children.props.children
+      ? props.children.props.children
+      : props.children;
+  return (
+    <CodeBlock
+      language={languageCode}
+      title={title}
+      highlightLines={highlightLines}
+      noPromptLines={noPromptLines}
+      content={content}
+    />
+  );
+};

--- a/packages/gatsby-theme-docs/src/components/index.js
+++ b/packages/gatsby-theme-docs/src/components/index.js
@@ -2,6 +2,7 @@ import * as Markdown from './markdown';
 
 export { default as BetaFlag } from './beta-flag';
 export { default as BurgerIcon } from './burger-icon';
+export { default as CodeBlock } from './code-block';
 export { default as ContentPagination } from './content-pagination';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as ContentNotifications } from './content-notifications';

--- a/packages/gatsby-theme-docs/src/components/markdown.js
+++ b/packages/gatsby-theme-docs/src/components/markdown.js
@@ -3,7 +3,7 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import RibbonIcon from '../icons/ribbon-icon.svg';
 import { colors, dimensions, typography, tokens } from '../design-system';
-import CodeBlock from './code-block';
+import { CodeBlockMarkdownWrapper as CodeBlock } from './code-block';
 import Link from './link';
 
 const TypographyPage = styled.div`


### PR DESCRIPTION
TL;DR: allows to use the `<CodeBlock>` component "outside" of the MDX context.

The base `<CodeBlock>` component now accepts specific props (`language`, `content`, etc.) which allows it to be used as a normal component. For the mdx component mapping, we provide a wrapper component that maps the mdx props.