### PR TITLE
[WIP] refactor(theme): disable production hostname for building external links

### DIFF
--- a/broken-link-checker.config.js
+++ b/broken-link-checker.config.js
@@ -1,3 +1,7 @@
 module.exports = {
-  excludedKeywords: [],
+  excludedKeywords: [
+    'https://docs.commercetools.com/docs-smoke-test',
+    'https://docs.commercetools.com/api-docs-smoke-test',
+    'https://docs.commercetools.com/site-template',
+  ],
 };

--- a/broken-link-checker.config.js
+++ b/broken-link-checker.config.js
@@ -1,19 +1,3 @@
 module.exports = {
-  excludedKeywords: [
-    '/getting-started#sign-up',
-    '/login',
-    '/http-api',
-    '/graphql-api',
-    '/release-notes',
-    '/software-development-kits',
-    '/import-api',
-    '/sunrise',
-    '/tutorials-overview',
-    '/custom-applications',
-    '/faqs',
-    '/merchant-center',
-    '/merchant-center-releases',
-    '/privacy',
-    '/imprint',
-  ],
+  excludedKeywords: [],
 };

--- a/cypress/integration/docs-smoke-test/links.js
+++ b/cypress/integration/docs-smoke-test/links.js
@@ -52,11 +52,26 @@ const scenarios = [
     expectationMessage:
       'It should render an absolute URL in dev mode and a relative path in prod mode',
     ...(isCI
-      ? {
-          expected: {
-            url: `${
-              Cypress.config().baseUrl
-            }${URL_DOCS_SMOKE_TEST}views/code-blocks`,
+      ? // TODO: revert once productionHostname is back to normal
+        // ? {
+        //     expected: {
+        //       url: `${
+        //         Cypress.config().baseUrl
+        //       }${URL_DOCS_SMOKE_TEST}views/code-blocks`,
+        //     },
+        //   }
+        {
+          expected: {},
+          linkSelector: () => {
+            cy.get('a')
+              .contains('Link')
+              .parent()
+              .parent()
+              .should(
+                'have.prop',
+                'href',
+                'https://docs.commercetools.com/docs-smoke-test/views/code-blocks/'
+              );
           },
         }
       : {
@@ -125,14 +140,18 @@ const scenarios = [
     expectationMessage:
       'It should be a normal html link (only in `production` mode)',
     linkSelector: () => {
+      // Revert once productionHostname is back to normal
       cy.get('a')
         .contains('Link')
+        .parent()
+        .parent()
         .should(
           'have.prop',
           'href',
-          isCI
-            ? `${Cypress.config().baseUrl}/site-template`
-            : 'https://docs.commercetools.com/site-template'
+          // isCI
+          //   ? `${Cypress.config().baseUrl}/site-template`
+          //   : 'https://docs.commercetools.com/site-template'
+          'https://docs.commercetools.com/site-template'
         );
     },
     expected: {},

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -38,7 +38,12 @@ module.exports = (themeOptions = {}) => {
   return {
     siteMetadata: {
       author: 'commercetools',
-      productionHostname: 'docs.commercetools.com',
+      // NOTE: for the time being, until all or most of the legacy docs are migrated
+      // to the new docs, we need to keep this functionality "disabled" to keep
+      // absolute links as external. This is important for the broken link checker,
+      // otherwise we need to whitelist all links to the legacy docs.
+      productionHostname: 'unknown',
+      // productionHostname: 'docs.commercetools.com',
       betaLink: null,
     },
     plugins: [

--- a/packages/gatsby-theme-docs/src/components/search-input.js
+++ b/packages/gatsby-theme-docs/src/components/search-input.js
@@ -129,7 +129,7 @@ SearchInput.propTypes = {
   size: PropTypes.oneOf(['small', 'scale']).isRequired,
   onFocus: PropTypes.func,
   onClose: PropTypes.func,
-  isDisabled: PropTypes.bool.isRequired,
+  isDisabled: PropTypes.bool,
 };
 
 export default SearchInput;


### PR DESCRIPTION
**DO NOT MERGE YET**

This PR disables the `productionHostname` value that is used for building external/internal links. This is necessary to avoid a lot of errors in the broken link checker during the migration of the legacy docs to the new ones.

With this change, we get the following errors. **These errors are expected** (read more below):

<img width="612" alt="image" src="https://user-images.githubusercontent.com/1110551/73348321-7c34a880-4289-11ea-8276-4fb31af59f60.png">

Some of the links (e.g. `/login`) are not yet merged in the legacy docs, so we would need to wait for the changes to be live first (cc @nkuehn ).
There are some link in the test pages that are now failing because of the "disabled" `productionHostname`. Again, this is expected, we would need to maybe remove that test link for now.

How should we proceed here?