### PR TITLE
feat(release-notes): Release notes fields and paths

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -29,7 +29,43 @@ exports.onPreBootstrap = ({ reporter }) => {
       fs.mkdirSync(dir);
     }
   });
+
+  createReleaseNoteIndex(reporter);
 };
+
+function createReleaseNoteIndex(reporter) {
+  const releaseNoteIndex = 'src/releases/index.mdx';
+  if (!fs.existsSync(releaseNoteIndex)) {
+    fs.writeFile(
+      releaseNoteIndex,
+      `---
+date: 1970-01-01 (necessary in this format)
+title: <title goes here>
+description: |
+  <Description for the template>
+type: enhancement # feature | fix | enhancement
+topics:
+  - foo
+  - barr
+  # Topics is an array, here are some examples:
+  #  - Products
+  #  - Product List
+  #  - Categories
+  #  - Carts
+  #  - API Clients
+  #  - Settings
+---
+      `,
+      (error) => {
+        if (error) {
+          throw error;
+        }
+
+        reporter.info(`Successfully created "${releaseNoteIndex}"`);
+      }
+    );
+  }
+}
 
 exports.sourceNodes = ({ actions }) => {
   actions.createTypes(`

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -39,10 +39,10 @@ function createReleaseNoteIndex(reporter) {
     fs.writeFile(
       releaseNoteIndex,
       `---
-date: 1970-01-01 (necessary in this format)
-title: <title goes here>
+date: 1970-01-01 # necessary in this format
+title: (title goes here)
 description: |
-  <Description for the template>
+  (description for the template)
 type: enhancement # feature | fix | enhancement
 topics:
   - foo

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -160,7 +160,7 @@ function generateReleaseNoteSlug(node) {
   }
 
   if (node.frontmatter.slug) {
-    return `${basePath}/${node.frontmatter.slug}`;
+    return trimTrailingSlash(`${basePath}/${node.frontmatter.slug}`);
   }
 
   const date = node.frontmatter.date ? node.frontmatter.date.split('T')[0] : '';

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -163,7 +163,7 @@ function generateReleaseNoteSlug(date = '', title = '', fileAbsolutePath) {
     return basePath;
   }
 
-  const slug = `${date} ${title}`
+  const slug = `${date.split('T')[0]} ${title}`
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-') // replace non alphanumeric with hyphen
     .replace(/(^-|-$)+/g, ''); // remove pre or post string hyphens

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -124,7 +124,8 @@ exports.onCreateNode = ({ node, getNode, actions }, pluginOptions) => {
   if (isReleaseNotesPage) {
     let releaseNoteSlug = generateReleaseNoteSlug(
       node.frontmatter.date,
-      node.frontmatter.title
+      node.frontmatter.title,
+      node.fileAbsolutePath
     );
     releaseNoteSlug = trimTrailingSlash(releaseNoteSlug) || '/';
     actions.createNodeField({
@@ -155,8 +156,13 @@ exports.onCreateNode = ({ node, getNode, actions }, pluginOptions) => {
   }
 };
 
-function generateReleaseNoteSlug(date = '', title = '') {
+function generateReleaseNoteSlug(date = '', title = '', fileAbsolutePath) {
   const basePath = '/releases';
+
+  if (fileAbsolutePath.endsWith('index.mdx')) {
+    return basePath;
+  }
+
   const slug = `${date} ${title}`
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-') // replace non alphanumeric with hyphen

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -122,14 +122,47 @@ exports.onCreateNode = ({ node, getNode, actions }, pluginOptions) => {
     path.resolve('src/releases')
   );
   if (isReleaseNotesPage) {
-    const releaseNoteSlug = trimTrailingSlash(slug) || '/';
+    let releaseNoteSlug = generateReleaseNoteSlug(
+      node.frontmatter.date,
+      node.frontmatter.title
+    );
+    releaseNoteSlug = trimTrailingSlash(releaseNoteSlug) || '/';
     actions.createNodeField({
       node,
       name: 'slug',
-      value: `/releases${releaseNoteSlug}`,
+      value: releaseNoteSlug,
+    });
+    actions.createNodeField({
+      node,
+      name: 'date',
+      value: node.frontmatter.date,
+    });
+    actions.createNodeField({
+      node,
+      name: 'description',
+      value: node.frontmatter.description,
+    });
+    actions.createNodeField({
+      node,
+      name: 'type',
+      value: node.frontmatter.type,
+    });
+    actions.createNodeField({
+      node,
+      name: 'topics',
+      value: node.frontmatter.topics,
     });
   }
 };
+
+function generateReleaseNoteSlug(date = '', title = '') {
+  const basePath = '/releases';
+  const slug = `${date} ${title}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-') // replace non alphanumeric with hyphen
+    .replace(/(^-|-$)+/g, ''); // remove pre or post string hyphens
+  return `${basePath}/${slug}`.replace(/\/\/+/g, '/'); // replace two or more slashes with single slash
+}
 
 // https://www.gatsbyjs.org/docs/mdx/programmatically-creating-pages/#create-pages-from-sourced-mdx-files
 exports.createPages = async ({ graphql, actions, reporter }) => {
@@ -168,6 +201,10 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
               slug
               title
               excludeFromSearchIndex
+              date
+              description
+              type
+              topics
             }
           }
           name

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -55,7 +55,8 @@
     "prop-types": "15.7.2",
     "react-helmet": "5.2.1",
     "rehype-slug": "3.0.0",
-    "remark-emoji": "2.0.2"
+    "remark-emoji": "2.0.2",
+    "slugify": "1.4.0"
   },
   "devDependencies": {
     "gatsby": "2.19.17",

--- a/websites/docs-smoke-test/gatsby-config.js
+++ b/websites/docs-smoke-test/gatsby-config.js
@@ -15,6 +15,7 @@ module.exports = {
         websiteKey: 'docs-smoke-test',
         excludeFromSearchIndex: isProd && !shouldEnableSearch,
         additionalPrismLanguages: ['scala', 'csharp'],
+        hasReleaseNotes: true,
       },
     },
   ],

--- a/websites/docs-smoke-test/src/releases/release-format-definition.mdx
+++ b/websites/docs-smoke-test/src/releases/release-format-definition.mdx
@@ -11,7 +11,7 @@ topics:
 #  - Baz
 #  - Foo
 published: true # hidden feature, see below
-slug: 2000-03-03-release-note-format-definition # hidden feature, see below
+slug: 2000-03-03-release-note-format-definition-custom # hidden feature, see below
 ---
 
 The file can have any name as long as it resides in `src/release-notes`. Only the content of the file controls the website content.

--- a/yarn.lock
+++ b/yarn.lock
@@ -19119,7 +19119,7 @@ slide@^1.1.6:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
-slugify@^1.3.6:
+slugify@1.4.0, slugify@^1.3.6:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.0.tgz#c9557c653c54b0c7f7a8e786ef3431add676d2cb"
   integrity sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==


### PR DESCRIPTION
Changes here include:

## Release notes custom fields
* date
* description
* type
* topics

## Paths
* Release notes overview page - `/releases`
* Release note details pages - `/releases/<date>-<title>`