### PR TITLE
fix(theme): disable search input when website has search index disabled

### DIFF
--- a/packages/gatsby-theme-docs/src/components/search-input.js
+++ b/packages/gatsby-theme-docs/src/components/search-input.js
@@ -42,9 +42,13 @@ const Input = styled.input`
     color: ${designSystem.colors.light.textFaded};
   }
   &:active,
-  &:focus {
+  &:focus:not(:disabled) {
     border-color: ${designSystem.colors.light.borderHighlight};
     padding-right: ${designSystem.dimensions.spacings.xs};
+  }
+  &:disabled {
+    background-color: ${designSystem.colors.light
+      .surfaceForSearchInputWhenDisabled};
   }
 `;
 const SearchInputIcon = styled.span`
@@ -63,10 +67,12 @@ const SearchInput = React.forwardRef((props, ref) => {
   const { onFocus } = props;
   const [isActive, setIsActive] = React.useState(false);
   const handleFocus = event => {
+    if (props.isDisabled) return;
     if (onFocus) onFocus(event);
     setIsActive(true);
   };
   const handleBlur = () => {
+    if (props.isDisabled) return;
     setIsActive(false);
   };
   React.useEffect(() => {
@@ -77,11 +83,15 @@ const SearchInput = React.forwardRef((props, ref) => {
         else setIsActive(true);
       }
     };
-    window.addEventListener('keyup', onKeyPress);
+    if (!props.isDisabled) {
+      window.addEventListener('keyup', onKeyPress);
+    }
     return () => {
-      window.removeEventListener('keyup', onKeyPress);
+      if (!props.isDisabled) {
+        window.removeEventListener('keyup', onKeyPress);
+      }
     };
-  }, [onFocus]);
+  }, [onFocus, props.isDisabled]);
   return (
     <Container>
       <SearchInputIcon position="left">
@@ -108,6 +118,7 @@ const SearchInput = React.forwardRef((props, ref) => {
         aria-label="Search"
         onFocus={handleFocus}
         onBlur={handleBlur}
+        disabled={props.isDisabled}
       />
     </Container>
   );
@@ -118,6 +129,7 @@ SearchInput.propTypes = {
   size: PropTypes.oneOf(['small', 'scale']).isRequired,
   onFocus: PropTypes.func,
   onClose: PropTypes.func,
+  isDisabled: PropTypes.bool.isRequired,
 };
 
 export default SearchInput;

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
@@ -201,17 +201,19 @@ const LayoutHeader = props => (
           <>
             <MediaQuery forViewport="mobile">
               <IconButton
+                icon={<SearchIcon />}
                 size="big"
                 label="Open search dialog"
                 onClick={props.openSearchDialog}
-                icon={<SearchIcon />}
+                isDisabled={props.excludeFromSearchIndex}
               />
             </MediaQuery>
             <MediaQuery forViewport="tablet">
               <SearchInput
                 id="search-input-placeholder"
-                onFocus={props.openSearchDialog}
                 size="small"
+                onFocus={props.openSearchDialog}
+                isDisabled={props.excludeFromSearchIndex}
               />
             </MediaQuery>
           </>

--- a/packages/ui-kit/src/design-system.js
+++ b/packages/ui-kit/src/design-system.js
@@ -31,6 +31,7 @@ export const colors = {
     surfaceWarning: customProperties.colorWarning95,
     surfaceError: customProperties.colorError95,
     surfaceSearchHighlight: customProperties.colorAccent95,
+    surfaceForSearchInputWhenDisabled: customProperties.colorNeutral90,
     // Different tones of text
     textPrimary: customProperties.colorSolid,
     textSecondary: '#666666',


### PR DESCRIPTION
When the website has `excludeFromSearchIndex` set to true, the search input should not be visible and be triggered in any way.
This PR enforces the input to be "disabled", as well as to disable the keyboard event handlers to activate the search.