### PR TITLE
Tune writing style checker for plugin compatibility and custom apps

### DIFF
--- a/packages/writing-style/README.md
+++ b/packages/writing-style/README.md
@@ -3,7 +3,8 @@
 This package provides
 
 - commercetools specific writing style and terminology rules for the configurable [vale](https://errata-ai.github.io/vale/) prose linter.
-- the `commercetools-vale` command line tool which wraps a bundled vale build and calls it using the included writing style and configuration
+- the `commercetools-vale` command-line tool which wraps a bundled vale build and calls it using the included writing style and configuration
+- the `commercetools-vale-bin` command is directly calling the current bundled vale binary without passing the commercetools configuration and writing style. The configuration has to be passed separately via vale's `--config` flag.
 
 The base style is the [Google Developer Documentation Style Guide](https://github.com/errata-ai/Google), which is included as a copy (MIT licensed, too) and modified and enriched with commercetools specific rules.
 
@@ -33,11 +34,11 @@ In addition, you can install a matching editor plugin to get immediate feedback 
 
 The plugin [for VSCode](https://marketplace.visualstudio.com/items?itemName=testthedocs.vale) does not support such configuration yet.
 
-## Linter Usage: CI and command line in Javascript Projects
+## Linter Usage: CI and command-line in Javascript Projects
 
 1. Add the writing-style package as a development dependency: `yarn add --dev @commercetools-docs/writing-style`
 1. In your project's folder, call it from the command
-   line via `npx commercetools-vale ./your/path/to/content` and optionally add vale command line parameters as needed (for example `--no-wrap` on command line jobs).
+   line via `npx commercetools-vale ./your/path/to/content` and optionally add vale command-line parameters as needed (for example `--no-wrap` on command-line jobs).
    - _Tip_: Running it over your complete repository is not a good idea since it checks the complete node_modules folder which takes a long time and is not your content.
 
 ## Contributing

--- a/packages/writing-style/package.json
+++ b/packages/writing-style/package.json
@@ -15,7 +15,7 @@
   },
   "bin": {
     "commercetools-vale": "./bin/commercetools-vale.js",
-    "vale": "./bin/vale-2.1.0"
+    "commercetools-vale-bin": "./bin/vale-2.1.0"
   },
   "scripts": {
     "postinstall": "node scripts/download-vale.js",

--- a/packages/writing-style/package.json
+++ b/packages/writing-style/package.json
@@ -14,7 +14,8 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git"
   },
   "bin": {
-    "commercetools-vale": "./bin/commercetools-vale.js"
+    "commercetools-vale": "./bin/commercetools-vale.js",
+    "vale": "./bin/vale-2.1.0"
   },
   "scripts": {
     "postinstall": "node scripts/download-vale.js",

--- a/packages/writing-style/vale-styles/commercetools/Acronyms.yml
+++ b/packages/writing-style/vale-styles/commercetools/Acronyms.yml
@@ -16,6 +16,7 @@ exceptions:
   - AWS
   - CDN # "content delivery network" does not make it more understandable
   - CLI
+  - CORS
   - CPU
   - CSS
   - CSV
@@ -54,12 +55,14 @@ exceptions:
   - RFC # "Request For Comment" would confuse readers even more.
   - RSA
   - SDK
+  - SHA
   - SKU # generally we try to explain domain terminology but this one is so prevalent across the documentation that we allow it
   - SNS # AWS SNS, appears in many pages in a single place and amazon uses the short name themselves, too
   - SQS # see above
   - SQL
   - SSH
   - SSL
+  - SSO
   - TLS # does not make sense to allow SSL but not TLS
   - SVG
   - TCP
@@ -78,6 +81,7 @@ exceptions:
   - ISO
   - RSS
   - YYYY # to be able to describe date formats like YYYY-MM-DD
+  - ZEIT # the zeit.co service is trademarked in uppercased letters.
   # the following exceptions are allowed because they are caught as errors by the ToDo rule.
   - XXX
   - FIXME

--- a/recommended.code-workspace
+++ b/recommended.code-workspace
@@ -37,7 +37,7 @@
         ]
       }
     },
-    "vscode-vale.path": "${workspaceFolder}/node_modules/.bin/vale",
+    "vscode-vale.path": "${workspaceFolder}/node_modules/.bin/commercetools-vale-bin",
     "vscode-vale.configPath": "${workspaceFolder}/packages/writing-style/.vale.ini",
     "vscode-vale.fileExtensions": [
       "md",

--- a/recommended.code-workspace
+++ b/recommended.code-workspace
@@ -37,7 +37,8 @@
         ]
       }
     },
-    "vscode-vale.path": "${workspaceFolder}/node_modules/.bin/commercetools-vale",
+    "vscode-vale.path": "${workspaceFolder}/node_modules/.bin/vale",
+    "vscode-vale.configPath": "${workspaceFolder}/packages/writing-style/.vale.ini",
     "vscode-vale.fileExtensions": [
       "md",
       "markdown",


### PR DESCRIPTION
 * provides a local "raw"  vale command that the config can be directly passed to.  This proved more robust when using the VSCode plugin. 
 * adjust recommended VSCode workspace to use the config directly from the package to make transparent that it's not the same as an NPM version.  Also allows for quicker local feedback in the editor when tuning the rules. 
 * add a few acronyms that are common in software development 
 * allow the "ZEIT" brand in acronymys (false negative, it's not an aconym).  