### PR TITLE
feat: code examples provided on graphQL by a transformer plugin 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+code-examples/
 dist/
 node_modules/*
 **/node_modules/*

--- a/packages/gatsby-theme-docs/README.md
+++ b/packages/gatsby-theme-docs/README.md
@@ -30,9 +30,10 @@ The project structure should contain at least the following files and folders:
     ├── content
     │   ├── files
     │   └── index.mdx
-    ├── data
-    │   └── navigation.yaml
-    └── images
+    ├── images
+    ├── code-examples
+    └── data
+        └── navigation.yaml
 ```
 
 - `.eslintrc.yaml`: in case you're using a monorepository, you need to provide this file with an empty object `{}`, otherwise provide a valid ESLint configuration.
@@ -78,6 +79,12 @@ The project structure should contain at least the following files and folders:
 
 - `src/content`: this is where you would put your content pages as `*.mdx` files (_see [Writing content pages](#writing-content-pages)_).
 
+- `src/content/files`: this folder should contain static files that can be referenced within the `*.mdx` content files. For example SVG files, PDF files, etc.
+
+- `src/images`: this folder should contain images that are used within the `*.mdx` content files. Images in this folder are processed and optimized by Gatsby for lazy loading. Supported image formats are `JPEG` and `PNG`.
+
+- `src/code-examples`: instead of placing them into markdown fenced code blocks, code examples can be put into this folder and be loaded into the documentation using the `<CodeExample>` component.
+
 - `src/data/navigation.yaml`: this contains the website main navigation links. The structure of the file is a _list of chapters_ as following:
 
   ```yaml
@@ -94,9 +101,6 @@ The project structure should contain at least the following files and folders:
   - chapter-title: {} # another chapter, and so on...
   ```
 
-- `src/content/files`: this folder should contain static files that can be referenced within the `*.mdx` content files. For example SVG files, PDF files, etc.
-
-- `src/images`: this folder should contain images that are used within the `*.mdx` content files. Images in this folder are processed and optimized by Gatsby for lazy loading. Supported image formats are `JPEG` and `PNG`.
 
 ## Writing content pages
 
@@ -142,6 +146,7 @@ The available JSX components are:
 - `<Info>`: a notification message with info colors
 - `<Warning>`: a notification message with warning colors
 - `<Error>`: a notification message with error colors
+- `<CodeExample file="/code-examples/example.js" title="JavaScript Code Sample" />`: loading a code block from a file, supports all parameters of the fenced code block.
 
 > When using JSX components, it's recommended to leave a **blank line** between the element tags and the actual content. This allows the content to be parsed as markdown, so you can use markdown syntax within the custom component tags.
 

--- a/packages/gatsby-theme-docs/README.md
+++ b/packages/gatsby-theme-docs/README.md
@@ -101,7 +101,6 @@ The project structure should contain at least the following files and folders:
   - chapter-title: {} # another chapter, and so on...
   ```
 
-
 ## Writing content pages
 
 Content pages are located in the `src/content` folder and should be `*.mdx` files.
@@ -146,7 +145,7 @@ The available JSX components are:
 - `<Info>`: a notification message with info colors
 - `<Warning>`: a notification message with warning colors
 - `<Error>`: a notification message with error colors
-- `<CodeExample file="/code-examples/example.js" title="JavaScript Code Sample" />`: loading a code block from a file, supports all parameters of the fenced code block.
+- `<CodeExample file="example.js" title="JavaScript Code Sample" />`: loading a code block from a file in `src/code-examples/`, supports all parameters of the fenced code block.
 
 > When using JSX components, it's recommended to leave a **blank line** between the element tags and the actual content. This allows the content to be parsed as markdown, so you can use markdown syntax within the custom component tags.
 

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -88,6 +88,14 @@ module.exports = (themeOptions = {}) => {
           path: path.resolve(`./src/content`),
         },
       },
+      // Code samples
+      {
+        resolve: 'gatsby-source-filesystem',
+        options: {
+          name: 'code-examples',
+          path: path.resolve(`./src/code-examples`),
+        },
+      },
 
       /**
        * Transformers for making content available in graphql queries
@@ -98,6 +106,9 @@ module.exports = (themeOptions = {}) => {
 
       // For querying configuration data
       'gatsby-transformer-yaml',
+
+      // For querying code samples
+      `@commercetools-docs/gatsby-transformer-code-examples`,
 
       // For querying MDX
       {

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -107,7 +107,7 @@ module.exports = (themeOptions = {}) => {
       // For querying configuration data
       'gatsby-transformer-yaml',
 
-      // For querying code samples
+      // For querying code examples
       `@commercetools-docs/gatsby-transformer-code-examples`,
 
       // For querying MDX

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -92,7 +92,7 @@ module.exports = (themeOptions = {}) => {
       {
         resolve: 'gatsby-source-filesystem',
         options: {
-          name: 'code-examples',
+          name: 'codeExamples',
           path: path.resolve(`./src/code-examples`),
         },
       },

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -88,7 +88,7 @@ module.exports = (themeOptions = {}) => {
           path: path.resolve(`./src/content`),
         },
       },
-      // Code samples
+      // Code examples
       {
         resolve: 'gatsby-source-filesystem',
         options: {

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -18,6 +18,7 @@ exports.onPreBootstrap = ({ reporter }) => {
     'src/images',
     'src/content',
     'src/content/files',
+    'src/code-examples',
   ];
   requiredDirectories.forEach(dir => {
     if (!fs.existsSync(dir)) {

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -15,6 +15,7 @@
   "main": "index.js",
   "dependencies": {
     "@commercetools-docs/ui-kit": "2.0.0",
+    "@commercetools-docs/gatsby-transformer-code-examples": "1.0.0",
     "@commercetools-uikit/card": "10.13.0",
     "@commercetools-uikit/design-system": "10.13.0",
     "@commercetools-uikit/icon-button": "10.13.0",

--- a/packages/gatsby-theme-docs/src/components/code-example.js
+++ b/packages/gatsby-theme-docs/src/components/code-example.js
@@ -7,7 +7,7 @@ function CodeExample(props) {
   const codeExamples = useCodeExamples();
 
   const codeExample = codeExamples.find(example => {
-    return example.absolutePath.includes(props.file);
+    return example.absolutePath.endsWith(props.file);
   });
 
   if (!codeExample) {

--- a/packages/gatsby-theme-docs/src/components/code-example.js
+++ b/packages/gatsby-theme-docs/src/components/code-example.js
@@ -11,7 +11,7 @@ function CodeExample(props) {
   });
 
   if (!codeExample) {
-    return reportError('Code example does not exist');
+    return reportError(`Unable to find file "${props.file}" within the "code-examples" folder. Make sure that the file exists and matches the value passed to the "file" property.`);
   }
 
   const language = props.file.split('.').pop();

--- a/packages/gatsby-theme-docs/src/components/code-example.js
+++ b/packages/gatsby-theme-docs/src/components/code-example.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CodeBlock, ContentNotifications } from '@commercetools-docs/ui-kit';
+import useCodeExamples from '../hooks/use-code-examples';
+
+function CodeExample(props) {
+  const codeExamples = useCodeExamples();
+
+  const codeExample = codeExamples.find(example => {
+    return example.absolutePath.includes(props.file);
+  });
+
+  if (!codeExample) {
+    return reportError('Code example does not exist');
+  }
+
+  const language = props.file.split('.').pop();
+
+  return (
+    <CodeBlock
+      content={codeExample.content}
+      language={language}
+      title={props.title}
+      highlightLines={props.highlightLines}
+      noPromptLines={props.noPromptLines}
+    />
+  );
+}
+
+function reportError(errorMsg) {
+  if (process.env.NODE_ENV !== 'production') {
+    return <ContentNotifications.Error>{errorMsg}</ContentNotifications.Error>;
+  }
+
+  throw new Error(errorMsg);
+}
+
+CodeExample.propTypes = {
+  file: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  highlightLines: PropTypes.arrayOf(PropTypes.number),
+  noPromptLines: PropTypes.arrayOf(PropTypes.number),
+};
+
+export default CodeExample;

--- a/packages/gatsby-theme-docs/src/components/code-example.js
+++ b/packages/gatsby-theme-docs/src/components/code-example.js
@@ -11,15 +11,15 @@ function CodeExample(props) {
   });
 
   if (!codeExample) {
-    return reportError(`Unable to find file "${props.file}" within the "code-examples" folder. Make sure that the file exists and matches the value passed to the "file" property.`);
+    return reportError(
+      `Unable to find file "${props.file}" within the "code-examples" folder. Make sure that the file exists and matches the value passed to the "file" property.`
+    );
   }
-
-  const language = props.file.split('.').pop();
 
   return (
     <CodeBlock
       content={codeExample.content}
-      language={language}
+      language={codeExample.extension}
       title={props.title}
       highlightLines={props.highlightLines}
       noPromptLines={props.noPromptLines}

--- a/packages/gatsby-theme-docs/src/components/code-example.js
+++ b/packages/gatsby-theme-docs/src/components/code-example.js
@@ -7,7 +7,7 @@ function CodeExample(props) {
   const codeExamples = useCodeExamples();
 
   const codeExample = codeExamples.find(example => {
-    return example.path.endsWith(props.path);
+    return example.path === props.path;
   });
 
   if (!codeExample) {

--- a/packages/gatsby-theme-docs/src/components/code-example.js
+++ b/packages/gatsby-theme-docs/src/components/code-example.js
@@ -7,19 +7,19 @@ function CodeExample(props) {
   const codeExamples = useCodeExamples();
 
   const codeExample = codeExamples.find(example => {
-    return example.absolutePath.endsWith(props.file);
+    return example.path.endsWith(props.path);
   });
 
   if (!codeExample) {
     return reportError(
-      `Unable to find file "${props.file}" within the "code-examples" folder. Make sure that the file exists and matches the value passed to the "file" property.`
+      `Unable to find file "${props.path}" within the "code-examples" folder. Make sure that the file exists and matches the value passed to the "file" property.`
     );
   }
 
   return (
     <CodeBlock
       content={codeExample.content}
-      language={codeExample.extension}
+      language={codeExample.language}
       title={props.title}
       highlightLines={props.highlightLines}
       noPromptLines={props.noPromptLines}
@@ -36,7 +36,7 @@ function reportError(errorMsg) {
 }
 
 CodeExample.propTypes = {
-  file: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
   title: PropTypes.string,
   highlightLines: PropTypes.arrayOf(PropTypes.number),
   noPromptLines: PropTypes.arrayOf(PropTypes.number),

--- a/packages/gatsby-theme-docs/src/components/index.js
+++ b/packages/gatsby-theme-docs/src/components/index.js
@@ -1,5 +1,6 @@
 export { default as BetaFlag } from './beta-flag';
 export { default as BurgerIcon } from './burger-icon';
+export { default as CodeExample } from './code-example';
 export { default as ContentPagination } from './content-pagination';
 export { default as GlobalNavigationLink } from './global-navigation-link';
 export { default as ErrorBoundary } from './error-boundary';

--- a/packages/gatsby-theme-docs/src/hooks/use-code-examples.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-code-examples.js
@@ -1,0 +1,20 @@
+import { useStaticQuery, graphql } from 'gatsby';
+
+export default () => {
+  const queryResult = useStaticQuery(
+    graphql`
+      query GetCodeExamplesQuery {
+        allCodeExample {
+          nodes {
+            name
+            extension
+            absolutePath
+            content
+          }
+        }
+      }
+    `
+  );
+
+  return queryResult.allCodeExample.nodes;
+};

--- a/packages/gatsby-theme-docs/src/hooks/use-code-examples.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-code-examples.js
@@ -7,8 +7,8 @@ export default () => {
         allCodeExample {
           nodes {
             name
-            extension
-            absolutePath
+            language
+            path
             content
           }
         }

--- a/packages/gatsby-theme-docs/src/hooks/use-code-examples.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-code-examples.js
@@ -3,7 +3,7 @@ import { useStaticQuery, graphql } from 'gatsby';
 export default () => {
   const queryResult = useStaticQuery(
     graphql`
-      query GetCodeExamplesQuery {
+      query GetAllCodeExamplesQuery {
         allCodeExample {
           nodes {
             name

--- a/packages/gatsby-theme-docs/src/templates/page-content.js
+++ b/packages/gatsby-theme-docs/src/templates/page-content.js
@@ -9,7 +9,7 @@ import {
   ContentNotifications,
 } from '@commercetools-docs/ui-kit';
 import LayoutContent from '../layouts/content';
-import { SEO, Link, ThemeProvider } from '../components';
+import { SEO, Link, ThemeProvider, CodeExample } from '../components';
 import PlaceholderMarkdownComponents from '../overrides/markdown-components';
 
 // See https://mdxjs.com/getting-started#table-of-components
@@ -52,6 +52,7 @@ const components = {
   Info: ContentNotifications.Info,
   Warning: ContentNotifications.Warning,
   Error: ContentNotifications.Error,
+  CodeExample,
 
   // Custom React components that can be injected from each website
   // See ../overrides/README.md

--- a/packages/gatsby-transformer-code-examples/LICENSE
+++ b/packages/gatsby-transformer-code-examples/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) commercetools GmbH and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/gatsby-transformer-code-examples/README.md
+++ b/packages/gatsby-transformer-code-examples/README.md
@@ -8,7 +8,7 @@ This plugin transforms file contents into CodeExample types in available in grap
 
 ## Usage
 
-As a prerequisite configure a source plugin, e.g. `gatsby-source-filesystem` to point the directory of the code examples, for example `src/code-examples`.  Other source plugins can be used, too. 
+As a prerequisite configure a source plugin, e.g. `gatsby-source-filesystem` to point the directory of the code examples, for example `src/code-examples`. Other source plugins can be used, too.
 
 Example `gatsby-config.js` content:
 
@@ -19,7 +19,7 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        name: `code-examples`,
+        name: `codeExamples`,
         path: `${__dirname}/src/code-examples`,
       },
     },
@@ -31,7 +31,7 @@ module.exports = {
 ## GraphQl Query Example
 
 ```graphql
-query GetCodeExamplesQuery {
+query GetAllCodeExamplesQuery {
   allCodeExample {
     nodes {
       name
@@ -43,14 +43,13 @@ query GetCodeExamplesQuery {
 }
 ```
 
-## Supported File Formats
+## Supported MIME Types
 
-- cs
-- graphql
-- java
-- js
-- json
-- php
-- sh
-- ts
-- yaml
+- application/javascript
+- text/x-java-source
+- application/octet-stream
+- application/json
+- application/x-httpd-php
+- application/x-sh
+- video/mp2t
+- text/yaml

--- a/packages/gatsby-transformer-code-examples/README.md
+++ b/packages/gatsby-transformer-code-examples/README.md
@@ -47,12 +47,16 @@ query GetAllCodeExamplesQuery {
 
 ## Supported MIME Types
 
-- application/javascript
-- text/x-java-source
-- application/octet-stream
-- application/json
-- application/x-httpd-php
-- application/x-sh
-- video/mp2t
-- text/yaml
-- text/vnd.curl
+- `application/javascript` (JavaScript)
+- `text/x-java-source` (Java)
+- `application/json` (JSON)
+- `application/x-httpd-php` (PHP)
+- `application/x-sh` (Shell / Bash)
+- `video/mp2t` (not actually TypeScript, but gatsbyJS represents .ts files as this mime type)
+- `text/yaml` (YAML)
+- `text/vnd.curl` (cURL)
+
+In addition the following are included to cover languages with no explicit mime type (e.g. C#)
+
+- `application/octet-stream`
+- `text/plain`

--- a/packages/gatsby-transformer-code-examples/README.md
+++ b/packages/gatsby-transformer-code-examples/README.md
@@ -14,13 +14,15 @@ Example `gatsby-config.js` content:
 
 ```js
 // In your gatsby-config.js
+const path = require('path');
+
 module.exports = {
   plugins: [
     {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `codeExamples`,
-        path: `${__dirname}/src/code-examples`,
+        path: path.resolve('./src/code-examples'),
       },
     },
     `@commercetools-docs/gatsby-transformer-code-examples`,
@@ -35,8 +37,8 @@ query GetAllCodeExamplesQuery {
   allCodeExample {
     nodes {
       name
-      extension
-      absolutePath
+      language
+      path
       content
     }
   }

--- a/packages/gatsby-transformer-code-examples/README.md
+++ b/packages/gatsby-transformer-code-examples/README.md
@@ -1,0 +1,56 @@
+# Gatsby Transformer Code Examples
+
+This plugin transforms file contents into CodeExample types in available in graphql.
+
+## Installation
+
+`npm install --save @commercetools-docs/gatsby-transformer-code-examples`
+
+## Usage
+
+As a prerequisite configure `gatsby-source-filesystem` plugin to point the directory of the code examples, for example `src/code-examples`.
+
+Example `gatsby-config.js` content:
+
+```js
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `code-examples`,
+        path: `${__dirname}/src/code-examples`,
+      },
+    },
+    `@commercetools-docs/gatsby-transformer-code-examples`,
+  ],
+};
+```
+
+## GraphQl Query Example
+
+```graphql
+query GetCodeExamplesQuery {
+  allCodeExample {
+    nodes {
+      name
+      extension
+      absolutePath
+      content
+    }
+  }
+}
+```
+
+## Supported File Formats
+
+- cs
+- graphql
+- java
+- js
+- json
+- php
+- sh
+- ts
+- yaml

--- a/packages/gatsby-transformer-code-examples/README.md
+++ b/packages/gatsby-transformer-code-examples/README.md
@@ -8,7 +8,7 @@ This plugin transforms file contents into CodeExample types in available in grap
 
 ## Usage
 
-As a prerequisite configure `gatsby-source-filesystem` plugin to point the directory of the code examples, for example `src/code-examples`.
+As a prerequisite configure a source plugin, e.g. `gatsby-source-filesystem` to point the directory of the code examples, for example `src/code-examples`.  Other source plugins can be used, too. 
 
 Example `gatsby-config.js` content:
 

--- a/packages/gatsby-transformer-code-examples/README.md
+++ b/packages/gatsby-transformer-code-examples/README.md
@@ -1,6 +1,6 @@
 # Gatsby Transformer Code Examples
 
-This plugin transforms file contents into CodeExample types in available in graphql.
+This plugin transforms file contents into `CodeExample` types and makes them available in Gatsby GraphQL schema.
 
 ## Installation
 

--- a/packages/gatsby-transformer-code-examples/README.md
+++ b/packages/gatsby-transformer-code-examples/README.md
@@ -53,3 +53,4 @@ query GetAllCodeExamplesQuery {
 - application/x-sh
 - video/mp2t
 - text/yaml
+- text/vnd.curl

--- a/packages/gatsby-transformer-code-examples/README.md
+++ b/packages/gatsby-transformer-code-examples/README.md
@@ -56,7 +56,7 @@ query GetAllCodeExamplesQuery {
 - `text/yaml` (YAML)
 - `text/vnd.curl` (cURL)
 
-In addition the following are included to cover languages with no explicit mime type (e.g. C#)
+In addition the following are included to cover languages with no explicit mime type (for example C#)
 
 - `application/octet-stream`
 - `text/plain`

--- a/packages/gatsby-transformer-code-examples/README.md
+++ b/packages/gatsby-transformer-code-examples/README.md
@@ -8,7 +8,7 @@ This plugin transforms file contents into `CodeExample` types and makes them ava
 
 ## Usage
 
-As a prerequisite configure a source plugin, e.g. `gatsby-source-filesystem` to point the directory of the code examples, for example `src/code-examples`. Other source plugins can be used, too.
+As a prerequisite configure a source plugin, for example, `gatsby-source-filesystem` to point the directory of the code examples, for example `src/code-examples`. Other source plugins can be used, too.
 
 Example `gatsby-config.js` content:
 

--- a/packages/gatsby-transformer-code-examples/gatsby-node.js
+++ b/packages/gatsby-transformer-code-examples/gatsby-node.js
@@ -10,6 +10,7 @@ const validMediaTypes = [
   'text/yaml',
   'text/vnd.curl',
 ];
+const validDirectory = `${process.cwd()}/src/code-examples`;
 
 const createSchemaCustomization = ({ actions, schema }) => {
   const { createTypes } = actions;
@@ -19,8 +20,8 @@ const createSchemaCustomization = ({ actions, schema }) => {
       name: 'CodeExample',
       fields: {
         name: 'String!',
-        extension: 'String!',
-        absolutePath: 'String!',
+        language: 'String!',
+        path: 'String!',
         content: 'String!',
       },
       interfaces: ['Node'],
@@ -64,8 +65,8 @@ async function onCreateNode({
   transformObject(
     {
       name: node.name,
-      extension: node.extension,
-      absolutePath: node.absolutePath,
+      language: node.extension,
+      path: node.relativePath,
       content,
     },
     createNodeId(`${node.id} >>> CodeExample`),
@@ -76,14 +77,8 @@ async function onCreateNode({
 function isValidNode(node) {
   return (
     validMediaTypes.includes(node.internal.mediaType) &&
-    isValidSourceDirectory(node.dir)
+    node.dir.startsWith(validDirectory)
   );
-}
-
-function isValidSourceDirectory(dir) {
-  const validDirectory = `${process.cwd()}/src/code-examples`;
-
-  return dir.startsWith(validDirectory);
 }
 
 exports.createSchemaCustomization = createSchemaCustomization;

--- a/packages/gatsby-transformer-code-examples/gatsby-node.js
+++ b/packages/gatsby-transformer-code-examples/gatsby-node.js
@@ -2,15 +2,16 @@
 const validMediaTypes = [
   'application/javascript',
   'text/x-java-source',
-  'application/octet-stream', // csharp, graphql
   'application/json',
   'application/x-httpd-php',
   'application/x-sh',
-  'video/mp2t', // typescript
+  'video/mp2t', // typescript represented as this because the .ts extension collides
   'text/yaml',
   'text/vnd.curl',
+  'application/octet-stream', // languages without registered media type
+  'text/plain', // more languages without registered media type
 ];
-const validDirectory = `${process.cwd()}/src/code-examples`;
+const examplesDirectory = `${process.cwd()}/src/code-examples`;
 
 const createSchemaCustomization = ({ actions, schema }) => {
   const { createTypes } = actions;
@@ -77,7 +78,7 @@ async function onCreateNode({
 function isValidNode(node) {
   return (
     validMediaTypes.includes(node.internal.mediaType) &&
-    node.dir.startsWith(validDirectory)
+    node.dir.startsWith(examplesDirectory)
   );
 }
 

--- a/packages/gatsby-transformer-code-examples/gatsby-node.js
+++ b/packages/gatsby-transformer-code-examples/gatsby-node.js
@@ -1,3 +1,15 @@
+// some files have no unique media type, see comments below
+const validMediaTypes = [
+  'application/javascript',
+  'text/x-java-source',
+  'application/octet-stream', // csharp, graphql
+  'application/json',
+  'application/x-httpd-php',
+  'application/x-sh',
+  'video/mp2t', // typescript
+  'text/yaml',
+];
+
 const createSchemaCustomization = ({ actions, schema }) => {
   const { createTypes } = actions;
 
@@ -62,25 +74,9 @@ async function onCreateNode({
 
 function isValidNode(node) {
   return (
-    isValidMediaType(node.internal.mediaType) &&
+    validMediaTypes.includes(node.internal.mediaType) &&
     isValidSourceDirectory(node.dir)
   );
-}
-
-function isValidMediaType(mediaType) {
-  // some files have no unique media type, see comments below
-  const validMediaTypes = [
-    'application/javascript',
-    'text/x-java-source',
-    'application/octet-stream', // csharp, graphql
-    'application/json',
-    'application/x-httpd-php',
-    'application/x-sh',
-    'video/mp2t', // typescript
-    'text/yaml',
-  ];
-
-  return validMediaTypes.includes(mediaType);
 }
 
 function isValidSourceDirectory(dir) {

--- a/packages/gatsby-transformer-code-examples/gatsby-node.js
+++ b/packages/gatsby-transformer-code-examples/gatsby-node.js
@@ -1,0 +1,74 @@
+const createSchemaCustomization = ({ actions, schema }) => {
+  const { createTypes } = actions;
+
+  const typeDefs = [
+    schema.buildObjectType({
+      name: 'CodeExample',
+      fields: {
+        name: 'String!',
+        extension: 'String!',
+        absolutePath: 'String!',
+        content: 'String!',
+      },
+      interfaces: ['Node'],
+      extensions: {
+        infer: false,
+      },
+    }),
+  ];
+
+  createTypes(typeDefs);
+};
+
+async function onCreateNode({
+  node,
+  actions,
+  loadNodeContent,
+  createNodeId,
+  createContentDigest,
+}) {
+  const validExtensions = [
+    'application/javascript',
+    'text/x-java-source',
+    'application/octet-stream',
+    'application/json',
+    'application/x-httpd-php',
+    'application/x-sh',
+    'video/mp2t',
+    'text/yaml',
+  ];
+  if (!validExtensions.includes(node.internal.mediaType)) return;
+
+  const { createNode, createParentChildLink } = actions;
+
+  function transformObject(obj, id, type) {
+    const codeSampleNode = {
+      ...obj,
+      id,
+      children: [],
+      parent: node.id,
+      internal: {
+        contentDigest: createContentDigest(obj),
+        type,
+      },
+    };
+    createNode(codeSampleNode);
+    createParentChildLink({ parent: node, child: codeSampleNode });
+  }
+
+  const content = await loadNodeContent(node);
+
+  transformObject(
+    {
+      name: node.name,
+      extension: node.extension,
+      absolutePath: node.absolutePath,
+      content,
+    },
+    createNodeId(`${node.id} >>> CodeExample`),
+    'CodeExample'
+  );
+}
+
+exports.createSchemaCustomization = createSchemaCustomization;
+exports.onCreateNode = onCreateNode;

--- a/packages/gatsby-transformer-code-examples/gatsby-node.js
+++ b/packages/gatsby-transformer-code-examples/gatsby-node.js
@@ -86,11 +86,7 @@ function isValidMediaType(mediaType) {
 function isValidSourceDirectory(dir) {
   const validDirectory = `${process.cwd()}/src/code-examples`;
 
-  if (dir.startsWith(validDirectory)) {
-    return true;
-  }
-
-  return false;
+  return dir.startsWith(validDirectory);
 }
 
 exports.createSchemaCustomization = createSchemaCustomization;

--- a/packages/gatsby-transformer-code-examples/gatsby-node.js
+++ b/packages/gatsby-transformer-code-examples/gatsby-node.js
@@ -27,17 +27,7 @@ async function onCreateNode({
   createNodeId,
   createContentDigest,
 }) {
-  const validExtensions = [
-    'application/javascript',
-    'text/x-java-source',
-    'application/octet-stream',
-    'application/json',
-    'application/x-httpd-php',
-    'application/x-sh',
-    'video/mp2t',
-    'text/yaml',
-  ];
-  if (!validExtensions.includes(node.internal.mediaType)) return;
+  if (!isValidMediaType(node.internal.mediaType)) return;
 
   const { createNode, createParentChildLink } = actions;
 
@@ -68,6 +58,22 @@ async function onCreateNode({
     createNodeId(`${node.id} >>> CodeExample`),
     'CodeExample'
   );
+}
+
+function isValidMediaType(mediaType) {
+  // some files have no unique media type, see comments below
+  const validMediaTypes = [
+    'application/javascript',
+    'text/x-java-source',
+    'application/octet-stream', // csharp, graphql
+    'application/json',
+    'application/x-httpd-php',
+    'application/x-sh',
+    'video/mp2t', // typescript
+    'text/yaml',
+  ];
+
+  return validMediaTypes.includes(mediaType);
 }
 
 exports.createSchemaCustomization = createSchemaCustomization;

--- a/packages/gatsby-transformer-code-examples/gatsby-node.js
+++ b/packages/gatsby-transformer-code-examples/gatsby-node.js
@@ -8,6 +8,7 @@ const validMediaTypes = [
   'application/x-sh',
   'video/mp2t', // typescript
   'text/yaml',
+  'text/vnd.curl',
 ];
 
 const createSchemaCustomization = ({ actions, schema }) => {

--- a/packages/gatsby-transformer-code-examples/gatsby-node.js
+++ b/packages/gatsby-transformer-code-examples/gatsby-node.js
@@ -27,7 +27,7 @@ async function onCreateNode({
   createNodeId,
   createContentDigest,
 }) {
-  if (!isValidMediaType(node.internal.mediaType)) return;
+  if (!isValidNode(node)) return;
 
   const { createNode, createParentChildLink } = actions;
 
@@ -60,6 +60,13 @@ async function onCreateNode({
   );
 }
 
+function isValidNode(node) {
+  return (
+    isValidMediaType(node.internal.mediaType) &&
+    isValidSourceDirectory(node.dir)
+  );
+}
+
 function isValidMediaType(mediaType) {
   // some files have no unique media type, see comments below
   const validMediaTypes = [
@@ -74,6 +81,16 @@ function isValidMediaType(mediaType) {
   ];
 
   return validMediaTypes.includes(mediaType);
+}
+
+function isValidSourceDirectory(dir) {
+  const validDirectory = `${process.cwd()}/src/code-examples`;
+
+  if (dir.startsWith(validDirectory)) {
+    return true;
+  }
+
+  return false;
 }
 
 exports.createSchemaCustomization = createSchemaCustomization;

--- a/packages/gatsby-transformer-code-examples/index.js
+++ b/packages/gatsby-transformer-code-examples/index.js
@@ -1,0 +1,1 @@
+// no-op file required for loading the plugin inside the private workspace

--- a/packages/gatsby-transformer-code-examples/package.json
+++ b/packages/gatsby-transformer-code-examples/package.json
@@ -6,7 +6,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "description": "Provides file contents as CodeExample GraphQl types.",
+  "description": "Provides contents of nodes with source code mime types as CodeExample GraphQl types.",
   "homepage": "https://github.com/commercetools/commercetools-docs-kit/tree/master/packages/gatsby-transformer-code-examples#readme",
   "keywords": [
     "gatsby",

--- a/packages/gatsby-transformer-code-examples/package.json
+++ b/packages/gatsby-transformer-code-examples/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@commercetools-docs/gatsby-transformer-code-examples",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Provides file contents as CodeExample GraphQl types.",
+  "homepage": "https://github.com/commercetools/commercetools-docs-kit/tree/master/packages/gatsby-transformer-code-examples#readme",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-transformer",
+    "code",
+    "examples"
+  ]
+}

--- a/packages/ui-kit/src/components/code-block.js
+++ b/packages/ui-kit/src/components/code-block.js
@@ -199,7 +199,9 @@ const languageAliases = {
   zsh: 'bash',
   console: 'bash',
   terminal: 'bash',
+  curl: 'bash',
   js: 'javascript',
+  yml: 'yaml',
 };
 const CodeBlock = props => {
   const languageCode = props.language || 'text';

--- a/packages/writing-style/vale-styles/commercetools/Acronyms.yml
+++ b/packages/writing-style/vale-styles/commercetools/Acronyms.yml
@@ -25,6 +25,7 @@ exceptions:
   - JSON
   - JSX
   - MDX
+  - MIME
   - PATH
   - PDF
   - PHP

--- a/websites/docs-smoke-test/src/code-examples/example.cs
+++ b/websites/docs-smoke-test/src/code-examples/example.cs
@@ -1,0 +1,5 @@
+public class MyClass {
+  public static void main(String[] args) {
+    System.out.println("Hello World");
+  }
+}

--- a/websites/docs-smoke-test/src/code-examples/example.cs
+++ b/websites/docs-smoke-test/src/code-examples/example.cs
@@ -1,5 +1,9 @@
-public class MyClass {
-  public static void main(String[] args) {
-    System.out.println("Hello World");
-  }
-}
+using System; 
+
+namespace HelloWorld { 
+  class Starter { 
+    static void Main(string[] args) { 
+      Console.WriteLine("Hello World!"); 
+    } 
+  } 
+} 

--- a/websites/docs-smoke-test/src/code-examples/example.curl
+++ b/websites/docs-smoke-test/src/code-examples/example.curl
@@ -1,0 +1,5 @@
+curl --request POST \
+  --url https://api.sendgrid.com/v3/mail/send \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --header 'Content-Type: application/json' \
+  --data '{"personalizations": [{"to": [{"email": "recipient@example.com"}]}],"from": {"email": "sendeexampexample@example.com"},"subject": "Hello, World!","content": [{"type": "text/plain", "value": "Heya!"}]}'

--- a/websites/docs-smoke-test/src/code-examples/example.graphql
+++ b/websites/docs-smoke-test/src/code-examples/example.graphql
@@ -1,0 +1,5 @@
+type Person {
+  id: ID!
+  name: String!
+  age: Int
+} 

--- a/websites/docs-smoke-test/src/code-examples/example.java
+++ b/websites/docs-smoke-test/src/code-examples/example.java
@@ -1,0 +1,5 @@
+public class MyClass {
+  public static void main(String[] args) {
+    System.out.println("Hello World");
+  }
+}

--- a/websites/docs-smoke-test/src/code-examples/example.js
+++ b/websites/docs-smoke-test/src/code-examples/example.js
@@ -1,0 +1,4 @@
+// Arrow function sample
+const arrowFuncSample = () => {
+  console.log('this is an arrow function example');
+};

--- a/websites/docs-smoke-test/src/code-examples/example.json
+++ b/websites/docs-smoke-test/src/code-examples/example.json
@@ -1,0 +1,4 @@
+{
+  "petType": "Tarantula",
+  "name": "Squishy"
+}

--- a/websites/docs-smoke-test/src/code-examples/example.php
+++ b/websites/docs-smoke-test/src/code-examples/example.php
@@ -1,0 +1,16 @@
+public class MyClass {
+  public static void main(String[] args) {
+    System.out.println("Hello World");
+  }
+}
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello Example</title>
+  </head>
+  <body>
+    <?php
+      echo "Hello world!";
+    ?>
+  </body>
+</html>

--- a/websites/docs-smoke-test/src/code-examples/example.php
+++ b/websites/docs-smoke-test/src/code-examples/example.php
@@ -1,12 +1,7 @@
-public class MyClass {
-  public static void main(String[] args) {
-    System.out.println("Hello World");
-  }
-}
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Hello Example</title>
+    <title>Hello World Example</title>
   </head>
   <body>
     <?php

--- a/websites/docs-smoke-test/src/code-examples/example.sh
+++ b/websites/docs-smoke-test/src/code-examples/example.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo Hello World

--- a/websites/docs-smoke-test/src/code-examples/example.ts
+++ b/websites/docs-smoke-test/src/code-examples/example.ts
@@ -1,0 +1,3 @@
+function sayHello(name: string) {
+  console.log(`Hello ${name}`);
+}

--- a/websites/docs-smoke-test/src/code-examples/example.yml
+++ b/websites/docs-smoke-test/src/code-examples/example.yml
@@ -1,0 +1,10 @@
+- title: Menu
+  pages:
+    - title: Home
+      path: /home
+    - title: About
+      path: /about
+    - title: Products
+      path: /products
+    - title: Contact
+      path: /contact

--- a/websites/docs-smoke-test/src/content/components/code-examples.mdx
+++ b/websites/docs-smoke-test/src/content/components/code-examples.mdx
@@ -1,0 +1,11 @@
+---
+title: Code Examples
+---
+
+# JavaScript
+
+<CodeExample file="/code-examples/example.js" title="JavaScript Code Sample" />
+
+# Java
+
+<CodeExample file="/code-examples/example.java" />

--- a/websites/docs-smoke-test/src/content/components/code-examples.mdx
+++ b/websites/docs-smoke-test/src/content/components/code-examples.mdx
@@ -4,40 +4,40 @@ title: Code Examples
 
 # JavaScript
 
-<CodeExample file="/code-examples/example.js" title="JavaScript Code Sample" />
+<CodeExample path="example.js" title="JavaScript Code Sample" />
 
 # Java
 
-<CodeExample file="/code-examples/example.java" />
+<CodeExample path="example.java" />
 
 # CSharp
 
-<CodeExample file="/code-examples/example.cs" title="CSharp Code Sample" />
+<CodeExample path="example.cs" title="CSharp Code Sample" />
 
 # Curl
 
-<CodeExample file="/code-examples/example.curl" title="Curl Code Sample" />
+<CodeExample path="example.curl" title="Curl Code Sample" />
 
 # GraphQl
 
-<CodeExample file="/code-examples/example.graphql" title="GraphQl Code Sample" />
+<CodeExample path="example.graphql" title="GraphQl Code Sample" />
 
 # JSON
 
-<CodeExample file="/code-examples/example.json" />
+<CodeExample path="example.json" />
 
 # PHP
 
-<CodeExample file="/code-examples/example.php" />
+<CodeExample path="example.php" />
 
 # Shell
 
-<CodeExample file="/code-examples/example.sh" />
+<CodeExample path="example.sh" />
 
 # TypeScript
 
-<CodeExample file="/code-examples/example.ts" />
+<CodeExample path="example.ts" />
 
 # YAML
 
-<CodeExample file="/code-examples/example.yml" />
+<CodeExample path="example.yml" />

--- a/websites/docs-smoke-test/src/content/components/code-examples.mdx
+++ b/websites/docs-smoke-test/src/content/components/code-examples.mdx
@@ -9,3 +9,35 @@ title: Code Examples
 # Java
 
 <CodeExample file="/code-examples/example.java" />
+
+# CSharp
+
+<CodeExample file="/code-examples/example.cs" title="CSharp Code Sample" />
+
+# Curl
+
+<CodeExample file="/code-examples/example.curl" title="Curl Code Sample" />
+
+# GraphQl
+
+<CodeExample file="/code-examples/example.graphql" title="GraphQl Code Sample" />
+
+# JSON
+
+<CodeExample file="/code-examples/example.json" />
+
+# PHP
+
+<CodeExample file="/code-examples/example.php" />
+
+# Shell
+
+<CodeExample file="/code-examples/example.sh" />
+
+# TypeScript
+
+<CodeExample file="/code-examples/example.ts" />
+
+# YAML
+
+<CodeExample file="/code-examples/example.yml" />

--- a/websites/docs-smoke-test/src/data/navigation.yaml
+++ b/websites/docs-smoke-test/src/data/navigation.yaml
@@ -17,6 +17,8 @@
       path: /components/content-notifications
     - title: Images
       path: /components/images
+    - title: Code Examples
+      path: /components/code-examples
 - chapter-title: Chapter 9999 With a Longer Multi-Word Name that Wraps
   pages:
     - title: Page with some very long title too much for our innocent API to handle

--- a/yarn.lock
+++ b/yarn.lock
@@ -7594,7 +7594,7 @@ detect-indent@^6.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
   integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
 
-detect-libc@^1.0.2, detect-libc@^1.0.3:
+detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -11396,7 +11396,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -14880,15 +14880,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.3.tgz#a041ad1d04a871b0ebb666f40baaf1fb47867117"
-  integrity sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -15053,22 +15044,6 @@ node-object-hash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-2.0.0.tgz#9971fcdb7d254f05016bd9ccf508352bee11116b"
   integrity sha512-VZR0zroAusy1ETZMZiGeLkdu50LGjG5U1KHZqTruqtTyQ2wfWhHG2Ow4nsUbfTFGlaREgNHcCWoM/OzEm6p+NQ==
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 node-releases@^1.1.50:
   version "1.1.52"
@@ -15236,7 +15211,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -15268,7 +15243,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -18453,7 +18428,7 @@ sanitize-html@^1.20.1:
     srcset "^2.0.1"
     xtend "^4.0.1"
 
-sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
+sax@>=0.6.0, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -19907,7 +19882,7 @@ tar-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
We chose to implement and provide a practically working approach that uses the same architecture as the RAML type rendering to be able to move on with the migration of the site independenly of whether we get the babel / webpack loader <-> MDX  related issues sorted out. 

### Gatsby Transformer Code Examples

`@commercetools-docs/gatsby-transformer-code-examples` transforms file contents into CodeExample types in available in graphql. Supported file formats are:

- cs
- graphql
- java
- js
- json
- php
- sh
- ts
- yaml

### `CodeExample` Component

`CodeExample` component uses the hook query `use-code-examples.js` to query CodeExample types and then return content wrapped with `CodeBlock` component.

Technically, any file in the project, with supported format can be rendered as an example but it is recommended to stick the the `code-examples` directory for this use case.