### PR TITLE
fix(theme): use data-link-type instead of aria role attribute

### DIFF
--- a/packages/gatsby-theme-docs/src/components/link.js
+++ b/packages/gatsby-theme-docs/src/components/link.js
@@ -99,7 +99,7 @@ const PureLink = extendedProps => {
   const { location, noUnderline, ...props } = extendedProps;
   // For image links, return the link as-is.
   if (props.href.startsWith(withPrefix('/static'))) {
-    return <a {...props} role="image-link" />;
+    return <a {...props} data-link-type="image-link" />;
   }
 
   // Remove possible `pathPrefix` from both the `location.pathname` and the provided `href`.
@@ -148,7 +148,7 @@ const PureLink = extendedProps => {
     return (
       <ExternalSiteLink
         {...props}
-        role="external-link"
+        data-link-type="external-link"
         css={getStylesFromProps({ noUnderline })}
       >
         {linkWithIcon}
@@ -163,7 +163,7 @@ const PureLink = extendedProps => {
   if (isAnchorLink || isLinkToSamePage) {
     return (
       <AnchorLink
-        role="anchor-link"
+        data-link-type="anchor-link"
         href={trimTrailingSlash(hrefObject.hash)}
         className={props.className}
         css={getStylesFromProps({ noUnderline })}
@@ -185,7 +185,7 @@ const PureLink = extendedProps => {
   if (!isLinkToAnotherDocsSite) {
     return (
       <GatsbyRouterLink
-        role="gatsby-link"
+        data-link-type="gatsby-link"
         to={trimTrailingSlash(hrefObject.pathname) + hrefObject.hash}
         className={props.className}
         css={getStylesFromProps({ noUnderline })}
@@ -206,7 +206,7 @@ const PureLink = extendedProps => {
       : trimTrailingSlash(hrefObject.pathname) + hrefObject.hash;
   return (
     <InternalSiteLink
-      role="internal-link"
+      data-link-type="internal-link"
       href={internalHref}
       className={props.className}
       css={getStylesFromProps({ noUnderline })}

--- a/packages/gatsby-theme-docs/src/components/link.spec.js
+++ b/packages/gatsby-theme-docs/src/components/link.spec.js
@@ -35,7 +35,7 @@ describe('rendering', () => {
       title: 'image link',
       props: { href: '/static/123' },
       location: { pathname: '/page-1' },
-      expected: { role: 'image-link' },
+      expected: { 'data-link-type': 'image-link' },
     },
     {
       title: 'external link',
@@ -43,98 +43,113 @@ describe('rendering', () => {
         href: 'https://github.com/commercetools/commercetools-docs-kit',
       },
       location: { pathname: '/page-1' },
-      expected: { role: 'external-link' },
+      expected: { 'data-link-type': 'external-link' },
     },
     {
       title: 'empty link',
       props: { href: '' },
       location: { pathname: '/page-1' },
-      expected: { role: 'anchor-link' },
+      expected: { 'data-link-type': 'anchor-link' },
     },
     {
       title: 'anchor link',
       props: { href: '#title-1' },
       location: { pathname: '/page-1' },
-      expected: { role: 'anchor-link' },
+      expected: { 'data-link-type': 'anchor-link' },
     },
     {
       title: 'gatsby link to another page',
       props: { href: '/page-2' },
       location: { pathname: '/page-1' },
-      expected: { role: 'gatsby-link', href: '/page-2' },
+      expected: { 'data-link-type': 'gatsby-link', href: '/page-2' },
     },
     {
       title: 'gatsby link to another page',
       props: { href: '/page-2/getting-started' },
       location: { pathname: '/page-1' },
-      expected: { role: 'gatsby-link', href: '/page-2/getting-started' },
+      expected: {
+        'data-link-type': 'gatsby-link',
+        href: '/page-2/getting-started',
+      },
     },
     {
       title: 'gatsby link to a sub-page',
       props: { href: 'page-1/getting-started' },
       location: { pathname: '/page-1' },
-      expected: { role: 'gatsby-link', href: '/page-1/getting-started' },
+      expected: {
+        'data-link-type': 'gatsby-link',
+        href: '/page-1/getting-started',
+      },
     },
     {
       title: 'gatsby link to a sub-page using a trailing slash',
       props: { href: 'page-1/getting-started/' },
       location: { pathname: '/page-1' },
-      expected: { role: 'gatsby-link', href: '/page-1/getting-started' },
+      expected: {
+        'data-link-type': 'gatsby-link',
+        href: '/page-1/getting-started',
+      },
     },
     {
       title: 'gatsby link to a parent page',
       props: { href: '../page-2' },
       location: { pathname: '/page-1' },
-      expected: { role: 'gatsby-link', href: '/page-2' },
+      expected: { 'data-link-type': 'gatsby-link', href: '/page-2' },
     },
     {
       title: 'gatsby link to a parent sub-page',
       props: { href: '../page-2/getting-started' },
       location: { pathname: '/page-1' },
-      expected: { role: 'gatsby-link', href: '/page-2/getting-started' },
+      expected: {
+        'data-link-type': 'gatsby-link',
+        href: '/page-2/getting-started',
+      },
     },
     {
       title: 'gatsby link to a parent page using a wrong path',
       props: { href: '../../../../../page-2' },
       location: { pathname: '/page-1' },
-      expected: { role: 'gatsby-link', href: '/page-2' },
+      expected: { 'data-link-type': 'gatsby-link', href: '/page-2' },
     },
     {
       title: 'gatsby link to another page with hash',
       props: { href: '/page-2#title' },
       location: { pathname: '/page-1' },
-      expected: { role: 'gatsby-link' },
+      expected: { 'data-link-type': 'gatsby-link' },
     },
     {
       title: 'internal link',
       props: { href: 'https://docs.commercetools.com/site-key/page-1' },
       location: { pathname: '/page-1' },
-      expected: { role: 'internal-link' },
+      expected: { 'data-link-type': 'internal-link' },
     },
     {
       title: 'internal link',
       props: { href: 'https://docs.commercetools.com/site-key/page-1' },
       location: { pathname: '/page-1' },
-      expected: { role: 'internal-link', href: '/site-key/page-1' },
+      expected: { 'data-link-type': 'internal-link', href: '/site-key/page-1' },
       isProd: true,
     },
     {
       title: 'internal link using "/../" notation',
       props: { href: '/../site-key/page-1' },
       location: { pathname: '/page-1' },
-      expected: { role: 'internal-link', href: '/site-key/page-1' },
+      expected: { 'data-link-type': 'internal-link', href: '/site-key/page-1' },
     },
     {
       title: 'internal link with hash',
       props: { href: 'https://docs.commercetools.com/site-key/page-2#title' },
       location: { pathname: '/page-1' },
-      expected: { role: 'internal-link' },
+      expected: { 'data-link-type': 'internal-link' },
     },
     {
       title: 'internal link with hash',
       props: { href: 'https://docs.commercetools.com/site-key/page-2#title' },
       location: { pathname: '/page-1' },
-      expected: { role: 'internal-link', href: '/site-key/page-2#title' },
+      expected: {
+        'data-link-type': 'internal-link',
+        href: '/site-key/page-2#title',
+      },
       isProd: true,
     },
   ];
@@ -162,7 +177,11 @@ describe('rendering', () => {
         scenario.location.pathname
       );
       expect(rendered.queryByText(scenario.title)).toBeInTheDocument();
-      expect(rendered.queryByRole(scenario.expected.role)).toHaveAttribute(
+      expect(
+        rendered.container.querySelector(
+          `[data-link-type="${scenario.expected['data-link-type']}"]`
+        )
+      ).toHaveAttribute(
         'href',
         'href' in scenario.expected
           ? scenario.expected.href

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -233,7 +233,7 @@ const withAnchorLink = Component => props => {
         display: flex;
         align-items: baseline;
         :hover {
-          [role='anchor-link'] {
+          [data-link-type='anchor-link'] {
             svg {
               * {
                 fill: ${colors.light.linkNavigation};
@@ -247,7 +247,7 @@ const withAnchorLink = Component => props => {
       `}
     >
       <span>{props.children}</span>
-      <a href={`#${props.id}`} role="anchor-link">
+      <a href={`#${props.id}`} data-link-type="anchor-link">
         <RibbonIcon />
       </a>
     </Component>


### PR DESCRIPTION
Fixes #255 

The `role` attribute is not meant to be used like this. I couldn't find any other ARIA attribute to describe the type of a link, so I opted to use a `data-link-type` attribute.