### PR TITLE
feat(docs-theme): make beta flag available in any content

### DIFF
--- a/packages/gatsby-theme-docs/src/components/beta-flag.js
+++ b/packages/gatsby-theme-docs/src/components/beta-flag.js
@@ -9,6 +9,9 @@ const getStyles = (props) => {
     border-radius: ${designSystem.tokens.borderRadiusForBetaFlag};
     color: ${designSystem.colors.light.textInfo};
     padding: 2px ${designSystem.dimensions.spacings.xs};
+    font-size: ${designSystem.typography.relativeFontSizes
+      .badgeFontToSurroundingInline};
+    vertical-align: middle;
   `;
   if (props.href) {
     return css`
@@ -17,7 +20,6 @@ const getStyles = (props) => {
       border: 1px solid ${designSystem.colors.light.borderInfo};
       box-shadow: ${designSystem.tokens.shadowForBetaFlag};
       color: ${designSystem.colors.light.textInfo} !important;
-      font-size: ${designSystem.typography.fontSizes.small};
 
       :active,
       :focus,
@@ -31,7 +33,6 @@ const getStyles = (props) => {
   return css`
     ${baseStyles}
     background-color: ${designSystem.colors.light.surfaceBeta};
-    font-size: ${designSystem.typography.fontSizes.ultraSmall};
   `;
 };
 

--- a/packages/gatsby-theme-docs/src/components/beta-flag.js
+++ b/packages/gatsby-theme-docs/src/components/beta-flag.js
@@ -36,6 +36,9 @@ const getStyles = (props) => {
   `;
 };
 
+const betaHint =
+  'This feature is marked as beta and is subject to change. Use with caution.';
+
 const BetaFlag = (props) => {
   if (props.href) {
     return (
@@ -44,7 +47,11 @@ const BetaFlag = (props) => {
       </Link>
     );
   }
-  return <span css={getStyles(props)}>{'BETA'}</span>;
+  return (
+    <span css={getStyles(props)} title={betaHint}>
+      {'BETA'}
+    </span>
+  );
 };
 BetaFlag.propTypes = {
   href: PropTypes.string,

--- a/packages/gatsby-theme-docs/src/components/beta-flag.js
+++ b/packages/gatsby-theme-docs/src/components/beta-flag.js
@@ -9,8 +9,7 @@ const getStyles = (props) => {
     border-radius: ${designSystem.tokens.borderRadiusForBetaFlag};
     color: ${designSystem.colors.light.textInfo};
     padding: 2px ${designSystem.dimensions.spacings.xs};
-    font-size: ${designSystem.typography.relativeFontSizes
-      .badgeFontToSurroundingInline};
+    font-size: ${designSystem.typography.relativeFontSizes.ultraSmall};
     vertical-align: middle;
   `;
   if (props.href) {

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-header.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-header.js
@@ -3,6 +3,7 @@ import { designSystem } from '@commercetools-docs/ui-kit';
 
 const LayoutPageHeader = styled.div`
   grid-area: page-header;
+  font-size: ${designSystem.typography.fontSizes.h3};
   padding: ${designSystem.dimensions.spacings.m}
     ${designSystem.dimensions.spacings.m} 0;
 

--- a/packages/gatsby-theme-docs/src/markdown-components.js
+++ b/packages/gatsby-theme-docs/src/markdown-components.js
@@ -3,7 +3,12 @@ import {
   Subtitle,
   ContentNotifications,
 } from '@commercetools-docs/ui-kit';
-import { Link, CodeExample, MultiCodeExample } from './components';
+import {
+  Link,
+  CodeExample,
+  MultiCodeExample,
+  BetaFlag as Beta,
+} from './components';
 import PlaceholderMarkdownComponents from './overrides/markdown-components';
 
 // See https://mdxjs.com/getting-started#table-of-components
@@ -48,6 +53,7 @@ const components = {
   Error: ContentNotifications.Error,
   CodeExample,
   MultiCodeExample,
+  Beta,
 
   // Custom React components that can be injected from each website
   // See ../overrides/README.md

--- a/packages/ui-kit/src/design-system.js
+++ b/packages/ui-kit/src/design-system.js
@@ -134,6 +134,11 @@ export const typography = {
     ultraSmall: pxToRem('10px'),
   },
 
+  relativeFontSizes: {
+    // design spec: 10px (ultrasmall) in beta flag if base font is 16px
+    badgeFontToSurroundingInline: '62.5%',
+  },
+
   fontWeights: {
     regular: '400',
     medium: '500',

--- a/packages/ui-kit/src/design-system.js
+++ b/packages/ui-kit/src/design-system.js
@@ -6,10 +6,10 @@ const pageWidthSmall = '592px';
 const navbarWidth = '224px';
 const navbarWidthSmall = '200px';
 
-export const pxToRem = (px) => {
+export const pxToRem = (px, suffix = 'rem') => {
   const pxNumber = px.replace(/([0-9]+)px$/, '$1');
   const remNumber = parseInt(pxNumber, 10) / rootFontSizeNumber;
-  return `${remNumber}rem`;
+  return `${remNumber}${suffix}`;
 };
 
 export const colors = {
@@ -135,8 +135,7 @@ export const typography = {
   },
 
   relativeFontSizes: {
-    // design spec: 10px (ultrasmall) in beta flag if base font is 16px
-    badgeFontToSurroundingInline: '62.5%',
+    ultraSmall: pxToRem('10px', 'em'),
   },
 
   fontWeights: {

--- a/websites/docs-smoke-test/src/content/index.mdx
+++ b/websites/docs-smoke-test/src/content/index.mdx
@@ -12,6 +12,10 @@ Custom React components **embedded in the markdown** can also support markdown s
 
 # A section header
 
+## A beta section <Beta />
+
+The `<Beta />`  tag can be used inline <Beta /> and should be applied self-closing
+
 ## Paragraphs
 
 Paragraphs are separated by a blank line.


### PR DESCRIPTION
To make the beta flag usable in any content its size is changed
to a relative measure calculated from the design spec.

To align it visually straighter it's middle-aligned with the surrounding text now.

The change leads to factual beta badge size changes in the area of < 1px  because I wanted to keep re-using the design system values instead of calculating theoretical font sizes e.g. for the page header.  

It's good for me this way and overall the better solution than to have to maintain a badge style for every potential situation it's used in 