### PR TITLE
fix(theme): dynamically render the cookie consent scripts only on *.commercetools.com domain

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-browser.js
+++ b/packages/gatsby-theme-docs/gatsby-browser.js
@@ -31,6 +31,8 @@ export const onClientEntry = (
         whitelistUrls: ['docs.commercetools.com', 'now.sh'],
       });
     });
+    if (window && !window.location.host.includes('.commercetools.com'))
+      document.body.classList.add('not-on-cookie-domain');
   }
 
   // Require additional Prism languages.

--- a/packages/gatsby-theme-docs/gatsby-browser.js
+++ b/packages/gatsby-theme-docs/gatsby-browser.js
@@ -17,6 +17,17 @@ const environment =
     ? 'production'
     : 'preview';
 
+const injectScript = (url, attributes = {}, onLoad) => {
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.src = url;
+  Object.keys(attributes).forEach((key) => {
+    script.setAttribute(key, attributes[key]);
+  });
+  if (onLoad) script.onload = onLoad;
+  document.body.appendChild(script);
+};
+
 export const onClientEntry = (
   _, // eslint-disable-line
   pluginOptions
@@ -31,8 +42,17 @@ export const onClientEntry = (
         whitelistUrls: ['docs.commercetools.com', 'now.sh'],
       });
     });
-    if (window && !window.location.host.includes('.commercetools.com'))
-      document.body.classList.add('not-on-cookie-domain');
+  }
+  // Inject the cookie consent scripts only if the page is served on the domain `*.commercetools.com`.
+  if (window && window.location.host.includes('.commercetools.com')) {
+    injectScript(
+      'https://cdn.cookielaw.org/consent/b104027d-4d10-4b75-9675-9ffef11562a8/OtAutoBlock.js'
+    );
+    injectScript(
+      'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+      { 'data-domain-script': 'b104027d-4d10-4b75-9675-9ffef11562a8' },
+      'function OptanonWrapper() {};'
+    );
   }
 
   // Require additional Prism languages.

--- a/packages/gatsby-theme-docs/gatsby-ssr.js
+++ b/packages/gatsby-theme-docs/gatsby-ssr.js
@@ -56,6 +56,7 @@ export const replaceRenderer = ({
 
   // Activate the cookie consent banner only on the live website environment.
   // We can narrow it down to the build step of Zeit Now for the master branch.
+  // That still not catches all cases, it's hidden client-side if not on a .commercetools.com domain
   if (isProduction && isNowBuild && isMasterBranch)
     setPostBodyComponents([
       <script
@@ -92,6 +93,17 @@ export const replaceRenderer = ({
       data-emotion-css={ids.join(' ')}
       dangerouslySetInnerHTML={{
         __html: css,
+      }}
+    />,
+    <style
+      key="optanon-killer"
+      data-emotion-css={ids.join(' ')}
+      dangerouslySetInnerHTML={{
+        __html: `
+          body.not-on-cookie-domain #onetrust-consent-sdk,
+          body.not-on-cookie-domain #onetrust-consent-sdk .onetrust-pc-dark-filter {
+            display: none !important;
+          }`,
       }}
     />,
   ]);

--- a/packages/gatsby-theme-docs/gatsby-ssr.js
+++ b/packages/gatsby-theme-docs/gatsby-ssr.js
@@ -13,10 +13,6 @@ import createEmotionServer from 'create-emotion-server';
 import { CacheProvider } from '@emotion/core';
 import { createDocsCache } from './create-emotion-cache';
 
-const isProduction = process.env.GATSBY_NODE_ENV === 'production';
-const isNowBuild = Boolean(process.env.GATSBY_NOW_GITHUB_DEPLOYMENT);
-const isMasterBranch = process.env.GATSBY_NOW_GITHUB_COMMIT_REF === 'master';
-
 const iconDarkDigest = createContentDigest(
   fs.readFileSync(require.resolve('./static/favicon-dark-32x32.png'))
 );
@@ -28,7 +24,6 @@ export const replaceRenderer = ({
   bodyComponent,
   replaceBodyHTMLString,
   setHeadComponents,
-  setPostBodyComponents,
 }) => {
   // https://emotion.sh/docs/ssr#on-server
   // https://emotion.sh/docs/ssr#gatsby
@@ -54,27 +49,6 @@ export const replaceRenderer = ({
     .replace(/> \* \+ \*/g, '> *:not(style) ~ *:not(style)');
   replaceBodyHTMLString(patchedHtml);
 
-  // Activate the cookie consent banner only on the live website environment.
-  // We can narrow it down to the build step of Zeit Now for the master branch.
-  // That still not catches all cases, it's hidden client-side if not on a .commercetools.com domain
-  if (isProduction && isNowBuild && isMasterBranch)
-    setPostBodyComponents([
-      <script
-        key="cookie-consent-part1"
-        type="text/javascript"
-        defer
-        src="https://cdn.cookielaw.org/consent/b104027d-4d10-4b75-9675-9ffef11562a8/OtAutoBlock.js"
-      />,
-      <script
-        key="cookie-consent-part2"
-        type="text/javascript"
-        defer
-        src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
-        data-domain-script="b104027d-4d10-4b75-9675-9ffef11562a8"
-        onLoad="function OptanonWrapper() {};"
-      />,
-    ]);
-
   setHeadComponents([
     <link
       key="favicon-dark"
@@ -93,17 +67,6 @@ export const replaceRenderer = ({
       data-emotion-css={ids.join(' ')}
       dangerouslySetInnerHTML={{
         __html: css,
-      }}
-    />,
-    <style
-      key="optanon-killer"
-      data-emotion-css={ids.join(' ')}
-      dangerouslySetInnerHTML={{
-        __html: `
-          body.not-on-cookie-domain #onetrust-consent-sdk,
-          body.not-on-cookie-domain #onetrust-consent-sdk .onetrust-pc-dark-filter {
-            display: none !important;
-          }`,
       }}
     />,
   ]);


### PR DESCRIPTION
addresses #346 

This is the technique that is used on the current docs.commercetools.com  site - it's a client side approach that activates a CSS rule that removes the complete thing from the visible DOM, letting it do it's buggy work however it wants as long as it doesn't show up. 

The check is on the .commercetools.com  domain level because that's the cookie scope the script uses. 
 The root cause it that the cookie consent script fails on other domains and does not close. 

