### PR TITLE
chore: check npm login before building a release

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:watch": "yarn test --watch",
     "test:e2e": "cross-env NODE_ENV=test cypress run",
     "changelog": "node scripts/changelog.js",
-    "prerelease": "yarn prebuild",
+    "check-npm-login": "npm_config_registry=https://registry.npmjs.org npm whoami",
+    "prerelease": "yarn check-npm-login && yarn prebuild",
     "release": "lerna publish --exact",
     "release:canary": "lerna publish --exact --dist-tag canary --canary --preid canary --yes"
   },


### PR DESCRIPTION
This PR adds a script to check if the user is logged into npm **before** starting the release process. This prevents "dirty releases", where lerna bumps versions and pushes a new tag, only to fail after that when trying publish packages to npm as the user is not logged in.