### PR TITLE
refactor(theme): to make the link underline style configurable via a prop

### DIFF
--- a/packages/gatsby-theme-docs/src/components/beta-flag.js
+++ b/packages/gatsby-theme-docs/src/components/beta-flag.js
@@ -18,7 +18,6 @@ const getStyles = props => {
       box-shadow: ${designSystem.tokens.shadowForBetaFlag};
       color: ${designSystem.colors.light.textInfo} !important;
       font-size: ${designSystem.typography.fontSizes.small};
-      text-decoration: none !important;
 
       :active,
       :focus,
@@ -39,7 +38,7 @@ const getStyles = props => {
 const BetaFlag = props => {
   if (props.href) {
     return (
-      <Link href={props.href} css={getStyles(props)}>
+      <Link href={props.href} noUnderline={true} css={getStyles(props)}>
         {'BETA'}
       </Link>
     );

--- a/packages/gatsby-theme-docs/src/components/global-navigation-link.js
+++ b/packages/gatsby-theme-docs/src/components/global-navigation-link.js
@@ -1,12 +1,12 @@
-import styled from '@emotion/styled';
+import React from 'react';
+import { css } from '@emotion/core';
 import { designSystem } from '@commercetools-docs/ui-kit';
 import Link from './link';
 
-const GlobalNavigationLink = styled(Link)`
+const linkStyles = css`
   font-size: ${designSystem.typography.fontSizes.extraSmall};
   line-height: 1.75;
   color: ${designSystem.colors.light.textPrimary} !important;
-  text-decoration: none !important;
 
   svg {
     * {
@@ -24,5 +24,9 @@ const GlobalNavigationLink = styled(Link)`
     }
   }
 `;
+
+const GlobalNavigationLink = props => (
+  <Link {...props} css={linkStyles} noUnderline={true} />
+);
 
 export default GlobalNavigationLink;

--- a/packages/gatsby-theme-docs/src/components/link.js
+++ b/packages/gatsby-theme-docs/src/components/link.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 import { Location } from '@reach/router';
 import { Link as GatsbyLink, withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
@@ -19,6 +20,10 @@ const withoutPrefix = (value, pathPrefix) =>
   value.replace(new RegExp(`^${pathPrefix}`), '');
 
 const trimTrailingSlash = url => url.replace(/(\/?)$/, '');
+
+const getStylesFromProps = ({ noUnderline }) => css`
+  text-decoration: ${noUnderline ? 'none' : 'underline'};
+`;
 
 const AnchorLink = styled(StyledLink)``;
 const InternalSiteLink = styled(StyledLink)``;
@@ -91,7 +96,7 @@ export const ExternalSiteLink = props => (
  */
 const PureLink = extendedProps => {
   const siteData = useSiteData();
-  const { location, ...props } = extendedProps;
+  const { location, noUnderline, ...props } = extendedProps;
   // For image links, return the link as-is.
   if (props.href.startsWith(withPrefix('/static'))) {
     return <a {...props} role="image-link" />;
@@ -127,19 +132,25 @@ const PureLink = extendedProps => {
       React.cloneElement(props.children, {
         children: (
           <InlineLink>
-            <span>{props.children.props.children}</span>
+            <span css={getStylesFromProps({ noUnderline })}>
+              {props.children.props.children}
+            </span>
             <ExternalLinkIcon size="small" />
           </InlineLink>
         ),
       })
     ) : (
       <InlineLink>
-        <span>{props.children}</span>
+        <span css={getStylesFromProps({ noUnderline })}>{props.children}</span>
         <ExternalLinkIcon size="small" />
       </InlineLink>
     );
     return (
-      <ExternalSiteLink {...props} role="external-link">
+      <ExternalSiteLink
+        {...props}
+        role="external-link"
+        css={getStylesFromProps({ noUnderline })}
+      >
         {linkWithIcon}
       </ExternalSiteLink>
     );
@@ -155,6 +166,7 @@ const PureLink = extendedProps => {
         role="anchor-link"
         href={trimTrailingSlash(hrefObject.hash)}
         className={props.className}
+        css={getStylesFromProps({ noUnderline })}
       >
         {props.children}
       </AnchorLink>
@@ -176,6 +188,7 @@ const PureLink = extendedProps => {
         role="gatsby-link"
         to={trimTrailingSlash(hrefObject.pathname) + hrefObject.hash}
         className={props.className}
+        css={getStylesFromProps({ noUnderline })}
       >
         {props.children}
       </GatsbyRouterLink>
@@ -196,6 +209,7 @@ const PureLink = extendedProps => {
       role="internal-link"
       href={internalHref}
       className={props.className}
+      css={getStylesFromProps({ noUnderline })}
     >
       {props.children}
     </InternalSiteLink>
@@ -205,6 +219,7 @@ PureLink.propTypes = {
   href: PropTypes.string.isRequired,
   target: PropTypes.string,
   className: PropTypes.string,
+  noUnderline: PropTypes.bool,
   children: PropTypes.node,
   // from @react/router
   location: PropTypes.object.isRequired,

--- a/packages/ui-kit/src/components/link.js
+++ b/packages/ui-kit/src/components/link.js
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { colors } from '../design-system';
 
 const Link = styled.a`
-  text-decoration: underline;
   &,
   > code {
     color: ${colors.light.link};


### PR DESCRIPTION
This helps to avoid having to override styles directly, but instead changing the appearance via a prop.