### PR TITLE
fix(theme-docs): Render mdx commonmark compliant

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -119,6 +119,8 @@ module.exports = (themeOptions = {}) => {
             '.mdx',
             // ".md"
           ],
+          // implement commonmark for stricter compatibility, e.g. backslash newlines
+          commonmark: true,
           // List of remark plugins, that transform the markdown AST.
           remarkPlugins: [require('remark-emoji')],
           // List of rehype plugins, that transform the HTML AST.

--- a/websites/docs-smoke-test/src/content/index.mdx
+++ b/websites/docs-smoke-test/src/content/index.mdx
@@ -20,6 +20,9 @@ The `<Beta />`  tag can be used inline <Beta /> and should be applied self-closi
 
 Paragraphs are separated by a blank line.
 
+Line breaks are expressed with a backslash\
+(before this) at the end of the line.
+
 Second paragraph. _Italic_, **bold**, **_italic and bold_**, ~~strikethrough~~ and `monospace`.
 
 ## List items


### PR DESCRIPTION
Since all of our processing and especially prettier is following the commonmark spec the site needs to understand backslashes as newlines.

This requires passing the commonmark option to MDX which is passed down to all remark plugins by mdx. 