### PR TITLE
feat(gatsby-theme-docs): option to not load the default configuration data

### DIFF
--- a/packages/gatsby-theme-docs/README.md
+++ b/packages/gatsby-theme-docs/README.md
@@ -79,6 +79,8 @@ The project structure should contain at least the following files and folders:
 
   - `availablePrismLanguages` (_optional_): in case you need to include **Prism languages** that are [not included by default by `prism-react-renderer`](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js), you can pass a list of them here.
 
+  - `defaultConfigurationData` (_optional_, defaults to `true`): in case you need to provide custom configuration data for the top and footer menus it's possible to deactivate the default content of the `src/data` folder by passing `false` to this option. If passed, all files in the [the default /src/data](./src/data) folder need to be provided in the website using the theme.
+
 - `src/content`: this is where you would put your content pages as `*.mdx` files (_see [Writing content pages](#writing-content-pages)_).
 
 - `src/content/files`: this folder should contain static files that can be referenced within the `*.mdx` content files. For example SVG files, PDF files, etc.

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -21,6 +21,7 @@ const defaultOptions = {
   excludeFromSearchIndex: true,
   createNodeSlug: undefined,
   additionalPrismLanguages: [],
+  defaultConfigurationData: true,
 };
 const requiredOptions = ['websiteKey'];
 
@@ -57,7 +58,7 @@ module.exports = (themeOptions = {}) => {
             node { etc...
       */
 
-      // Data files (.yaml)
+      // Configuration data files provided by the website using the theme (.yaml)
       {
         resolve: 'gatsby-source-filesystem',
         options: {
@@ -65,14 +66,16 @@ module.exports = (themeOptions = {}) => {
           path: path.resolve(`./src/data`),
         },
       },
-      // Data files for internal use (.yaml)
-      {
-        resolve: 'gatsby-source-filesystem',
-        options: {
-          name: 'internalConfigurationData',
-          path: path.join(__dirname, `./src/data`),
-        },
-      },
+      // Default configuration data files provided by the theme (.yaml)
+      pluginOptions.defaultConfigurationData
+        ? {
+            resolve: 'gatsby-source-filesystem',
+            options: {
+              name: 'internalConfigurationData',
+              path: path.join(__dirname, `./src/data`),
+            },
+          }
+        : false,
       // Assets (e.g. images) used from the markdown pages
       {
         resolve: 'gatsby-source-filesystem',


### PR DESCRIPTION
Addresses #396 , alternative approach to #400 

This allows to control whether the theme provides default configuration data (used for the top, meta and footer navigation) or not.  