### PR TITLE
Nav Content: Add Integrations marketplace to meta nav

### DIFF
--- a/packages/gatsby-theme-docs/src/data/top-side-menu.yaml
+++ b/packages/gatsby-theme-docs/src/data/top-side-menu.yaml
@@ -4,7 +4,7 @@
   href: https://docs.commercetools.com/login
 - label: Tech Blog
   href: https://techblog.commercetools.com
-- label: Integrations Marketplace
+- label: Integrations
   href: https://marketplace.commercetools.com
 - label: Status
   href: https://status.commercetools.com

--- a/packages/gatsby-theme-docs/src/data/top-side-menu.yaml
+++ b/packages/gatsby-theme-docs/src/data/top-side-menu.yaml
@@ -2,8 +2,10 @@
   href: https://docs.commercetools.com/getting-started#sign-up
 - label: Log in
   href: https://docs.commercetools.com/login
-- label: Tech blog
+- label: Tech Blog
   href: https://techblog.commercetools.com
+- label: Integrations Marketplace
+  href: https://marketplace.commercetools.com
 - label: Status
   href: https://status.commercetools.com
 - label: Support


### PR DESCRIPTION
The integrations marketplace is going live (earliest) 6th of april and should then be linked from the meta navigation part of the docs site. 

Do not merge or release this before 6th of April and confirm back with  @nkuehn  before going live. 

