### PR TITLE
fix: force canary releases to always publish all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prerelease": "yarn check-npm-login && yarn prebuild",
     "prerelease:canary": "yarn check-npm-login && yarn prebuild",
     "release": "lerna publish --exact",
-    "release:canary": "lerna publish --exact --dist-tag canary --canary --preid canary --yes"
+    "release:canary": "lerna publish --exact --dist-tag canary --canary --preid canary --yes --force-publish \"*\""
   },
   "devDependencies": {
     "@babel/core": "7.8.4",


### PR DESCRIPTION
TL;DR: canary releases only publish packages that changed in the last commit. This sometimes results in "broken" packages that refer to wrong versions, as multiple canary releases might not include the same package version.

See https://github.com/lerna/lerna/issues/2060

To ensure that each canary release is fully functioning, we can force all packages to be published.