### PR TITLE
refactor(api-theme): compose themes in website instead of inheriting

### DIFF
--- a/packages/gatsby-theme-api-docs/README.md
+++ b/packages/gatsby-theme-api-docs/README.md
@@ -4,11 +4,41 @@ This is the core Gatsby theme for building commercetools documentation websites,
 
 ## Getting started
 
-To create a new documentation website you need to install this theme and its peer dependencies:
+To create a new documentation website you need to install this theme, the base docs theme and its peer dependencies:
 
+```sh
+npx install-peerdeps --dev @commercetools-docs/gatsby-theme-docs @commercetools-docs/gatsby-theme-api-docs
 ```
-npx install-peerdeps --dev @commercetools-docs/gatsby-theme-api-docs
+
+Then configure both in `gatsby-config.js` with the api docs theme coming after the base docs theme.
+
+```js
+module.exports = {
+  // ... more
+  plugins: [
+    {
+      resolve: '@commercetools-docs/gatsby-theme-docs',
+      options: {
+        websiteKey: 'api-docs-example',
+      },
+    },
+    {
+      resolve: '@commercetools-docs/gatsby-theme-api-docs',
+      options: {
+        transformerRaml: {
+          includeApis: ['example'],
+          movePropertiesToTop: [
+            'id',
+          ],
+          movePropertiesToBottom: ['custom'],
+        },
+      },
+    },
+  ],
+};
 ```
+
+Read more about GatsbyJS theme composition [here](https://www.gatsbyjs.org/docs/theme-api/#theme-composition).
 
 ### API spec theme
 

--- a/packages/gatsby-theme-api-docs/gatsby-config.js
+++ b/packages/gatsby-theme-api-docs/gatsby-config.js
@@ -26,10 +26,6 @@ module.exports = (themeOptions = {}) => {
         resolve: '@commercetools-docs/gatsby-transformer-raml',
         options: themeOptions.transformerRaml,
       },
-      {
-        resolve: '@commercetools-docs/gatsby-theme-docs',
-        options: themeOptions,
-      },
     ],
   };
 };

--- a/packages/gatsby-theme-api-docs/package.json
+++ b/packages/gatsby-theme-api-docs/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git"
   },
   "dependencies": {
-    "@commercetools-docs/gatsby-theme-docs": "2.5.0",
     "@commercetools-docs/gatsby-transformer-mdx-introspection": "2.5.0",
     "@commercetools-docs/gatsby-transformer-raml": "2.5.0",
     "@commercetools-docs/ui-kit": "2.5.0",

--- a/websites/api-docs-smoke-test/gatsby-config.js
+++ b/websites/api-docs-smoke-test/gatsby-config.js
@@ -9,11 +9,16 @@ module.exports = {
   },
   plugins: [
     {
-      resolve: '@commercetools-docs/gatsby-theme-api-docs',
+      resolve: '@commercetools-docs/gatsby-theme-docs',
       options: {
         websiteKey: 'api-docs-smoke-test',
         websitePrimaryColor: 'goldenrod',
         excludeFromSearchIndex: isProd,
+      },
+    },
+    {
+      resolve: '@commercetools-docs/gatsby-theme-api-docs',
+      options: {
         transformerRaml: {
           includeApis: ['test'],
           movePropertiesToTop: [

--- a/websites/api-docs-smoke-test/package.json
+++ b/websites/api-docs-smoke-test/package.json
@@ -14,6 +14,7 @@
     "generate-ramldoc": "npx commercetools-ramldoc-generator --name test --src ./source-raml/test/api.raml"
   },
   "dependencies": {
+    "@commercetools-docs/gatsby-theme-docs": "2.5.0",
     "@commercetools-docs/gatsby-theme-api-docs": "2.5.0",
     "gatsby": "2.20.26",
     "gatsby-cli": "2.11.12"


### PR DESCRIPTION
This is a small but powerful change, that's also a breaking change because sites that use the API docs theme have to be reconfigured to require and configure the API theme and the docs theme separately. 

**Background**

The commercetools-docs repository now contains six websites, of whome one (and later two) are using the API docs theme because they generate docs from RAML. 

The commercetools-docs repository also has a central "wrapper" theme that provides central configuration (e.g. the theme version, the google analytics key, etc) and data (navigation links in preview branches, **limits data**). 

**Problem**

The (in that repo) central configuration and data still has to be maintained twice for the sites using the API theme and the plain docs theme to avoid the base theme being loaded and run twice (including all config data being duplicated).  I could choose to pull the API theme into every site but that would render the point of a separate theme add-on useless. 

**Solution**

Stay more in line how gatsby themes are designed and do not require and configure the base docs theme directly in the api-docs theme.  The websites using API docs separately require the API theme and the base theme.  This is more expressive and flexible. 
