### PR TITLE
refactor(theme): adjust spacings of some elements to improve visual grouping

### DIFF
--- a/packages/ui-kit/src/components/code-block.js
+++ b/packages/ui-kit/src/components/code-block.js
@@ -13,7 +13,7 @@ import codeBlockHighlightCode from '../utils/code-block-highlight-code';
 const Container = styled.div`
   border: 1px solid ${colors.light.surfaceCodeHighlight};
   border-radius: ${tokens.borderRadiusForCodeBlock};
-  margin: 0;
+  margin: 0 0 ${dimensions.spacings.xxl};
 `;
 const Header = styled.div`
   background-color: ${colors.light.textPrimary};

--- a/packages/ui-kit/src/components/globals.js
+++ b/packages/ui-kit/src/components/globals.js
@@ -34,7 +34,7 @@ const Globals = () => (
       .gatsby-resp-image-wrapper {
         background-color: ${colors.light.surfaceSecondary1};
         border-radius: ${tokens.borderRadiusForImageFrame};
-        margin: ${dimensions.spacings.m} 0;
+        margin: ${dimensions.spacings.m} 0 ${dimensions.spacings.xxl};
         padding: ${dimensions.spacings.s};
       }
       .gatsby-resp-image-figure {

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -38,7 +38,7 @@ const H2 = styled.h2`
   border-bottom: 1px solid ${colors.light.borderPrimary};
   font-size: ${typography.fontSizes.h2};
   font-weight: ${typography.fontWeights.bold};
-  margin: ${dimensions.spacings.huge} 0 ${dimensions.spacings.xl};
+  margin: ${dimensions.spacings.huge} 0 ${dimensions.spacings.m};
   padding-bottom: ${dimensions.spacings.s};
 `;
 const H3 = styled.h3`
@@ -83,21 +83,26 @@ const Blockquote = styled.blockquote`
   }
 `;
 const Ul = styled.ul`
-  margin: 0;
+  margin: 0 0 ${dimensions.spacings.xxl};
   padding-left: ${dimensions.spacings.xl};
   > * + * {
-    margin-top: ${dimensions.spacings.m};
+    margin-top: ${dimensions.spacings.s};
   }
 `;
 const Ol = styled.ol`
-  margin: 0;
+  margin: 0 0 ${dimensions.spacings.xxl};
   padding-left: ${dimensions.spacings.xl};
   > * + * {
-    margin-top: ${dimensions.spacings.m};
+    margin-top: ${dimensions.spacings.s};
   }
 `;
 const Li = styled.li`
   line-height: 1.46;
+
+  > ul,
+  > ol {
+    margin: 0 0 ${dimensions.spacings.m};
+  }
 `;
 const Dl = styled.dl`
   > dd + * {


### PR DESCRIPTION
As requested by @Shecki , this is an attempt to improve the visual grouping of some elements, by adjusting the spacing between then.