### PR TITLE
enhancement(workspace): set the window title better find the window

### DIFF
--- a/recommended.code-workspace
+++ b/recommended.code-workspace
@@ -6,6 +6,7 @@
   ],
   "settings": {
     // https://vscode.readthedocs.io/en/latest/getstarted/settings/
+    "window.title": "${activeEditorShort}${separator}commercetools-docs-kit (workspace)",
     "npm.packageManager": "yarn",
     "eslint.packageManager": "yarn",
     "search.exclude": {


### PR DESCRIPTION
Just "recommended" is not helpful as a window title if you have multiple vscode windows open. 
This sets the default VSCode convention and adds the repo name to it