### PR TITLE
fix(theme): list items spacing

### DIFF
--- a/packages/gatsby-theme-docs/src/components/markdown.js
+++ b/packages/gatsby-theme-docs/src/components/markdown.js
@@ -84,19 +84,21 @@ const Blockquote = styled.blockquote`
 `;
 const Ul = styled.ul`
   margin: 0;
-  padding-left: 2em;
+  padding-left: ${dimensions.spacings.xl};
   > * + * {
-    margin-top: 0.25em;
+    margin-top: ${dimensions.spacings.m};
   }
 `;
 const Ol = styled.ol`
   margin: 0;
-  padding-left: 2em;
+  padding-left: ${dimensions.spacings.xl};
   > * + * {
-    margin-top: 0.25em;
+    margin-top: ${dimensions.spacings.m};
   }
 `;
-const Li = styled.li``;
+const Li = styled.li`
+  line-height: 1.46;
+`;
 const Dl = styled.dl`
   > dd + * {
     margin: ${dimensions.spacings.m} 0 0;


### PR DESCRIPTION
To give a bit more breathing space to the list items.

Example:

<img width="704" alt="image" src="https://user-images.githubusercontent.com/1110551/70704907-3c166800-1cd3-11ea-8c53-7c5e7b3475b2.png">
