### PR TITLE
fix(theme): css overrides for search overlay

### DIFF
--- a/packages/gatsby-theme-docs/src/components/overlay.js
+++ b/packages/gatsby-theme-docs/src/components/overlay.js
@@ -3,12 +3,12 @@ import styled from '@emotion/styled';
 const Overlay = styled.div`
   background-color: rgba(0, 0, 0, 0.5);
   z-index: 20;
-  position: fixed;
-  top: 0;
+  position: ${props => props.position || 'fixed'};
+  top: ${props => props.top || '0'};
   left: 0;
   right: 0;
   bottom: 0;
-  display: flex;
+  display: ${props => props.display || 'flex'};
   justify-content: ${props => props.justifyContent || 'flex-start'};
 `;
 

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
@@ -177,10 +177,8 @@ const LayoutHeader = props => (
           </SwitcherButton>
           {props.isTopMenuOpen ? (
             <Overlay
+              top={designSystem.dimensions.heights.header}
               onClick={props.closeTopMenu}
-              css={css`
-                top: ${designSystem.dimensions.heights.header} !important;
-              `}
             >
               <TopMenu />
             </Overlay>
@@ -189,12 +187,7 @@ const LayoutHeader = props => (
       </Inline>
       <SearchContainer excludeFromSearchIndex={props.excludeFromSearchIndex}>
         {props.isSearchDialogOpen ? (
-          <Overlay
-            onClick={props.closeSearchDialog}
-            css={css`
-              position: absolute;
-            `}
-          >
+          <Overlay position="absolute" onClick={props.closeSearchDialog}>
             <SearchDialog onClose={props.closeSearchDialog} />
           </Overlay>
         ) : (

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-sidebar.js
@@ -115,13 +115,12 @@ const LayoutSidebar = props => {
         />
         {props.isSearchDialogOpen && (
           <Overlay
+            position="absolute"
+            display="none"
             css={css`
-              position: absolute;
-              display: none;
-
               @media screen and (${designSystem.dimensions.viewports
                   .largeTablet}) {
-                display: block;
+                display: block !important;
               }
             `}
           />


### PR DESCRIPTION
Problem: the search container results does not scroll with the page.

In the production bundle, the css override styles didn't get properly applied, so that the default styles of the overlay were still used. This could be solved by using `!important`, but it's not the best solution.

In this PR we pass the override styles as props, so that the final bundle contains the correct applied styles. 