### PR TITLE
WIP writing style: adjustments

### DIFF
--- a/packages/writing-style/.vale.ini
+++ b/packages/writing-style/.vale.ini
@@ -28,6 +28,7 @@ write-good.TooWordy = suggestion
 write-good.Passive = suggestion
 Google.Will = suggestion
 Google.EnDash = suggestion
+Google.OptionalPlurals = suggestion # the UI text uses this and we need to refer to UI text --> to be decided with Design
 Google.Ellipses = suggestion # for example "Read more..." links are intended and OK.
 ## TODO find a way to apply "We" and "Will" to specific content (e.g. reference docs) only without having to put the rule into every file
 

--- a/packages/writing-style/styles/commercetools/Acronyms.yml
+++ b/packages/writing-style/styles/commercetools/Acronyms.yml
@@ -77,6 +77,7 @@ exceptions:
   - UTC
   - UTF
   - UUID
+  - VAT
   - XML
   - XSS
   - YAML # Do not use YML

--- a/packages/writing-style/styles/commercetools/Acronyms.yml
+++ b/packages/writing-style/styles/commercetools/Acronyms.yml
@@ -23,6 +23,7 @@ exceptions:
   - DEBUG
   - DHL
   - DOM
+  - ENUM
   - EUR
   - FAQ
   - GET
@@ -49,12 +50,14 @@ exceptions:
   - PHP
   - PNG
   - POST
+  - PSR
   - RAM
   - RAML
   - REST
   - RFC # "Request For Comment" would confuse readers even more.
   - RSA
   - SDK
+  - SDL # appears in many pages
   - SHA
   - SKU # generally we try to explain domain terminology but this one is so prevalent across the documentation that we allow it
   - SNS # AWS SNS, appears in many pages in a single place and amazon uses the short name themselves, too

--- a/packages/writing-style/styles/commercetools/Acronyms.yml
+++ b/packages/writing-style/styles/commercetools/Acronyms.yml
@@ -23,7 +23,6 @@ exceptions:
   - DEBUG
   - DHL
   - DOM
-  - ENUM
   - EUR
   - FAQ
   - GET
@@ -50,14 +49,14 @@ exceptions:
   - PHP
   - PNG
   - POST
-  - PSR
+  - PSR # PHP Specification Request, used in PHP content and in that context known.
   - RAM
   - RAML
   - REST
   - RFC # "Request For Comment" would confuse readers even more.
   - RSA
   - SDK
-  - SDL # appears in many pages
+  - SDL # We refer to the "GraphQL SDL" in our Release notes and in the GraphQL context that's ok.
   - SHA
   - SKU # generally we try to explain domain terminology but this one is so prevalent across the documentation that we allow it
   - SNS # AWS SNS, appears in many pages in a single place and amazon uses the short name themselves, too
@@ -77,7 +76,6 @@ exceptions:
   - UTC
   - UTF
   - UUID
-  - VAT
   - VIP
   - XML
   - XSS
@@ -85,6 +83,11 @@ exceptions:
   - ZIP
   - ISO
   - RSS
+  # MC UI Text (Cart discount rule editor)
+  - NOT
+  - AND
+  - OR
+  # Specials and Brands
   - YYYY # to be able to describe date formats like YYYY-MM-DD
   - ZEIT # the zeit.co service is trademarked in uppercased letters.
   # the following exceptions are allowed because they are caught as errors by the ToDo rule.

--- a/packages/writing-style/styles/commercetools/Acronyms.yml
+++ b/packages/writing-style/styles/commercetools/Acronyms.yml
@@ -78,6 +78,7 @@ exceptions:
   - UTF
   - UUID
   - VAT
+  - VIP
   - XML
   - XSS
   - YAML # Do not use YML

--- a/packages/writing-style/styles/commercetools/DateFormat.yml
+++ b/packages/writing-style/styles/commercetools/DateFormat.yml
@@ -7,5 +7,5 @@ ignorecase: true
 level: error
 nonword: true
 tokens:
-  - '\d{1,2}(?:\.|/)\d{1,2}(?:\.|/)\d{4}'
-  - '\d{1,2} (?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)|May|Jun(?:e)|Jul(?:y)|Aug(?:ust)|Sep(?:tember)?|Oct(?:ober)|Nov(?:ember)?|Dec(?:ember)?) \d{4}'
+  - '\d{1,2}(?:\.|\/)\d{1,2}(?:\.|\/)\d{2,4}'
+  - '(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)|May|Jun(?:e)|Jul(?:y)|Aug(?:ust)|Sep(?:tember)?|Oct(?:ober)|Nov(?:ember)?|Dec(?:ember)?) \d{1,2}(th|st|nd|rd|) \d{2,4}'

--- a/packages/writing-style/styles/commercetools/FirstPerson.yml
+++ b/packages/writing-style/styles/commercetools/FirstPerson.yml
@@ -1,27 +1,13 @@
-# Adjusted to tolerate uppercased "My" because of our "My Carts", "My Orders" etc. APIs. which are referenced throughout the documentation.
-# TODO refactor: a better approach would be to keep the original rule and add an exceptions list.
 extends: existence
-message: "Avoid first-person pronouns such as '%s' (and uppercase it in 'My ...' APIs)."
+message: "Avoid first-person pronouns such as '%s'."
 link: 'https://developers.google.com/style/pronouns#personal-pronouns'
-ignorecase: false
+ignorecase: true
 level: warning
 nonword: true
 tokens:
   - (?:^|\s)I\s
-  - (?:^|\s)i\s # it's a misspelling but this way we catch this too
   - (?:^|\s)I,\s
-  - (?:^|\s)i,\s # see above
   - \bI'm\b
-  - \bi'm\b # see above
   - \bme\b
-  - \bMe\b
-  - \bmy\b # this one NOT checked in uppercase (see first line)
+  - \bmy(?!\s?(cart|order|profile|customer|payment|transaction|account|shopping)s?)\b # "negative lookahead" regex to rule out cases followed by our "my" apis
   - \bmine\b
-  - \bMine\b
-#exceptions:
-#  - My Carts
-#  - My Payments
-#  - My Orders
-#  - My Shopping Lists
-#  - ...
-

--- a/packages/writing-style/styles/commercetools/Weasel.yml
+++ b/packages/writing-style/styles/commercetools/Weasel.yml
@@ -147,7 +147,7 @@ tokens:
 #  - really
 #  - recently
   - recklessly
-  - regularly
+#  - regularly
   - remarkably
 #  - relatively
   - reluctantly

--- a/packages/writing-style/styles/commercetools/WordList.yml
+++ b/packages/writing-style/styles/commercetools/WordList.yml
@@ -40,7 +40,7 @@ swap:
   open-source: open source
   regex: regular expression
   sign into: sign in to
-  sign-?on: single sign-on
+  single sign on: single sign-on
   stylesheet: style sheet
   synch: sync
   tablename: table name


### PR DESCRIPTION
Vale writing style check shows some minor issus. 
Due to this some rules have to be adjusted:
- acronym (add exceptions: ENUM, PSR, SDL, VAT, VIP) 
- `Google.Quotes: commas and periods go inside quotation marks.` Rule is not useful for us.
- `commercetools.DateFormat`is not working properly. 
- `commercetools.WordList - single sign-on`is not working properly. 