### PR TITLE
fix: publish canary only if lerna detects that packages changed

### DIFF
--- a/scripts/release_canary.sh
+++ b/scripts/release_canary.sh
@@ -25,8 +25,13 @@ EOF
   echo "Working tree status"
   git status
 
-  echo "Releasing canary version"
-  yarn release:canary
+    # Release package only if lerna detected some changes in packages
+  if yarn run lerna changed &> /dev/null; then
+    echo "Releasing canary version"
+    yarn release:canary
+  else
+    echo "Skipping release, no changes in packages..."
+  fi
 
 else
   echo "Skipping release due to commit message..."


### PR DESCRIPTION
In #276  we forced all packages to be published.

However, when commits do not contain any changes in packages, lerna tries to publish `null` versions.

<img width="661" alt="image" src="https://user-images.githubusercontent.com/1110551/74020922-db39a200-499a-11ea-9d90-0bf181fa0808.png">

This seems to be a known issue in lerna (https://github.com/lerna/lerna/issues/1769).

This PR attempts to fix that, by triggering the release only if lerna detects that packages have changed. For that, we can use the `lerna changed` command.

<img width="390" alt="image" src="https://user-images.githubusercontent.com/1110551/74020929-de349280-499a-11ea-973b-2a3a544b1333.png">
