### PR TITLE
refactor: use more semantic HTML elements for the search crawler

### DIFF
--- a/cypress/integration/docs-smoke-test/menu-navigation.js
+++ b/cypress/integration/docs-smoke-test/menu-navigation.js
@@ -5,8 +5,8 @@ describe('Menu navigation', () => {
     it('should toggle main left side navigation', () => {
       cy.setTabletViewport();
       cy.visit(URL_DOCS_SMOKE_TEST);
-      cy.findByLabelText('Open main navigation').click();
-      cy.findByLabelText('Main navigation').should('be.visible');
+      cy.findByLabelText('Open Main Navigation').click();
+      cy.findByLabelText('Main Navigation').should('be.visible');
       cy.get('#modal-portal').within(() => {
         cy.findByText('Docs Smoke Test');
         cy.percySnapshot(cy.state('runnable').fullTitle(), {

--- a/cypress/integration/docs-smoke-test/top-menu.js
+++ b/cypress/integration/docs-smoke-test/top-menu.js
@@ -3,14 +3,14 @@ import { URL_DOCS_SMOKE_TEST } from '../../support/urls';
 describe('Top menu', () => {
   it('should toggle top menu and take a snapshot', () => {
     cy.visit(URL_DOCS_SMOKE_TEST);
-    cy.findByLabelText('Open top menu').click();
+    cy.findByLabelText('Open Top Menu').click();
     cy.findByRole('top-menu').should('be.visible');
     cy.findByLabelText('Close top menu').should('exist');
     cy.percySnapshot();
   });
   it('should close top menu when clicking on the search input', () => {
     cy.visit(URL_DOCS_SMOKE_TEST);
-    cy.findByLabelText('Open top menu').click();
+    cy.findByLabelText('Open Top Menu').click();
     cy.findByRole('top-menu').should('be.visible');
     cy.findByLabelText('Search').click();
     cy.findByText('Developer Center').should('not.be.visible');

--- a/cypress/integration/docs-smoke-test/top-menu.js
+++ b/cypress/integration/docs-smoke-test/top-menu.js
@@ -5,7 +5,7 @@ describe('Top menu', () => {
     cy.visit(URL_DOCS_SMOKE_TEST);
     cy.findByLabelText('Open Top Menu').click();
     cy.findByRole('top-menu').should('be.visible');
-    cy.findByLabelText('Close top menu').should('exist');
+    cy.findByLabelText('Close Top Menu').should('exist');
     cy.percySnapshot();
   });
   it('should close top menu when clicking on the search input', () => {

--- a/cypress/integration/docs-smoke-test/viewports.js
+++ b/cypress/integration/docs-smoke-test/viewports.js
@@ -5,7 +5,7 @@ describe('Viewports', () => {
     cy.visit(URL_DOCS_SMOKE_TEST);
     cy.findAllByText('Docs Smoke Test');
     // wait for menu button to appear
-    cy.findByLabelText('Open main navigation');
+    cy.findByLabelText('Open Main Navigation');
     cy.percySnapshot(cy.state('runnable').fullTitle(), {
       widths: [512, 956],
     });

--- a/packages/gatsby-theme-docs/src/components/content-pagination.js
+++ b/packages/gatsby-theme-docs/src/components/content-pagination.js
@@ -15,7 +15,7 @@ const trimTrailingSlash = url => url.replace(/(\/?)$/, '');
 
 const isMatching = (a, b) => trimTrailingSlash(a) === trimTrailingSlash(b);
 
-const Container = styled.div`
+const Container = styled.nav`
   display: grid;
   grid-gap: ${designSystem.dimensions.spacings.m};
   grid-auto-columns: 1fr;

--- a/packages/gatsby-theme-docs/src/components/content-pagination.js
+++ b/packages/gatsby-theme-docs/src/components/content-pagination.js
@@ -124,7 +124,7 @@ export const PurePagination = props => {
   const nextPage = activeChapter.pages[currentPageLinkIndex + 1];
 
   return (
-    <Container>
+    <Container aria-label="Next / Previous in Chapter Navigation">
       {hasPagination && previousPage ? (
         <PaginationLink
           linkTo={previousPage.path}

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -81,7 +81,7 @@ const LayoutContent = props => {
             <PlaceholderPageHeaderSide />
           </LayoutPageHeaderSide>
           <LayoutPageContent>
-            <PageContentInset>
+            <PageContentInset id="body-content">
               {props.children}
               <ContentPagination slug={props.pageContext.slug} />
             </PageContentInset>

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
@@ -161,7 +161,7 @@ const LayoutHeader = props => (
           <SwitcherButton
             role="button"
             aria-label={
-              props.isTopMenuOpen ? 'Close top menu' : 'Open top menu'
+              props.isTopMenuOpen ? 'Close Top Menu' : 'Open Top Menu'
             }
             isActive={props.isTopMenuOpen}
             onClick={props.toggleTopMenu}

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
-const Container = styled.div`
+const Container = styled.main`
   grid-area: main;
   min-width: 0;
   position: relative;

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
@@ -1,9 +1,8 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
-const Container = styled.main`
+const LayoutMain = styled.main`
   grid-area: main;
   min-width: 0;
   position: relative;
@@ -22,7 +21,5 @@ const Container = styled.main`
       overflow-y: hidden;
     `}
 `;
-
-const LayoutMain = props => <Container {...props} />;
 
 export default LayoutMain;

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
@@ -23,8 +23,6 @@ const Container = styled.div`
     `}
 `;
 
-const LayoutMain = props => (
-  <Container role="main" aria-label="Page content" {...props} />
-);
+const LayoutMain = props => <Container {...props} />;
 
 export default LayoutMain;

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
-const Container = styled.main`
+const Container = styled.div`
   grid-area: main;
   min-width: 0;
   position: relative;

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-header-side.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-header-side.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
-const LayoutPageHeaderSide = styled.div`
+const LayoutPageHeaderSide = styled.aside`
   grid-area: page-header-side;
   display: none;
 

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
@@ -96,7 +96,7 @@ const LayoutPageNavigation = props => {
     return null;
 
   const navigationContainer = (
-    <nav aria-label="Page index navigation">
+    <nav aria-label="Page Table of Contents Navigation">
       <SpacingsStack scale="m">
         <PageTitleLink href="#top">
           <SpacingsInline scale="s" alignItems="center">

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
-const LayoutPage = styled.main`
+const LayoutPage = styled.div`
   display: block;
   max-width: 100vw;
   box-shadow: ${designSystem.tokens.shadowForPageContent};

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
-const LayoutPage = styled.div`
+const LayoutPage = styled.article`
   display: block;
   max-width: 100vw;
   box-shadow: ${designSystem.tokens.shadowForPageContent};

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
-const LayoutPage = styled.div`
+const LayoutPage = styled.main`
   display: block;
   max-width: 100vw;
   box-shadow: ${designSystem.tokens.shadowForPageContent};

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-sidebar.js
@@ -71,7 +71,7 @@ const LayoutSidebar = props => {
 
   const menuButton = (
     <MenuButton
-      aria-label="Open main navigation"
+      aria-label="Open Main Navigation"
       onClick={props.toggleSidebarMenu}
     >
       <BurgerIcon isActive={props.isMenuOpen} />
@@ -86,8 +86,7 @@ const LayoutSidebar = props => {
           ReactDOM.createPortal(
             <Overlay onClick={props.closeSidebarMenu}>
               <Container
-                role="nav"
-                aria-label="Main navigation"
+                aria-label="Main Navigation"
                 isMenuOpen={true}
                 onClick={event => {
                   event.stopPropagation();
@@ -109,7 +108,7 @@ const LayoutSidebar = props => {
   return (
     <>
       {menuButtonNode && ReactDOM.createPortal(menuButton, menuButtonNode)}
-      <Container role="nav" aria-label="Main navigation" isMenuOpen={false}>
+      <Container role="nav" aria-label="Main Navigation" isMenuOpen={false}>
         <Sidebar
           siteTitle={props.siteTitle}
           isGlobalBeta={props.isGlobalBeta}

--- a/packages/gatsby-theme-docs/src/layouts/internals/page-content-inset.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/page-content-inset.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
-const PageContentInset = styled.div`
+const PageContentInset = styled.article`
   padding: ${designSystem.dimensions.spacings.m}
     ${designSystem.dimensions.spacings.m} ${designSystem.dimensions.spacings.xl};
 

--- a/packages/gatsby-theme-docs/src/layouts/internals/page-content-inset.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/page-content-inset.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
-const PageContentInset = styled.article`
+const PageContentInset = styled.div`
   padding: ${designSystem.dimensions.spacings.m}
     ${designSystem.dimensions.spacings.m} ${designSystem.dimensions.spacings.xl};
 

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -138,6 +138,7 @@ const Sidebar = props => {
         <SpacingsStack scale="xs">
           <div>{props.isGlobalBeta && <BetaFlag />}</div>
           <Link
+            id="site-title"
             to="/"
             css={css`
               text-decoration: none;


### PR DESCRIPTION
This
 * marks more navigation elements as `<nav>` to exclude them from the body content flow
 * marks the top right corner area (e.g. Github link and version) as `<aside>` to exclude it from the content flow (when reading the DOM linearly it's positioned between the Title H1 and the content)
 * marks the page content as `<article>` to address it semantically without having to adress the complete `<main>` which includes more.  It would have been nicer to put the <main> nearer to the body content but the grid-oriented DOM does not allow that (main should not contain things that are the same across many sites like in our case the top nav)
 * gives the actual markdown generated body content a `body-content` ID in the DOM (for transparency, not directly needed yet)
 * introduces a `site-title` ID for the microsite name that is then adressable in the crawler config. 

Once this and the matching changes in the legacy site codebase are live we can ask Algolia to update the search crawler config to this proposed structure:
https://github.com/nkuehn/docsearch-configs/blob/commercetools-changes-2020-02/configs/commercetools.json

This updated crawler config would push the structure in Algolia "down", making it match our content hierarchy of  site->page->section->subsection  (currently the site level is ignored and all pages are flat next to each other, which is starting to become a usability issue because of same-named pages in a list. 
