### PR TITLE
chore: do not format mdx files with prettier

### DIFF
--- a/jest.prettier.config.js
+++ b/jest.prettier.config.js
@@ -6,7 +6,7 @@ module.exports = {
     'ts',
     'tsx',
     'md',
-    'mdx',
+    // 'mdx',
     'css',
     'yaml',
     'yml',
@@ -18,7 +18,7 @@ module.exports = {
     '<rootDir>/**/*.tsx',
     '<rootDir>/**/*.css',
     '<rootDir>/**/*.md',
-    '<rootDir>/**/*.mdx',
+    // '<rootDir>/**/*.mdx',
     '<rootDir>/**/*.graphql',
   ],
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  '*.{md,mdx}': ['prettier --write --parser markdown'],
+  '*.md': ['prettier --write --parser markdown'],
   '*.yaml': ['prettier --write --parser yaml'],
   '*.js': [
     'prettier --write',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:text": "jest --config jest.text.config.js",
     "format": "yarn format:js && yarn format:md && yarn format:yaml",
     "format:js": "prettier --write '**/*.{js,ts,tsx}'",
-    "format:md": "prettier --write --parser markdown '**/*.{md,mdx}'",
+    "format:md": "prettier --write --parser markdown '**/*.md'",
     "format:yaml": "prettier --write --parser yaml '**/*.yaml'",
     "labels:sync": "github-labels sync",
     "test": "jest --config jest.test.config.js",

--- a/recommended.code-workspace
+++ b/recommended.code-workspace
@@ -18,7 +18,7 @@
       "**/*.svg": true
     },
     "files.associations": {
-      "*.mdx": "mdx"
+      "*.mdx": "markdown"
     },
     "javascript.validate.enable": true,
     "eslint.validate": [


### PR DESCRIPTION
The prettier parser for markdown does not work well with mdx. The prettier mdx parser also does not work well.
I’ll disable auto formatting of mdx files for now until we find a good solution.
Some related issue that I found: https://github.com/luckylwk/hoppin-design-system/pull/21

For example: with this mdx content:

```
1. hey
  <Info>
  This is indented
  </Info>
```

When prettier runs with parser: markdown  it gets like this

```
1. hey
  <Info>
This is indented
  </Info>
```

Notice the indentation is lost.

For now we keep it disabled.