### PR TITLE
fix: corrected expected order of properties

### DIFF
--- a/websites/api-docs-smoke-test/src/api-specs/test/api.raml
+++ b/websites/api-docs-smoke-test/src/api-specs/test/api.raml
@@ -302,51 +302,54 @@ types:
     properties:
       eigthProperty:
         type: string
-        description: Should display 7th (1st in RAML)
+        description: Should display 8th (1st in RAML)
       createdBy:
         type: object
         (beta): true
-        description: Should display 4th (2nd in RAML)
+        description: Should display 5th (2nd in RAML)
       ninthProperty:
         type: string
-        description: Should display 8th (3rd in RAML)
+        description: Should display 9th (3rd in RAML)
       key:
         type: string
-        description: Should display 2nd (4th in RAML)
+        description: Should display 3rd (4th in RAML)
       tenthProperty:
         type: string
-        description: Should display 9th (5th in RAML)
+        description: Should display 10th (5th in RAML)
       custom:
         type: string
-        description: Should display 15th (6th in RAML)
+        description: Should display 16th (6th in RAML)
       eleventhPropery:
         type: string
-        description: Should display 10th (7th in RAML)
+        description: Should display 11th (7th in RAML)
       id:
         type: string
         description: Should display 1st (8th in RAML)
       twelthProperty:
         type: string
-        description: Should display 11th (9th in RAML)
+        description: Should display 12th (9th in RAML)
       lastModifiedBy:
         type: object
         (beta): true
-        description: Should display 6th (10th in RAML)
+        description: Should display 7th (10th in RAML)
       thirteenthProperty:
         type: string
-        description: Should display 12th (11th in RAML)
+        description: Should display 13th (11th in RAML)
       lastModifiedAt:
         type: datetime
-        description: Should display 5th (12th in RAML)
+        description: Should display 6th (12th in RAML)
       fourteenthProperty:
         type: string
-        description: Should display 13th (13th in RAML)
+        description: Should display 14th (13th in RAML)
       fifteenthProperty:
         type: string
-        description: Should display 14th (14th in definition)
+        description: Should display 15th (14th in definition)
       createdAt:
         type: datetime
-        description: Should display 3rd (15th in RAML)
+        description: Should display 4th (15th in RAML)
+      version:
+        type: string
+        description: Should display 2nd (16th in RAML)
 
 
   # References

--- a/websites/api-docs-smoke-test/src/api-specs/test/api.raml
+++ b/websites/api-docs-smoke-test/src/api-specs/test/api.raml
@@ -302,51 +302,51 @@ types:
     properties:
       eigthProperty:
         type: string
-        description: Should display 8th (1st in RAML)
+        description: Should display 7th (1st in RAML)
       createdBy:
         type: object
         (beta): true
-        description: Should display 5th (2nd in RAML)
+        description: Should display 4th (2nd in RAML)
       ninthProperty:
         type: string
-        description: Should display 9th (3rd in RAML)
+        description: Should display 8th (3rd in RAML)
       key:
         type: string
         description: Should display 2nd (4th in RAML)
       tenthProperty:
         type: string
-        description: Should display 10th (5th in RAML)
+        description: Should display 9th (5th in RAML)
       custom:
         type: string
-        description: Should display last (6th in RAML)
+        description: Should display 15th (6th in RAML)
       eleventhPropery:
         type: string
-        description: Should display 11th (7th in RAML)
+        description: Should display 10th (7th in RAML)
       id:
         type: string
         description: Should display 1st (8th in RAML)
       twelthProperty:
         type: string
-        description: Should display 12th (9th in RAML)
+        description: Should display 11th (9th in RAML)
       lastModifiedBy:
         type: object
         (beta): true
-        description: Should display 7th (10th in RAML)
+        description: Should display 6th (10th in RAML)
       thirteenthProperty:
         type: string
-        description: Should display 13th (11th in RAML)
+        description: Should display 12th (11th in RAML)
       lastModifiedAt:
         type: datetime
-        description: Should display 6th (12th in RAML)
+        description: Should display 5th (12th in RAML)
       fourteenthProperty:
         type: string
-        description: Should display 14th (13th in RAML)
+        description: Should display 13th (13th in RAML)
       fifteenthProperty:
         type: string
-        description: Should display 15th (14th in definition)
+        description: Should display 14th (14th in definition)
       createdAt:
         type: datetime
-        description: Should display 4th (15th in RAML)
+        description: Should display 3rd (15th in RAML)
 
 
   # References


### PR DESCRIPTION
Corrected the descriptions of the expected order, as "Should display 3rd" was missing.

I also included `OutOfOrderPropertiesTestType.properties.version`.