### PR TITLE
fix(theme): to use height auto for small screens

### DIFF
--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
@@ -7,14 +7,18 @@ import { designSystem } from '@commercetools-docs/ui-kit';
 const Root = styled.div`
   position: relative;
   width: 100vw;
-  height: 100vh;
+  height: auto;
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch; /* enables "momentum" style scrolling */
 
+  @media screen and (${designSystem.dimensions.viewports.largeTablet}) {
+    height: 100vh;
+  }
+
   @media only percy {
     /* Unset the 100vh to make view scrollable in order to take full page snapshots */
-    height: auto;
+    height: auto !important;
   }
 `;
 const Container = styled.div`


### PR DESCRIPTION
Duplicate of #347 

Just checking if the percy snapshots fail here as well.