### PR TITLE
fix(theme): beta style link

### DIFF
--- a/packages/gatsby-theme-docs/src/components/beta-flag.js
+++ b/packages/gatsby-theme-docs/src/components/beta-flag.js
@@ -18,7 +18,7 @@ const getStyles = props => {
       box-shadow: ${designSystem.tokens.shadowForBetaFlag};
       color: ${designSystem.colors.light.textInfo} !important;
       font-size: ${designSystem.typography.fontSizes.small};
-      text-decoration: none;
+      text-decoration: none !important;
 
       :active,
       :focus,


### PR DESCRIPTION
Small fix to ensure that the link does not get an underline (apparently the behavior is somehow different between chrome and firefox)