### PR TITLE
Scroll to chapter, keep scroll pos without flicker

### DIFF
--- a/packages/gatsby-theme-docs/src/hooks/use-active-section.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-active-section.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import throttle from 'lodash.throttle';
 import { designSystem } from '@commercetools-docs/ui-kit';
+import useScrollSpy from './use-scroll-spy';
 
 const calculateOffset = () => {
   const pxNumber = designSystem.dimensions.heights.header.replace(
@@ -12,37 +12,24 @@ const calculateOffset = () => {
 
 const getSectionElements = () =>
   document.querySelectorAll('section[class^="section-h"]');
-const getScrollContainer = () => document.querySelector('[role="application"]');
 
-const throttleMs = 100;
 const offset = calculateOffset();
 
-const useScrollSpy = () => {
+const useActiveSelection = () => {
   const [activeSection, setActiveSection] = React.useState();
-
-  const onScroll = React.useCallback(
-    throttle(() => {
-      const sectionElements = getSectionElements();
-      let nextActiveSection;
-      sectionElements.forEach(section => {
-        if (section.getBoundingClientRect().top - offset < 0) {
-          nextActiveSection = section;
-        }
-      });
-      setActiveSection(nextActiveSection);
-    }, throttleMs),
-    [setActiveSection]
-  );
-
-  React.useEffect(() => {
-    const container = getScrollContainer();
-    container.addEventListener('scroll', onScroll);
-    return () => {
-      container.removeEventListener('scroll', onScroll);
-    };
-  }, [onScroll]);
+  const onScroll = React.useCallback(() => {
+    const sectionElements = getSectionElements();
+    let nextActiveSection;
+    sectionElements.forEach(section => {
+      if (section.getBoundingClientRect().top - offset < 0) {
+        nextActiveSection = section;
+      }
+    });
+    setActiveSection(nextActiveSection);
+  }, []);
+  useScrollSpy('[role="application"]', onScroll);
 
   return activeSection;
 };
 
-export default useScrollSpy;
+export default useActiveSelection;

--- a/packages/gatsby-theme-docs/src/hooks/use-scroll-position.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-scroll-position.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import useScrollSpy from './use-scroll-spy';
+
+const useScrollPosition = containerId => {
+  const [position, setPosition] = React.useState(0);
+  const onScroll = React.useCallback(element => {
+    setPosition(element.scrollTop);
+  }, []);
+  useScrollSpy(`#${containerId}`, onScroll);
+
+  return position;
+};
+
+export default useScrollPosition;

--- a/packages/gatsby-theme-docs/src/hooks/use-scroll-spy.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-scroll-spy.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import throttle from 'lodash.throttle';
+
+const getElement = selector => document.querySelector(selector);
+
+const throttleMs = 100;
+
+const useScrollSpy = (selector, callback) => {
+  const onScroll = React.useCallback(
+    throttle(() => {
+      const element = getElement(selector);
+      callback(element);
+    }, throttleMs),
+    [callback]
+  );
+
+  React.useEffect(() => {
+    const element = getElement(selector);
+    element.addEventListener('scroll', onScroll);
+    return () => {
+      element.removeEventListener('scroll', onScroll);
+    };
+  }, [onScroll, selector]);
+};
+
+export default useScrollSpy;

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -83,7 +83,7 @@ const SidebarLink = React.forwardRef((props, ref) => {
   const restoreScrollPosition = React.useCallback(() => {
     document
       .getElementById(scrollContainerId)
-      .scrollBy(0, cachedScrollPosition);
+      .scrollTo(0, cachedScrollPosition);
   }, [cachedScrollPosition]);
   React.useEffect(() => {
     const isActive = linkRef.current.getAttribute('aria-current') === 'page';

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -74,7 +74,8 @@ const SidebarLink = React.forwardRef((props, ref) => {
 
   const linkRef = React.useRef();
   const scrollIntoView = React.useCallback(() => {
-    ref.current.scrollIntoView({ block: 'center' });
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#Parameters
+    ref.current.scrollIntoView({ block: 'start' });
   }, [ref]);
   const restoreScrollPosition = React.useCallback(() => {
     document

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -65,7 +65,7 @@ const LinkItem = styled.div`
   align-items: flex-end;
 `;
 
-const SidebarLink = React.forwardRef((props, ref) => {
+const SidebarLink = React.forwardRef(props => {
   // Filter out props that we don't want to forward to the Link component
   const { location, nextScrollPosition, ...forwardProps } = props;
 
@@ -73,32 +73,25 @@ const SidebarLink = React.forwardRef((props, ref) => {
   const locationPath = trimTrailingSlash(location.pathname);
 
   const linkRef = React.useRef();
-  const scrollIntoView = React.useCallback(() => {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#Parameters defaulting to block=start, defaults are most compatible
-    const chapterContainer = ref.current.closest
-      ? ref.current.closest('.sidebar-chapter')
-      : ref.current;
-    chapterContainer.scrollIntoView();
-  }, [ref]);
-  const restoreScrollPosition = React.useCallback(() => {
-    document
-      .getElementById(scrollContainerId)
-      .scrollTo(0, cachedScrollPosition);
-  }, [cachedScrollPosition]);
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const isActive = linkRef.current.getAttribute('aria-current') === 'page';
     // In case there was no scroll position saved in the location, and the link
     // is the active one, make sure that the chapter is "visible".
     if (isActive && !cachedScrollPosition) {
-      scrollIntoView();
+      const chapterContainer = linkRef.current.closest
+        ? linkRef.current.closest('.sidebar-chapter')
+        : linkRef.current;
+      chapterContainer.scrollIntoView();
     }
     // In case there was a scroll position saved in the location make sure that
     // the scroll position is restored.
     // We check for the active link to ensure that we scroll to the position only once.
     else if (isActive && cachedScrollPosition >= 0) {
-      restoreScrollPosition();
+      document
+        .getElementById(scrollContainerId)
+        .scrollTo(0, cachedScrollPosition);
     }
-  }, [linkRef, cachedScrollPosition, scrollIntoView, restoreScrollPosition]);
+  }, [linkRef, cachedScrollPosition]);
 
   return (
     <ClassNames>

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -74,8 +74,11 @@ const SidebarLink = React.forwardRef((props, ref) => {
 
   const linkRef = React.useRef();
   const scrollIntoView = React.useCallback(() => {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#Parameters
-    ref.current.scrollIntoView({ block: 'start' });
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#Parameters defaulting to block=start, defaults are most compatible
+    const chapterContainer = ref.current.closest
+      ? ref.current.closest('.sidebar-chapter')
+      : ref.current;
+    chapterContainer.scrollIntoView();
   }, [ref]);
   const restoreScrollPosition = React.useCallback(() => {
     document
@@ -166,7 +169,7 @@ SidebarLink.propTypes = {
 const SidebarChapter = props => {
   const ref = React.useRef();
   return (
-    <div ref={ref}>
+    <div ref={ref} className="sidebar-chapter">
       <SpacingsStack scale="s">
         <LinkItem>
           <LinkTitle>{props.chapter.chapterTitle}</LinkTitle>

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Location } from '@reach/router';
 import { useStaticQuery, graphql, Link } from 'gatsby';
 import { css, ClassNames } from '@emotion/core';
 import styled from '@emotion/styled';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import { designSystem, LogoButton } from '@commercetools-docs/ui-kit';
+import useScrollPosition from '../../hooks/use-scroll-position';
 import { BetaFlag } from '../../components';
 
 const trimTrailingSlash = url => url.replace(/(\/?)$/, '');
+
+const scrollContainerId = 'navigation-scroll-container';
 
 const ScrollContainer = styled.div`
   overflow: auto;
@@ -61,55 +65,151 @@ const LinkItem = styled.div`
   align-items: flex-end;
 `;
 
-const SidebarLink = props => (
-  <ClassNames>
-    {({ css: makeClassName }) => {
-      const linkClassName = makeClassName`
-        border-left: ${designSystem.dimensions.spacings.xs} solid
-          ${designSystem.colors.light.surfacePrimary};
-        padding-left: calc(
-          ${designSystem.dimensions.spacings.m} - ${designSystem.dimensions.spacings.xs}
-        );
-        text-decoration: none;
-        color: ${designSystem.colors.light.textSecondary};
-        display: flex;
-        flex-direction: row;
-        align-items: flex-end;
+const SidebarLink = React.forwardRef((props, ref) => {
+  // Filter out props that we don't want to forward to the Link component
+  const { location, nextScrollPosition, ...forwardProps } = props;
 
-        :hover {
+  const cachedScrollPosition = (location.state || {}).scrollPosition;
+  const locationPath = trimTrailingSlash(location.pathname);
+
+  const linkRef = React.useRef();
+  const scrollIntoView = React.useCallback(() => {
+    ref.current.scrollIntoView({ block: 'center' });
+  }, [ref]);
+  const restoreScrollPosition = React.useCallback(() => {
+    document
+      .getElementById(scrollContainerId)
+      .scrollBy(0, cachedScrollPosition);
+  }, [cachedScrollPosition]);
+  React.useEffect(() => {
+    const isActive = linkRef.current.getAttribute('aria-current') === 'page';
+    // In case there was no scroll position saved in the location, and the link
+    // is the active one, make sure that the chapter is "visible".
+    if (isActive && !cachedScrollPosition) {
+      scrollIntoView();
+    }
+    // In case there was a scroll position saved in the location make sure that
+    // the scroll position is restored.
+    // We check for the active link to ensure that we scroll to the position only once.
+    else if (isActive && cachedScrollPosition >= 0) {
+      restoreScrollPosition();
+    }
+  }, [linkRef, cachedScrollPosition, scrollIntoView, restoreScrollPosition]);
+
+  return (
+    <ClassNames>
+      {({ css: makeClassName }) => {
+        const linkClassName = makeClassName`
+          border-left: ${designSystem.dimensions.spacings.xs} solid
+            ${designSystem.colors.light.surfacePrimary};
+          padding-left: calc(
+            ${designSystem.dimensions.spacings.m} - ${designSystem.dimensions.spacings.xs}
+          );
+          text-decoration: none;
+          color: ${designSystem.colors.light.textSecondary};
+          display: flex;
+          flex-direction: row;
+          align-items: flex-end;
+
+          :hover {
+            color: ${designSystem.colors.light.linkNavigation} !important;
+          }
+
+          > * + * {
+            margin: 0 0 0 ${designSystem.dimensions.spacings.s};
+          }
+        `;
+        const activeClassName = makeClassName`
+          border-left: ${designSystem.dimensions.spacings.xs} solid ${designSystem.colors.light.linkNavigation} !important;
           color: ${designSystem.colors.light.linkNavigation} !important;
-        }
-
-        > * + * {
-          margin: 0 0 0 ${designSystem.dimensions.spacings.s};
-        }
-      `;
-      const activeClassName = makeClassName`
-        border-left: ${designSystem.dimensions.spacings.xs} solid ${designSystem.colors.light.linkNavigation} !important;
-        color: ${designSystem.colors.light.linkNavigation} !important;
-      `;
-      return (
-        <Link
-          {...props}
-          // eslint-disable-next-line react/prop-types
-          to={trimTrailingSlash(props.to)}
-          getProps={({ href, location }) => {
-            // Manually check that the link is the active one, even with trailing slashes.
-            // The gatsby link is by default configured to match the exact path, therefore we
-            // need to check this manually.
-            const linkPath = trimTrailingSlash(href);
-            const locationPath = trimTrailingSlash(location.pathname);
-            if (linkPath === locationPath) {
-              return { className: [linkClassName, activeClassName].join(' ') };
-            }
-            return { className: linkClassName };
-          }}
-        />
-      );
-    }}
-  </ClassNames>
-);
+        `;
+        return (
+          <Link
+            {...forwardProps}
+            innerRef={linkRef}
+            to={trimTrailingSlash(props.to)}
+            state={{
+              scrollPosition: nextScrollPosition,
+            }}
+            getProps={({ href }) => {
+              // Manually check that the link is the active one, even with trailing slashes.
+              // The gatsby link is by default configured to match the exact path, therefore we
+              // need to check this manually.
+              const linkPath = trimTrailingSlash(href);
+              if (linkPath === locationPath) {
+                return {
+                  className: [linkClassName, activeClassName].join(' '),
+                  'aria-current': 'page',
+                };
+              }
+              return { className: linkClassName };
+            }}
+          />
+        );
+      }}
+    </ClassNames>
+  );
+});
 SidebarLink.displayName = 'SidebarLink';
+SidebarLink.propTypes = {
+  to: PropTypes.string.isRequired,
+  nextScrollPosition: PropTypes.number.isRequired,
+  location: PropTypes.shape({
+    state: PropTypes.shape({
+      scrollPosition: PropTypes.number,
+    }),
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+const SidebarChapter = props => {
+  const ref = React.useRef();
+  return (
+    <div ref={ref}>
+      <SpacingsStack scale="s">
+        <LinkItem>
+          <LinkTitle>{props.chapter.chapterTitle}</LinkTitle>
+          {props.chapter.beta && !props.isGlobalBeta && <BetaFlag />}
+        </LinkItem>
+        <SpacingsStack scale="s">
+          {props.chapter.pages &&
+            props.chapter.pages.map((pageLink, pageIndex) => (
+              <Location key={`${props.index}-${pageIndex}-${pageLink.path}`}>
+                {({ location }) => (
+                  <SidebarLink
+                    ref={ref}
+                    to={pageLink.path}
+                    onClick={props.onLinkClick}
+                    location={location}
+                    nextScrollPosition={props.nextScrollPosition}
+                  >
+                    <LinkSubtitle>{pageLink.title}</LinkSubtitle>
+                    {pageLink.beta && !props.isGlobalBeta && <BetaFlag />}
+                  </SidebarLink>
+                )}
+              </Location>
+            ))}
+        </SpacingsStack>
+      </SpacingsStack>
+    </div>
+  );
+};
+SidebarChapter.propTypes = {
+  index: PropTypes.number.isRequired,
+  chapter: PropTypes.shape({
+    chapterTitle: PropTypes.string.isRequired,
+    beta: PropTypes.bool,
+    pages: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string.isRequired,
+        path: PropTypes.string.isRequired,
+      })
+    ),
+  }).isRequired,
+  isGlobalBeta: PropTypes.bool.isRequired,
+  onLinkClick: PropTypes.func,
+  nextScrollPosition: PropTypes.number.isRequired,
+};
 
 const Sidebar = props => {
   const data = useStaticQuery(graphql`
@@ -127,6 +227,12 @@ const Sidebar = props => {
       }
     }
   `);
+  // Restore scroll position
+  // - read the position from the location state, in case it was set
+  // - clear the location state
+  // - initialize the new scroll position
+  // - scroll to the previous position in case it was defined
+  const nextScrollPosition = useScrollPosition(scrollContainerId);
   return (
     <>
       <LogoContainer>
@@ -149,27 +255,16 @@ const Sidebar = props => {
           </Link>
         </SpacingsStack>
       </WebsiteTitle>
-      <ScrollContainer>
+      <ScrollContainer id={scrollContainerId}>
         {data.allNavigationYaml.nodes.map((node, index) => (
-          <SpacingsStack scale="s" key={index}>
-            <LinkItem>
-              <LinkTitle>{node.chapterTitle}</LinkTitle>
-              {node.beta && !props.isGlobalBeta && <BetaFlag />}
-            </LinkItem>
-            <SpacingsStack scale="s">
-              {node.pages &&
-                node.pages.map((pageLink, pageIndex) => (
-                  <SidebarLink
-                    to={pageLink.path}
-                    key={`${index}-${pageIndex}-${pageLink.path}`}
-                    onClick={props.onLinkClick}
-                  >
-                    <LinkSubtitle>{pageLink.title}</LinkSubtitle>
-                    {pageLink.beta && !props.isGlobalBeta && <BetaFlag />}
-                  </SidebarLink>
-                ))}
-            </SpacingsStack>
-          </SpacingsStack>
+          <SidebarChapter
+            key={index}
+            index={index}
+            chapter={node}
+            isGlobalBeta={props.isGlobalBeta}
+            onLinkClick={props.onLinkClick}
+            nextScrollPosition={nextScrollPosition}
+          />
         ))}
       </ScrollContainer>
     </>


### PR DESCRIPTION
!! This is a PR to merge from nm-nav-scroll-position--nk into nm-nav-scroll-position, not into master.  re-route as you like if merging directly to master is better. 
---
I think I tamed the flickering by switching to the synchronous  `useLayoutEffect()` hook and removing the extra layer of `useCallback()` nesting. 

UX change: If no previous position is known, the nav now scrolls the current chapter heading to the top instead of the individual page.  

The smoke test site's fake nav entries confuse it but e.g. in the API smoke test it's fine:
https://commercetools-docs-kit-git-nm-nav-scroll-position-nk.commercetools.now.sh/api-docs-smoke-test/endpoints/simple-resource-get

One click flow is not ideal yet but I can live with it:  After a reload (e.g. navigating from another site) the first click on a nav entry does not keep the position but scrolls to the top of the chapter if you never scrolled before.  So on initial load the position seems to not be set yet or something like that.  