### PR TITLE
fix(writing-style): make custom apps capitalized

### DIFF
--- a/packages/writing-style/vale-styles/commercetools/Brand.yml
+++ b/packages/writing-style/vale-styles/commercetools/Brand.yml
@@ -19,8 +19,13 @@ swap:
   merchant center: Merchant Center
   Merchant center: Merchant Center
   merchant Center: Merchant Center
-  Custom Applications: custom applications
-  Custom applications: custom applications
-  custom Applications: custom applications
-  custom apps: custom applications
-  Custom Apps: custom applications
+  Custom Applications: Custom Applications
+  Custom applications: Custom Applications
+  custom Applications: Custom Applications
+  custom apps: Custom Applications
+  Custom Apps: Custom Applications
+  Custom Application: Custom Application
+  Custom application: Custom Application
+  custom Application: Custom Application
+  custom app: Custom Application
+  Custom App: Custom Application


### PR DESCRIPTION
As suggested by @adinakleine 

> Custom Application is an established ct term due to this it has to be capitalized.