### PR TITLE
feat(ui-kit): export only ContentNotification

### DIFF
--- a/packages/ui-kit/src/components/content-notifications.js
+++ b/packages/ui-kit/src/components/content-notifications.js
@@ -56,7 +56,7 @@ const Container = styled.div`
   min-width: 100%;
 `;
 
-const ContentNotification = props => {
+export const ContentNotification = props => {
   const Icon = getIconByType(props.type);
   const iconColor = getIconColorByType(props.type);
   return (

--- a/packages/ui-kit/src/index.js
+++ b/packages/ui-kit/src/index.js
@@ -3,8 +3,10 @@ import * as Markdown from './components/markdown';
 
 // components
 export { designSystem, Markdown };
-export { ContentNotification } from './components/content-notifications';
-export { default as ContentNotifications } from './components/content-notifications';
+export {
+  default as ContentNotifications,
+  ContentNotification,
+} from './components/content-notifications';
 export { default as Globals } from './components/globals';
 export { default as Link } from './components/link';
 export { default as Reset } from './components/reset';

--- a/packages/ui-kit/src/index.js
+++ b/packages/ui-kit/src/index.js
@@ -3,6 +3,7 @@ import * as Markdown from './components/markdown';
 
 // components
 export { designSystem, Markdown };
+export { ContentNotification } from './components/content-notifications';
 export { default as ContentNotifications } from './components/content-notifications';
 export { default as Globals } from './components/globals';
 export { default as Link } from './components/link';


### PR DESCRIPTION
I would like to use the `ContentNotification` in a couple of the components on the `gatsby-theme-api-docs`. To avoid potential bloat caused by importing multiple components, exporting only the `ContentNotification` is useful. 