### PR TITLE
fix(theme): gracefully handle missing heading level in TOC

### DIFF
--- a/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.js
@@ -2,12 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
-import { SafeHTMLElement, designSystem } from '@commercetools-docs/ui-kit';
+import {
+  SafeHTMLElement,
+  designSystem,
+  ContentNotifications,
+} from '@commercetools-docs/ui-kit';
 import useActiveSection from '../../hooks/use-active-section';
 
 const itemType = {
-  url: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  url: PropTypes.string,
+  title: PropTypes.string,
 };
 const itemsType = PropTypes.arrayOf(
   PropTypes.shape({
@@ -88,18 +92,39 @@ const LevelGroup = (props) => {
   return (
     <Group level={props.level}>
       {props.items.map((item, subItemIndex) => {
-        const isActive = getIsActive(props.activeSection, item.url);
+        if (item.url) {
+          const isActive = getIsActive(props.activeSection, item.url);
+          return (
+            <ListItem key={subItemIndex}>
+              <Link
+                href={item.url}
+                level={props.level}
+                role={`level-${props.level}`}
+                isActive={isActive}
+                aria-current={isActive}
+              >
+                <Indented level={props.level}>{item.title}</Indented>
+              </Link>
+              {props.children &&
+                React.cloneElement(props.children, {
+                  items: item.items,
+                  level: props.level + 1,
+                  activeSection: props.activeSection,
+                })}
+            </ListItem>
+          );
+        }
+        console.warn(
+          `The items in the table of contents are missing the heading for level ${props.level}. Please make sure to check the heading structure in the MDX content page.`
+        );
+        // Render the list without the link, but show an error message
         return (
           <ListItem key={subItemIndex}>
-            <Link
-              href={item.url}
-              level={props.level}
-              role={`level-${props.level}`}
-              isActive={isActive}
-              aria-current={isActive}
-            >
-              <Indented level={props.level}>{item.title}</Indented>
-            </Link>
+            {process.env.NODE_ENV !== 'development' && (
+              <Indented level={props.level}>
+                <ContentNotifications.Error>{`Missing heading for level ${props.level}`}</ContentNotifications.Error>
+              </Indented>
+            )}
             {props.children &&
               React.cloneElement(props.children, {
                 items: item.items,

--- a/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.spec.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.spec.js
@@ -39,6 +39,22 @@ const createTestProps = (custom) => ({
           },
         ],
       },
+      {
+        title: 'Link 3',
+        url: '#link-3',
+        items: [
+          {
+            // Here we skip the level 2 links on purpose, to simulate
+            // a missing heading level.
+            items: [
+              {
+                title: 'Link 3/1/1',
+                url: '#link-3-1-1',
+              },
+            ],
+          },
+        ],
+      },
     ],
   },
   ...custom,
@@ -59,6 +75,12 @@ const renderApp = (ui) =>
         </Section>
         <Section id="section-link-2-1-1" className="section-h4">
           <h4 id="link-2-1-1">{'Title for link 2/1/1'}</h4>
+        </Section>
+        <Section id="section-link-3" className="section-h2">
+          <h2 id="link-3">{'Title for link 3'}</h2>
+        </Section>
+        <Section id="section-link-3-1-1" className="section-h4">
+          <h4 id="link-3-1-1">{'Title for link 3/1/1'}</h4>
         </Section>
       </Content>
       {ui}
@@ -86,6 +108,7 @@ jest.useFakeTimers();
 
 describe('rendering', () => {
   it('should mark links as active for visible sections when scrolling', () => {
+    console.warn = jest.fn();
     const props = createTestProps();
     const rendered = renderApp(<PageNavigation {...props} />);
 
@@ -93,10 +116,20 @@ describe('rendering', () => {
     expect(rendered.queryByText('Link 2')).toBeInTheDocument();
     expect(rendered.queryByText('Link 2/1')).toBeInTheDocument();
     expect(rendered.queryByText('Link 2/1/1')).toBeInTheDocument();
+    expect(rendered.queryByText('Link 3')).toBeInTheDocument();
+    expect(rendered.queryByText('Link 3/1')).not.toBeInTheDocument();
+    expect(rendered.queryByText('Link 3/1/1')).toBeInTheDocument();
 
     expect(rendered.queryByRole(/^active-(.*)/)).not.toBeInTheDocument();
 
-    const hrefIds = ['link-1', 'link-2', 'link-2-1', 'link-2-1-1'];
+    const hrefIds = [
+      'link-1',
+      'link-2',
+      'link-2-1',
+      'link-2-1-1',
+      'link-3',
+      'link-3-1-1',
+    ];
 
     hrefIds.forEach((hrefId) => {
       applySectionElementsMocks(
@@ -112,5 +145,14 @@ describe('rendering', () => {
         rendered.container.querySelector('[aria-current=true]')
       ).toHaveAttribute('href', `#${hrefId}`);
     });
+
+    expect(
+      rendered.queryByText('Missing heading for level 2')
+    ).toBeInTheDocument();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'The items in the table of contents are missing the heading for level 2'
+      )
+    );
   });
 });


### PR DESCRIPTION
Fixes #389 

TL;DR: if nested headings are missing a "level" in between, the TOC would throw an error.

For example, if heading 2 `##` is missing:

```
# Heading 1
Content

### Heading 3
Content
```

Now if a heading is missing, in dev mode we log a warning and show a notification error in the TOC:

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/1110551/80023407-c53d7700-84dd-11ea-9be8-4103a11a74f3.png">
