### PR TITLE
fix: inconsistent url and title or index nav

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -54,6 +54,7 @@ const resolverPassthrough = ({
   typeName = 'Mdx',
   fieldName,
   resolveNode = identity,
+  processResult = identity,
 }) => async (source, args, context, info) => {
   const type = info.schema.getType(typeName);
   const mdxNode = context.nodeModel.getNodeById({
@@ -64,11 +65,7 @@ const resolverPassthrough = ({
     fieldName,
   });
 
-  if (fieldName === 'tableOfContents') {
-    return processTableOfContentFields(result);
-  }
-
-  return result;
+  return processResult(result);
 };
 
 exports.sourceNodes = ({ actions, schema }) => {
@@ -138,7 +135,10 @@ exports.sourceNodes = ({ actions, schema }) => {
               default: 6,
             },
           },
-          resolve: resolverPassthrough({ fieldName: 'tableOfContents' }),
+          resolve: resolverPassthrough({
+            fieldName: 'tableOfContents',
+            processResult: processTableOfContentFields,
+          }),
         },
       },
       interfaces: ['Node'],

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -10,6 +10,7 @@ const crypto = require('crypto');
 const { createFilePath } = require('gatsby-source-filesystem');
 const { ContextReplacementPlugin } = require('webpack');
 const slugify = require('slugify');
+const processTableOfContentFields = require('./src/utils/process-table-of-content-fields');
 
 const trimTrailingSlash = (url) => url.replace(/(\/?)$/, '');
 
@@ -62,6 +63,11 @@ const resolverPassthrough = ({
   const result = await field.resolve(resolveNode(mdxNode), args, context, {
     fieldName,
   });
+
+  if (fieldName === 'tableOfContents') {
+    return processTableOfContentFields(result);
+  }
+
   return result;
 };
 

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -50,6 +50,7 @@
     "gatsby-transformer-remark": "2.7.3",
     "gatsby-transformer-sharp": "2.4.6",
     "gatsby-transformer-yaml": "2.3.3",
+    "github-slugger": "1.3.0",
     "hast-util-heading": "1.0.4",
     "lodash.throttle": "4.1.1",
     "prismjs": "1.20.0",

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Markdown } from '@commercetools-docs/ui-kit';
+import processTableOfContentFields from '../utils/process-table-of-content-fields';
 import useLayoutState from '../hooks/use-layout-state';
 import { useSiteData } from '../hooks/use-site-data';
 import { BetaFlag, ContentPagination } from '../components';
@@ -60,7 +61,9 @@ const LayoutContent = (props) => {
           </LayoutPageContent>
           <LayoutPageNavigation
             pageTitle={props.pageContext.shortTitle || props.pageData.title}
-            tableOfContents={props.pageData.tableOfContents}
+            tableOfContents={processTableOfContentFields(
+              props.pageData.tableOfContents
+            )}
           />
         </LayoutPage>
         <LayoutFooter />

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Markdown } from '@commercetools-docs/ui-kit';
-import processTableOfContentFields from '../utils/process-table-of-content-fields';
 import useLayoutState from '../hooks/use-layout-state';
 import { useSiteData } from '../hooks/use-site-data';
 import { BetaFlag, ContentPagination } from '../components';
@@ -61,9 +60,7 @@ const LayoutContent = (props) => {
           </LayoutPageContent>
           <LayoutPageNavigation
             pageTitle={props.pageContext.shortTitle || props.pageData.title}
-            tableOfContents={processTableOfContentFields(
-              props.pageData.tableOfContents
-            )}
+            tableOfContents={props.pageData.tableOfContents}
           />
         </LayoutPage>
         <LayoutFooter />

--- a/packages/gatsby-theme-docs/src/utils/process-table-of-content-fields.js
+++ b/packages/gatsby-theme-docs/src/utils/process-table-of-content-fields.js
@@ -1,4 +1,4 @@
-import githubSlugger from 'github-slugger';
+const githubSlugger = require('github-slugger');
 
 const slugger = githubSlugger();
 
@@ -28,4 +28,4 @@ function processTableOfContentFields(tableOfContents, level = 0) {
   return returnedTableOfContents;
 }
 
-export default processTableOfContentFields;
+module.exports = processTableOfContentFields;

--- a/packages/gatsby-theme-docs/src/utils/process-table-of-content-fields.js
+++ b/packages/gatsby-theme-docs/src/utils/process-table-of-content-fields.js
@@ -1,0 +1,31 @@
+import githubSlugger from 'github-slugger';
+
+const slugger = githubSlugger();
+
+function processTableOfContentFields(tableOfContents, level = 0) {
+  const returnedTableOfContents = {};
+
+  Object.keys(tableOfContents).forEach((key) => {
+    if (key === 'title') {
+      const titleWithoutJsx = tableOfContents[key]
+        .replace(/<(\w+)[^>]*>.*<\/\1>/gi, '') // remove jsx with texts between - https://www.webdeveloper.com/d/252483-regex-to-strip-html-and-content-between-tags/5
+        .replace(/(<([^>]+)>)/gi, ''); // remove jsx - https://stackoverflow.com/questions/1499889/remove-html-tags-in-javascript-with-regex
+      returnedTableOfContents[key] = titleWithoutJsx.trim();
+      returnedTableOfContents.url = `#${slugger.slug(titleWithoutJsx)}`;
+    }
+
+    if (Array.isArray(tableOfContents[key])) {
+      returnedTableOfContents[key] = tableOfContents[key].map((item) =>
+        processTableOfContentFields(item, level + 1)
+      );
+    }
+  });
+
+  if (level === 0) {
+    // only reset if no longer recursing
+    slugger.reset();
+  }
+  return returnedTableOfContents;
+}
+
+export default processTableOfContentFields;

--- a/packages/gatsby-theme-docs/src/utils/process-table-of-content-fields.spec.js
+++ b/packages/gatsby-theme-docs/src/utils/process-table-of-content-fields.spec.js
@@ -1,0 +1,105 @@
+import processTableOfContentFields from './process-table-of-content-fields';
+
+describe('processTableOfContentFields', () => {
+  it('should remove jsx from titles and urls', () => {
+    const tableOfContentBefore = {
+      items: [
+        {
+          url: '#expected-usage',
+          title: 'Expected Usage',
+          items: [
+            {
+              url: '#in-markdown-document',
+              title: 'In markdown document',
+            },
+            {
+              url: '#generated-dom',
+              title: 'Generated DOM',
+            },
+          ],
+        },
+        {
+          url: '#with-children',
+          title: 'With Children',
+          items: [
+            {
+              url: '#in-markdown-document-1',
+              title: 'In markdown document',
+            },
+            {
+              url: '#generated-dom-1',
+              title: 'Generated DOM',
+            },
+          ],
+        },
+        {
+          url: '#in-a-title',
+          title: 'In a title',
+          items: [
+            {
+              url:
+                '#anchor-in-title-links-here-anchor-nameany-html-id-compatible-string-in-a-title-',
+              title:
+                'Anchor in title links here <Anchor name="any-html-id-compatible-string-in-a-title" />',
+            },
+            {
+              url: '#usage',
+              title: 'Usage',
+            },
+          ],
+        },
+      ],
+    };
+
+    const tableOfContentAfter = {
+      items: [
+        {
+          url: '#expected-usage',
+          title: 'Expected Usage',
+          items: [
+            {
+              url: '#in-markdown-document',
+              title: 'In markdown document',
+            },
+            {
+              url: '#generated-dom',
+              title: 'Generated DOM',
+            },
+          ],
+        },
+        {
+          url: '#with-children',
+          title: 'With Children',
+          items: [
+            {
+              url: '#in-markdown-document-1',
+              title: 'In markdown document',
+            },
+            {
+              url: '#generated-dom-1',
+              title: 'Generated DOM',
+            },
+          ],
+        },
+        {
+          url: '#in-a-title',
+          title: 'In a title',
+          items: [
+            {
+              url: '#anchor-in-title-links-here',
+              title: 'Anchor in title links here',
+            },
+            {
+              url: '#usage',
+              title: 'Usage',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(processTableOfContentFields(tableOfContentBefore)).toEqual(
+      tableOfContentAfter
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10694,7 +10694,7 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
-github-slugger@^1.1.1, github-slugger@^1.2.1:
+github-slugger@1.3.0, github-slugger@^1.1.1, github-slugger@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.3.0.tgz#9bd0a95c5efdfc46005e82a906ef8e2a059124c9"
   integrity sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==


### PR DESCRIPTION
Fixes #392 

Since we use [rehype-slug](https://github.com/rehypejs/rehype-slug) to generate header IDs which are in turn used for header anchors, this change regenerates `tableOfContent` url using [github-slugger](https://github.com/Flet/github-slugger) which [github-slugger](https://github.com/Flet/github-slugger) uses to generate slugs. The change also includes stripping out JSX from titles of tableOfContent.

### Image of Problem

<img width="1680" alt="Screenshot 2020-04-24 at 09 51 52" src="https://user-images.githubusercontent.com/8238495/80188855-0d5db600-8612-11ea-93dd-329283ed8e2a.png">
