### PR TITLE
fix(theme): sticky page nav and scrolling container

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -2,6 +2,10 @@ version: 1
 snapshot:
   widths: [1634]
   min-height: 1024
+  percy-css: |
+    #application {
+      height: auto;
+    }
 static-snapshots:
   base-url: /
   snapshot-files: '**/components/**/*.html'

--- a/.percy.yml
+++ b/.percy.yml
@@ -2,10 +2,6 @@ version: 1
 snapshot:
   widths: [1634]
   min-height: 1024
-  percy-css: |
-    #application {
-      height: auto;
-    }
 static-snapshots:
   base-url: /
   snapshot-files: '**/components/**/*.html'

--- a/cypress/integration/docs-smoke-test/viewports.js
+++ b/cypress/integration/docs-smoke-test/viewports.js
@@ -10,7 +10,9 @@ describe('Viewports', () => {
       widths: [512, 956],
     });
   });
-  it('should take snapshots of sticky page navigation', () => {
+  // Currently snapshots with scroll postion are not supported by Percy.
+  // https://github.com/percy/percy-cypress/issues/2#issuecomment-533316240
+  it.skip('should take snapshots of sticky page navigation', () => {
     cy.visit(URL_DOCS_SMOKE_TEST);
     cy.findByLabelText('Page Table of Contents Navigation').within(() => {
       cy.findByText('Last section').click();

--- a/cypress/integration/docs-smoke-test/viewports.js
+++ b/cypress/integration/docs-smoke-test/viewports.js
@@ -10,4 +10,13 @@ describe('Viewports', () => {
       widths: [512, 956],
     });
   });
+  it('should take snapshots of sticky page navigation', () => {
+    cy.visit(URL_DOCS_SMOKE_TEST);
+    cy.findByLabelText('Page Table of Contents Navigation').within(() => {
+      cy.findByText('Last section').click();
+      cy.percySnapshot(cy.state('runnable').fullTitle(), {
+        percyCSS: `#application { height: 100vh !important; }`,
+      });
+    });
+  });
 });

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -30,7 +30,12 @@ const LayoutContent = (props) => {
         isGlobalBeta={props.pageData.isGlobalBeta}
         hasReleaseNotes={props.pageContext.hasReleaseNotes}
       />
-      <LayoutMain isTopMenuOpen={layoutState.topMenu.isTopMenuOpen}>
+      <LayoutMain
+        preventScroll={
+          layoutState.topMenu.isTopMenuOpen ||
+          layoutState.sidebar.isSidebarMenuOpen
+        }
+      >
         <LayoutHeader
           {...layoutState.searchDialog}
           {...layoutState.topMenu}

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
@@ -12,8 +12,7 @@ const Root = styled.div`
   overflow-y: auto;
   -webkit-overflow-scrolling: touch; /* enables "momentum" style scrolling */
 
-  @media (not(percy)) and screen and (${designSystem.dimensions.viewports
-      .largeTablet}) {
+  @media only screen and (${designSystem.dimensions.viewports.tablet}) {
     height: 100vh;
   }
 `;
@@ -38,7 +37,7 @@ const Container = styled.div`
 
 const LayoutApplication = (props) => (
   <UiKitThemeProvider theme={designSystem.uikitTheme}>
-    <Root role="application">
+    <Root role="application" id="application">
       <Container {...props} />
     </Root>
     <div id="modal-portal" />

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
@@ -15,7 +15,7 @@ const LayoutMain = styled.main`
 
   ${(props) =>
     // Prevents scroll when top menu is open
-    props.isTopMenuOpen &&
+    props.preventScroll &&
     css`
       height: 100vh;
       overflow-y: hidden;

--- a/packages/gatsby-theme-docs/src/layouts/release-notes-detail.js
+++ b/packages/gatsby-theme-docs/src/layouts/release-notes-detail.js
@@ -34,7 +34,12 @@ const LayoutReleaseNotesDetail = (props) => {
         // that there are release notes.
         hasReleaseNotes={true}
       />
-      <LayoutMain isTopMenuOpen={layoutState.topMenu.isTopMenuOpen}>
+      <LayoutMain
+        preventScroll={
+          layoutState.topMenu.isTopMenuOpen ||
+          layoutState.sidebar.isSidebarMenuOpen
+        }
+      >
         <LayoutHeader
           {...layoutState.searchDialog}
           {...layoutState.topMenu}

--- a/packages/gatsby-theme-docs/src/layouts/release-notes-list.js
+++ b/packages/gatsby-theme-docs/src/layouts/release-notes-list.js
@@ -29,7 +29,12 @@ const LayoutReleaseNotesList = (props) => {
         isGlobalBeta={props.pageData.isGlobalBeta}
         hasReleaseNotes={props.pageContext.hasReleaseNotes}
       />
-      <LayoutMain isTopMenuOpen={layoutState.topMenu.isTopMenuOpen}>
+      <LayoutMain
+        preventScroll={
+          layoutState.topMenu.isTopMenuOpen ||
+          layoutState.sidebar.isSidebarMenuOpen
+        }
+      >
         <LayoutHeader
           {...layoutState.searchDialog}
           {...layoutState.topMenu}

--- a/packages/ui-kit/src/components/globals.js
+++ b/packages/ui-kit/src/components/globals.js
@@ -29,6 +29,12 @@ const Globals = () => (
         padding: 0 0 0 ${dimensions.spacings.l};
       }
 
+      @media only percy {
+        #application {
+          height: auto;
+        }
+      }
+
       /* Images */
 
       .gatsby-resp-image-wrapper {

--- a/packages/ui-kit/src/components/globals.js
+++ b/packages/ui-kit/src/components/globals.js
@@ -29,12 +29,6 @@ const Globals = () => (
         padding: 0 0 0 ${dimensions.spacings.l};
       }
 
-      @media only percy {
-        #application {
-          height: auto;
-        }
-      }
-
       /* Images */
 
       .gatsby-resp-image-wrapper {


### PR DESCRIPTION
In #347 we attempted to fix the container `height` in order for the page to be printable.
However, the media query (including the `percy` agent) didn't really work, resulting in the `height: 100vh` to never be applied and thus the page nav on the right to not be sticky.

This PR removes the `percy` agent media query and uses instead a normal CSS selector in order for Percy to take full page snapshots.

It also fixes the page content to not scroll when the sidebar menu and top menu are open (with the overlay).

I also added a Cypress test with the intent of preventing regressions for the sticky behavior.