### PR TITLE
path into raml-generator PR:  automatically download rmf-codegen, polish

### DIFF
--- a/packages/ramldoc-generator/.gitignore
+++ b/packages/ramldoc-generator/.gitignore
@@ -1,0 +1,1 @@
+bin/rmf-codegen-*.jar

--- a/packages/ramldoc-generator/README.md
+++ b/packages/ramldoc-generator/README.md
@@ -1,12 +1,18 @@
-# Docs Kit RAML Doc Generator
+# commercetools Docs Kit "RAMLdoc" Generator
 
-This package provides an executable script that generates RAML documents compatible with the [RAML transformer ](https://www.npmjs.com/package/@commercetools-docs/gatsby-transformer-raml) plugin.
+This package provides an executable that transform any spec-compliant RAML API definition into the (also RAML-compliant) RAML document structure and layout required by the [@commercetools-docs/gatsby-transformer-raml](https://www.npmjs.com/package/@commercetools-docs/gatsby-transformer-raml) plugin.
 
-It's based on the [rmf-codegen](https://github.com/vrapio/rmf-codegen) tool.
+The conversion step is applying a number normalizations and resolutions so that the RAML spec exposed to the site generator can be published exactly as-is without further semantic understanding of the API definition.
 
-## Pre-Installation
+Among others, it flattens most type inheritance into the effectively visible API surface and distributes the information into separate fragments for API Endpoints and API Types that match the way they are exposed in web documentation.
 
-At least Java 8 is required to be installed before using this tool.
+It's based on the REST Modeling Framework's [rmf-codegen](https://github.com/vrapio/rmf-codegen) CLI.
+
+## Prerequisites
+
+A Java 8 or newer `java` runtime is required to be installed and available on the path. `rmf-codegen` is downloaded automatically at install time.
+
+`rmf-codegen` was chosen over other (native JS and/or official) RAML parsers because it proved to be the only implementation that can correctly and reliably load even extremely large API definitions in very short time where others fail to load the same API definition at all.
 
 ## Usage
 
@@ -35,10 +41,6 @@ For globally installation, there is an optional third parameter that should be p
 
 `npx commercetools-ramldoc-generator --name <api-spec-name> --src <api-spec-source-path> --dest <api-spec-destination-path>`
 
-## RMF-Codegen Jar File
+## Maintenance
 
-The [rmf-codegen](https://github.com/vrapio/rmf-codegen) jar file is deployed on [Bintray](https://bintray.com/vrapio/vrapio/rmf-codegen#files/io%2Fvrap%2Frmf%2Fcodegen%2Fcli-application%2F1.0.0-20200221085820). A direct download link of the cli application, that includes necessary dependencies, is found here:
-
-https://dl.bintray.com/vrapio/vrapio/io/vrap/rmf/codegen/cli-application/1.0.0-20200221085820/
-
-Note: To update the jar file in this tool (found in `<root>/jar/rmf-codegen.jar`), you must rename the downloaded jar file to `rmf-codegen.jar`.
+To update the `rmf-codegen` version, update the custom `rmfCodegenVersion` property in `package.json`

--- a/packages/ramldoc-generator/package.json
+++ b/packages/ramldoc-generator/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@commercetools-docs/ramldoc-generator",
   "version": "1.0.0",
+  "rmfCodegenVersion": "1.0.0-20200304142749",
   "description": "Generates RAML docs compatible with @commercetools-docs/gatsby-transformer-raml",
   "license": "MIT",
   "publishConfig": {
@@ -11,6 +12,7 @@
     "ramldoc-generator"
   ],
   "scripts": {
+    "postinstall": "node scripts/download-rmf-codegen.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "bin": {

--- a/packages/ramldoc-generator/package.json
+++ b/packages/ramldoc-generator/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "mri": "1.1.4",
     "shelljs": "0.8.3",
-    "chalk": "3.0.0"
+    "chalk": "3.0.0",
+    "hasbin": "1.2.3"
   }
 }

--- a/packages/ramldoc-generator/scripts/download-rmf-codegen.js
+++ b/packages/ramldoc-generator/scripts/download-rmf-codegen.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+const shelljs = require('shelljs');
+const { rmfCodegenVersion } = require('../package.json');
+
+const binPath = path.join(__dirname, '../bin');
+const jarName = `rmf-codegen-${rmfCodegenVersion}.jar`;
+const jarPath = path.join(binPath, jarName);
+const downloadURI = `https://dl.bintray.com/vrapio/vrapio/io/vrap/rmf/codegen/cli-application/${rmfCodegenVersion}/cli-application-${rmfCodegenVersion}-all.jar`;
+
+const abortIfError = result => {
+  if (result.code > 0) {
+    throw new Error(result.stderr);
+  }
+};
+const downloadArchive = async url => {
+  // Download the archive
+  const res = await fetch(url);
+  const fileStream = fs.createWriteStream(jarPath);
+  await new Promise((resolve, reject) => {
+    res.body.pipe(fileStream);
+    res.body.on('error', error => {
+      reject(error);
+    });
+    fileStream.on('finish', resolve);
+  });
+
+  // Assign proper write permissions to the file
+  abortIfError(shelljs.chmod(755, jarPath));
+};
+
+console.log('[ramldoc-generator] Verifying rmf-codegen installation...');
+// TODO test for java being installed and warn (but do not abort)
+if (fs.existsSync(jarPath)) {
+  console.log(
+    '[ramldoc-generator] rmf-codegen jar already installed, skipping installation...'
+  );
+} else {
+  console.log('[ramldoc-generator] Installing rmf-codegen jar..');
+  downloadArchive(downloadURI).then(
+    () => {
+      console.log('[ramldoc-generator] rmf-codegen jar installed.');
+    },
+    error => {
+      console.error(
+        '[ramldoc-generator] Error installing rmf-codegen jar',
+        error
+      );
+      process.exit(1);
+    }
+  );
+}

--- a/packages/ramldoc-generator/scripts/download-rmf-codegen.js
+++ b/packages/ramldoc-generator/scripts/download-rmf-codegen.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
 const shelljs = require('shelljs');
+const hasbin = require('hasbin');
 const { rmfCodegenVersion } = require('../package.json');
 
 const binPath = path.join(__dirname, '../bin');
@@ -30,8 +31,12 @@ const downloadArchive = async url => {
   abortIfError(shelljs.chmod(755, jarPath));
 };
 
+if (!hasbin.sync('java')) {
+  console.warn(
+    '[ramldoc-generator] Warning: no java runtime detected in path. Using existing RAMLdocs is possible but not regeneration from master RAML definitions.'
+  );
+}
 console.log('[ramldoc-generator] Verifying rmf-codegen installation...');
-// TODO test for java being installed and warn (but do not abort)
 if (fs.existsSync(jarPath)) {
   console.log(
     '[ramldoc-generator] rmf-codegen jar already installed, skipping installation...'

--- a/packages/ramldoc-generator/src/cli.js
+++ b/packages/ramldoc-generator/src/cli.js
@@ -33,10 +33,8 @@ async function promptForMissingOptions(options) {
     console.log(`
     Usage: commercetools-ramldoc-generator --name <api-spec-name> --src <api-spec-source-path>
 
-    Displays help information.
-
     Options:
-      --dest <api-spec-destination-path>               (optional) the path for the generated RAML documents."
+      --dest <api-spec-destination-path>               (optional) alternative path for the generated RAML documents."
     `);
 
     process.exit(0);

--- a/packages/ramldoc-generator/src/main.js
+++ b/packages/ramldoc-generator/src/main.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const shell = require('shelljs');
 const chalk = require('chalk');
+const { rmfCodegenVersion } = require('../package.json');
 
 function generateRaml(options) {
   const resolvedSourcePath = path.resolve(options.src);
@@ -26,7 +27,10 @@ function generateRamlIfSpecPath(options) {
     )}`
   );
 
-  const jarFile = path.resolve(__dirname, '../jar/rmf-codegen.jar');
+  const jarFile = path.resolve(
+    __dirname,
+    `../bin/rmf-codegen-${rmfCodegenVersion}.jar`
+  );
 
   shell.exec(
     `java -jar ${jarFile} generate ${options.src} -o ${resolvedDestinationPath}/${options.name} -t ramldoc`

--- a/yarn.lock
+++ b/yarn.lock
@@ -11482,25 +11482,6 @@ inquirer@3.3.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@7.0.4, inquirer@^7.0.0:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.4.tgz#99af5bde47153abca23f5c7fc30db247f39da703"
-  integrity sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^2.4.2"
-    cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.15"
-    mute-stream "0.0.8"
-    run-async "^2.2.0"
-    rxjs "^6.5.3"
-    string-width "^4.1.0"
-    strip-ansi "^5.1.0"
-    through "^2.3.6"
-
 inquirer@^6.2.0:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
@@ -11517,6 +11498,25 @@ inquirer@^6.2.0:
     run-async "^2.2.0"
     rxjs "^6.4.0"
     string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
+
+inquirer@^7.0.0:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.4.tgz#99af5bde47153abca23f5c7fc30db247f39da703"
+  integrity sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^2.4.2"
+    cli-cursor "^3.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
+    run-async "^2.2.0"
+    rxjs "^6.5.3"
+    string-width "^4.1.0"
     strip-ansi "^5.1.0"
     through "^2.3.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4400,7 +4400,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async@1.5.2:
+async@1.5.2, async@~1.5:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
@@ -10648,6 +10648,13 @@ has@^1.0.0, has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hasbin@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/hasbin/-/hasbin-1.2.3.tgz#78c5926893c80215c2b568ae1fd3fcab7a2696b0"
+  integrity sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=
+  dependencies:
+    async "~1.5"
 
 hash-base@^3.0.0:
   version "3.0.4"


### PR DESCRIPTION
This automatically downloads the rmf-codegen JAR at install time like we do for the vale language linter. 

Plus an overhaul of some of the README sections, explaining more why and what this does. 

Some of the open comments in #296  will be obsolete but not all (not the CLI related polish that is open)

The jar now has the version in the file name to increase transparency and to make sure it's reliably downloading the newest version when the package is upgraded.  