### PR TITLE
docs(cards): draft authoring spec proposal for cards

### DIFF
--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -202,14 +202,4 @@ would | work   |
 
 ## Output
 
-<Card>
-
-## Disallowed Subsection Heading
-This would render like the full page body and should be prevented or not done
-
-Even  | Tables |
-------|--------|
-would | work   |
-
-
-</Card>
+(breaks the build until card is implemented)

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -66,8 +66,8 @@ title: Cards
 
 Properties (for authors):
  * `title` (string): the card title, no markdown allowed.
- * `href` (string): the link target of the bottom link and, if `clickable` is set, the whole card. `href` has no effect when neither `clickable` or `link` are set.
- * `link` (string): the bottom link text. If not set, no bottom link is rendered at all.
+ * `href` (string): the link target of the bottom link and, if `clickable` is set, the whole card. `href` has no effect when neither `clickable` or `textLink` are set.
+ * `textLink` (string): the bottom link text. If not set, no bottom link is rendered at all.
  * `icon` (component): the component to be rendered into the 48x48px space reserved for an icon. If not set, the space is not reserved.
 
 ## Flat with Link
@@ -77,7 +77,7 @@ Properties (for authors):
   <Card
     title="A regular heading"
     href="/components/images"
-    link="Read more about images...">
+    textLink="Read more about images...">
   This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.
   </Card>
 </Cards>
@@ -89,7 +89,7 @@ Properties (for authors):
   <Card
     title="A regular heading"
     href="/components/images"
-    link="Read more about images...">
+    textLink="Read more about images...">
   This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.
   </Card>
 </Cards>
@@ -103,7 +103,7 @@ Properties (for authors):
   <Card
     title="A regular heading"
     href="/components/images"
-    link="Read more about images...">
+    textLink="Read more about images...">
   This is visually eleveated, has a link to the **images (bold)** page and the complete card is a clickable target.
   </Card>
 </Cards>
@@ -115,7 +115,7 @@ Properties (for authors):
   <Card
     title="A regular heading"
     href="/components/images"
-    link="Read more about images...">
+    textLink="Read more about images...">
   This is visually elevated, has a link to the **images (bold)** page and the complete card is a clickable target.
   </Card>
 </Cards>

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -9,7 +9,7 @@ title: Cards
    * To start with, Images are _not_ supported for free-form in-content cards, only in places that are fully designed and implemented by developers. An Image is sized into the width of the card.
    * Icons are supported anywhere but only those that are officially provided by the kit. An icon is sized into a fixed 48x48px square.
  * Cards can occur in two interaction variants, "active" (visually elevated) and "flat" (visually an outline only).
- * Cards must be embedded into a wrapper component that defines the responsive sizes (two aside / three aside) and parameters that must be identical in a give row or grid (active card area, the heading size)
+ * Cards must be embedded into a wrapper component that defines the responsive sizes (two aside / three aside) and parameters that must be identical in a given row or grid (active card area, the heading size)
    * trial & error led to a minimum width of ca 250px for narrow three-aside cards and ca 332px for two-aside cards.
  * A single card must not fill the full width but stay left aligned.
  * Multiple cards fill the full width and are scaled up to fill even if their content is smaller. Every card has the same width in all rows (resulting in a grid if it's multiple rows)
@@ -20,7 +20,7 @@ title: Cards
  Properties (for authors):
  * `active` (boolean): if set, the whole area of all child cards is a link, the card is elevated and has a hover effect if a link url is set.
  * `narrow` (boolean): by default, two cards are shown side by side (except mobile viewports). if `narrow` is passed, the minimum card width is reduced so that three cards fit the content width on microsite landing pages.
- * `smallTitle` (boolean): lets all cards have a smaller
+ * `smallTitle` (boolean): lets all cards have a smaller title font.
 
 ## Minimal form
 
@@ -68,7 +68,7 @@ Properties (for authors):
  * `title` (string): the card title, no markdown allowed.
  * `href` (string): the link target of the bottom link and, if `active` is set, the whole card. `href` has no effect when neither `active` or `link` are set.
  * `link` (string): the bottom link text. If not set, no bottom link is rendered at all.
- * `icon` (function): the component to be rendered into the 48x48px space reserved for an icon. If not set, the space is not reserved.
+ * `icon` (component): the component to be rendered into the 48x48px space reserved for an icon. If not set, the space is not reserved.
 
 ## Flat with Link
 

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -10,6 +10,10 @@ title: Cards
    * Icons are supported anywhere but only those that are officially provided by the kit. An icon is sized into a fixed 48x48px square.
  * Cards can occur in two interaction variants, "active" (visually elevated) and "flat" (visually an outline only).
  * Cards must be embedded into a wrapper component that defines the responsive sizes (two aside / three aside) and parameters that must be identical in a give row or grid (active card area, the heading size)
+   * trial & error led to a minimum width of ca 250px for narrow three-aside cards and ca 332px for two-aside cards.
+ * A single card must not fill the full width but stay left aligned.
+ * Multiple cards fill the full width and are scaled up to fill even if their content is smaller. Every card has the same width in all rows (resulting in a grid if it's multiple rows)
+ * Cards are sorted in rows, then columns.
 
 # "Cards" Wrapper
 
@@ -57,30 +61,6 @@ title: Cards
   <Card>next row unless three aside (narrow) prop passed?</Card>
   <Card>next row in any case</Card>
 </Cards>
-
-
-## Pseudo-CSS:
-
-This is for illustration. The implementation can be done differently. The design intent matches the CSS flexbox intent, but CSS grid might be more powerful although not originally being intended for rows with floating overflow.
-
-```css
-.cards {
-	width: 100%;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: stretch;
- }
-.cards > * {
-	flex-basis: 332px; /* the minimum width to never be three in a row */
-	flex-grow: 1;
-	flex-shrink: 1;
-	/* No maximum width possible here in flexbox, i.e. there could be one card taking full width (not intended, but acceptable)  */
-}
-.cards.narrow > * {
-	flex-basis: 250px; /* the minimum width to never be four in a row */
-}
-```
 
 # "Card": the actual card
 

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -1,0 +1,187 @@
+---
+title: Cards
+---
+
+<Info>This describes variations that use the maximum extent of the feature set, all can be used with less and need to render</Info>
+
+Cards typically need to be embedded into a flexbox-ish overflow wrapper that defines the responsive behavior and defines whether it's two aside or three aside if necessary.
+
+ * All content including headings is markdown (blank lines needed but that has to be learnt for all components)
+ * Headings have no linkable / hover anchor.
+ * Headings can never become entries in the page index nav if used in a content page
+ * `#` for the larger heading variant ("H3" in the design)?
+ * `##` or higher levels for the smaller heading variant ("H4" in the design)?
+ * Either an icon or an image path can be set, but not both. An Image is sized into the width of the card, an icon is sized into a fixed 48x48px square.
+ * Cards can occur in two interaction variants, "active" (visually elevated) and "flat" (visually an outline only).
+
+
+# Wrapper
+
+```jsx
+<Cards narrow>
+  <Card>foo</Card>
+  <Card>bar</Card>
+  <Card>next row unless three aside (narrow) prop passed?</Card>
+  <Card>next row in any case</Card>
+</Cards>
+```
+
+## Pseudo-CSS:
+```css
+.cards {
+	width: 100%;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: stretch;
+ }
+.cards > * {
+	flex-basis: 332px; /* the minimum width to never be three in a row */
+	flex-grow: 1;
+	flex-shrink: 1;
+	/* No maximum width possible here in flexbox, i.e. there could be one card taking full width (not intended, but acceptable)
+     Worth trying to abuse CSS grid as a single-row, auto-growing hack with explicit responsive breakpoints?
+  */
+}
+.cards.narrow > * {
+	flex-basis: 250px; /* the minimum width to never be four in a row */
+}
+```
+
+## Output
+
+<Cards>
+  <Card>foo</Card>
+  <Card>bar</Card>
+  <Card>next row unless three aside prop passed?</Card>
+  <Card>next row in any case</Card>
+</Cards>
+
+# Flat
+
+Flat cards have one card-level link target (href) and can have other links in the content, too, or no linking at all.
+The link target (href) is only useful if a link label for the bottom of the card is set.
+
+## Flat with Image and Link
+
+### MDX
+
+```jsx
+<Card
+  href="/components/images"
+  linkLabel="Read more about images..."
+  image="/images/200.jpg">
+## Example Small Heading
+This links to the images page and has an image and a read more link.
+</Card>
+```
+
+### Output
+
+<Card
+  href="/components/images"
+  linkLabel="Read more about images..."
+  image="/images/200.jpg">
+## Example Small Heading
+This links to the images page and has an image and a read more link.
+</Card>
+
+## Flat with Icon and no Link
+
+### MDX
+
+```jsx
+<Card icon="/images/200.jpg">
+# Example Large Heading
+This links to the images page and has an image and a read more link.
+</Card>
+```
+The `href` property can be set but will have no effect when neither `active` or `linkLabel` are set.
+
+### Output
+
+<Card icon="/images/200.jpg">
+# Example Large Heading
+This links to the images page and has an image and a read more link.
+</Card>
+
+
+# Active
+
+Active cards have one card-level link target (href) and no other links in the content.
+They are visually elevated and elevate even more when hovered.
+The link target (href) can be repeated as a link at the bottom by setting a card link label.
+
+## Active with Image and Link
+
+### MDX
+
+```jsx
+<Card active
+  href="/components/images"
+  linkLabel="Read more about images..."
+  image="/images/200.jpg">
+# Example Large Heading
+This links to the images page and has an image and a read more link.
+</Card>
+```
+
+### Output
+
+<Card active
+  href="/components/images"
+  linkLabel="Read more about images..."
+  image="/images/200.jpg">
+# Example Large Heading
+This links to the images page and has an image and a read more link.
+</Card>
+
+## Active with Icon and no Link
+
+### MDX
+
+```jsx
+<Card active
+  href="/components/images"
+  icon="/images/200.jpg">
+## Example Small Heading
+This links to the images page and has an image and a read more link.
+</Card>
+```
+
+### Output
+
+<Card active
+  href="/components/images"
+  icon="/images/200.jpg">
+## Example Small Heading
+This links to the images page and has an image and a read more link.
+</Card>
+
+# Embedded MDX in the Component Body
+
+<Warning>this (really??) cannot be prevented but should not be used</Warning>
+
+Since the MD(X) spec allows embedding markdown into JSX without a custom rendering by leaving blank lines, authors can use that pattern to place arbitrary article body content that would render in a way that is not card compatible.
+
+If possible we should either embrace it or try to block it and warn the user.
+
+### MDX
+
+```jsx
+<Card>
+
+## Disallowed Subsection Heading
+This would render like the full page body and should be prevented or not done
+
+Even  | Tables |
+------|--------|
+would | work   |
+
+
+</Card>
+```
+
+### Output
+
+(breaks until implemented?)

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -8,8 +8,8 @@ title: Cards
  * Either an icon or an image path can be set, but not both.
    * To start with, Images are _not_ supported for free-form in-content cards, only in places that are fully designed and implemented by developers. An Image is sized into the width of the card.
    * Icons are supported anywhere but only those that are officially provided by the kit. An icon is sized into a fixed 48x48px square.
- * Cards can occur in two interaction variants, "active" (visually elevated) and "flat" (visually an outline only).
- * Cards must be embedded into a wrapper component that defines the responsive sizes (two aside / three aside) and parameters that must be identical in a given row or grid (active card area, the heading size)
+ * Cards can occur in two interaction variants, "clickable" (visually elevated) and "flat" (visually an outline only).
+ * Cards must be embedded into a wrapper component that defines the responsive sizes (two aside / three aside) and parameters that must be identical in a given row or grid (clickable card area, the heading size)
    * trial & error led to a minimum width of ca 250px for narrow three-aside cards and ca 332px for two-aside cards.
  * A single card must not fill the full width but stay left aligned.
  * Multiple cards fill the full width and are scaled up to fill even if their content is smaller. Every card has the same width in all rows (resulting in a grid if it's multiple rows)
@@ -18,7 +18,7 @@ title: Cards
 # "Cards" Wrapper
 
  Properties (for authors):
- * `active` (boolean): if set, the whole area of all child cards is a link, the card is elevated and has a hover effect if a link url is set.
+ * `clickable` (boolean): if set, the whole area of all child cards is a link, the card is elevated and has a hover effect if a link url is set.
  * `narrow` (boolean): by default, two cards are shown side by side (except mobile viewports). if `narrow` is passed, the minimum card width is reduced so that three cards fit the content width on microsite landing pages.
  * `smallTitle` (boolean): lets all cards have a smaller title font.
 
@@ -45,7 +45,7 @@ title: Cards
 ## All options configured
 
 ```jsx
-<Cards active narrow smallTitle>
+<Cards clickable narrow smallTitle>
   <Card>foo</Card>
   <Card>bar</Card>
   <Card>next row unless three aside (narrow) prop passed?</Card>
@@ -55,7 +55,7 @@ title: Cards
 
 ### Output
 
-<Cards active narrow smallTitle>
+<Cards clickable narrow smallTitle>
   <Card>foo</Card>
   <Card>bar</Card>
   <Card>next row unless three aside (narrow) prop passed?</Card>
@@ -66,7 +66,7 @@ title: Cards
 
 Properties (for authors):
  * `title` (string): the card title, no markdown allowed.
- * `href` (string): the link target of the bottom link and, if `active` is set, the whole card. `href` has no effect when neither `active` or `link` are set.
+ * `href` (string): the link target of the bottom link and, if `clickable` is set, the whole card. `href` has no effect when neither `clickable` or `link` are set.
  * `link` (string): the bottom link text. If not set, no bottom link is rendered at all.
  * `icon` (component): the component to be rendered into the 48x48px space reserved for an icon. If not set, the space is not reserved.
 
@@ -94,12 +94,12 @@ Properties (for authors):
   </Card>
 </Cards>
 
-## Active with Link
+## Clickable with Link
 
-<Info>Active cards must have a href set. If not that is an error condition in development mode</Info>
+<Info>Clickable cards must have a href set. If not that is an error condition in development mode</Info>
 
 ```jsx
-<Cards active>
+<Cards clickable>
   <Card
     title="A regular heading"
     href="/components/images"
@@ -111,7 +111,7 @@ Properties (for authors):
 
 ### Output
 
-<Cards active>
+<Cards clickable>
   <Card
     title="A regular heading"
     href="/components/images"
@@ -154,9 +154,9 @@ As discussed:
   </Card>
 </Cards>
 
-# Active
+# Clickable (visually elevated)
 
-Active cards have one card-level link target (href) and no other links in the content.
+Clickable cards have one card-level link target (href) and no other links in the content.
 They are visually elevated and elevate even more when hovered.
 The link target (href) can be repeated as a link at the bottom by setting a card link label.
 

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -70,6 +70,8 @@ Properties (for authors):
  * `textLink` (string): the bottom link text. If not set, no bottom link is rendered at all.
  * `icon` (component): the component to be rendered into the 48x48px space reserved for an icon. If not set, the space is not reserved.
 
+None of the properties are required but the body content should not be empty.
+
 ## Flat with Link
 
 ```jsx
@@ -77,9 +79,7 @@ Properties (for authors):
   <Card
     title="A regular heading"
     href="/components/images"
-    textLink="Read more about images...">
-  This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.
-  </Card>
+    textLink="Read more about images...">This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.</Card>
 </Cards>
 ```
 
@@ -89,9 +89,7 @@ Properties (for authors):
   <Card
     title="A regular heading"
     href="/components/images"
-    textLink="Read more about images...">
-  This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.
-  </Card>
+    textLink="Read more about images...">This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.</Card>
 </Cards>
 
 ## Clickable with Link
@@ -103,9 +101,7 @@ Properties (for authors):
   <Card
     title="A regular heading"
     href="/components/images"
-    textLink="Read more about images...">
-  This is visually eleveated, has a link to the **images (bold)** page and the complete card is a clickable target.
-  </Card>
+    textLink="Read more about images...">This is visually eleveated, has a link to the **images (bold)** page and the complete card is a clickable target.</Card>
 </Cards>
 ```
 
@@ -115,10 +111,9 @@ Properties (for authors):
   <Card
     title="A regular heading"
     href="/components/images"
-    textLink="Read more about images...">
-  This is visually elevated, has a link to the **images (bold)** page and the complete card is a clickable target.
-  </Card>
+    textLink="Read more about images...">This is visually eleveated, has a link to the **images (bold)** page and the complete card is a clickable target.</Card>
 </Cards>
+
 
 ## Flat with Icon
 
@@ -136,9 +131,7 @@ As discussed:
 <Cards smallTitle>
   <Card
     icon={Icon.ShoppingList}
-    title="A smaller title">
-    Example Text on a card with an icon.
-  </Card>
+    title="A smaller title">Example Text on a card with an icon.</Card>
 </Cards>
 ```
 
@@ -148,10 +141,8 @@ As discussed:
 
 <Cards smallTitle>
   <Card
-    icon={function(){}}
-    title="A smaller title">
-    Example Text on a card with an icon.
-  </Card>
+    icon={Icon.ShoppingList}
+    title="A smaller title">Example Text on a card with an icon.</Card>
 </Cards>
 
 # Clickable (visually elevated)

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -4,7 +4,7 @@ title: Cards
 
  * The actual card content is markdown
  * Title have no linkable / hover anchor like section headings
- * Titles never become entries in the page index nav like section headings
+ * Card titles never become entries in the page index nav like section headings
  * Either an icon or an image path can be set, but not both.
    * To start with, Images are _not_ supported for free-form in-content cards, only in places that are fully designed and implemented by developers. An Image is sized into the width of the card.
    * Icons are supported anywhere but only those that are officially provided by the kit. An icon is sized into a fixed 48x48px square.

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -86,9 +86,9 @@ This is for illustration. The implementation can be done differently. The design
 
 Properties (for authors):
  * `title` (string): the card title, no markdown allowed.
- * `href` (string): the link target of the bottom link and, if "active", the whole card. `href` has no effect when neither `active` or `link` are set.
+ * `href` (string): the link target of the bottom link and, if `active` is set, the whole card. `href` has no effect when neither `active` or `link` are set.
  * `link` (string): the bottom link text. If not set, no bottom link is rendered at all.
- * `icon` (function): the component to be rendered into the 48x48px space reserved for an icon.  If not set, the space is not reserved.
+ * `icon` (function): the component to be rendered into the 48x48px space reserved for an icon. If not set, the space is not reserved.
 
 ## Flat with Link
 
@@ -142,13 +142,13 @@ Properties (for authors):
 
 ## Flat with Icon
 
-This example assumes that the icon used here is already provided by the MDX provider anyways.  But since it's MDX, alternative or site-specific icons can be provided by adding an `import` statement in the MDX.
+This example assumes that the icon used here is already provided by the MDX provider anyways. But since it's MDX alternative or site-specific icons can be provided by adding an `import` statement in the MDX.
 
 <Warning>
 
 As discussed:
  * this would be the first place where authors have to learn more JSX syntax and not just the HTML-compatible subset.
- * Also, from an author experience perspective we need to be aware that referencing an icon that does not exist cannot be caught gracefully or dynamically but will cause a compilation error.
+ * Also, from an author experience perspective we need to be aware that referencing an icon that does not exist cannot be caught at runtime but will cause a compilation error.
 
 </Warning>
 
@@ -182,7 +182,7 @@ The link target (href) can be repeated as a link at the bottom by setting a card
 
 # Embedded MDX in the Component Body
 
-The MDX spec and implementation allows for putting two blank lines to allow fully rendered markdown inside a JSX component. Because the cards must render markdown in the body differently than the same markdown would be rendered in the page body the implementation must either block the situation (e.g. detecting that the children aren't text but finished components) or override the renderer to use the MD fragment renderer instead.
+The MDX spec and implementation allows for putting two blank lines to allow fully rendered markdown inside a JSX component. Because the cards must render markdown in the body differently than the same markdown would be rendered in the page body the implementation must either block the situation (for example detecting that the children aren't text but finished components) or override the renderer to use the MD fragment renderer instead.
 
 ```jsx
 <Card>

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -141,7 +141,7 @@ As discussed:
 
 <Cards smallTitle>
   <Card
-    icon={Icon.ShoppingList}
+    icon={ /* Icon.ShoppingList */ }
     title="A smaller title">Example Text on a card with an icon.</Card>
 </Cards>
 

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -2,8 +2,6 @@
 title: Cards
 ---
 
-<Info>This describes variations that use the maximum extent of the feature set, all can be used with less and need to render</Info>
-
  * The actual card content is markdown
  * Title have no linkable / hover anchor like section headings
  * Titles never become entries in the page index nav like section headings
@@ -15,11 +13,10 @@ title: Cards
 
 # "Cards" Wrapper
 
- * Component: `<Cards>`
- * Properties (for authors):
-   * `active` (boolean): if set, the whole area of all child cards is a link, the card is elevated and has a hover effect if a link url is set.
-   * `narrow` (boolean): by default, two cards are shown side by side (except mobile viewports). if `narrow` is passed, the minimum card width is reduced so that three cards fit the content width on microsite landing pages.
-   * `smallTitle` (boolean): lets all cards have a smaller
+ Properties (for authors):
+ * `active` (boolean): if set, the whole area of all child cards is a link, the card is elevated and has a hover effect if a link url is set.
+ * `narrow` (boolean): by default, two cards are shown side by side (except mobile viewports). if `narrow` is passed, the minimum card width is reduced so that three cards fit the content width on microsite landing pages.
+ * `smallTitle` (boolean): lets all cards have a smaller
 
 ## Minimal form
 
@@ -87,21 +84,20 @@ This is for illustration. The implementation can be done differently. The design
 
 # "Card": the actual card
 
- * Component: `<Card>`
- * Properties (for authors):
-  * `title` (string): the card title, no markdown allowed.
-  * `href` (string): the link target of the bottom link and, if "active", the whole card. `href` has no effect when neither `active` or `link` are set.
-  * `link` (string): the bottom link text. If not set, no bottom link is rendered at all.
-  * `icon` (function): the component to be rendered into the 48x48px space reserved for an icon.  If not set, the space is not reserved.
+Properties (for authors):
+ * `title` (string): the card title, no markdown allowed.
+ * `href` (string): the link target of the bottom link and, if "active", the whole card. `href` has no effect when neither `active` or `link` are set.
+ * `link` (string): the bottom link text. If not set, no bottom link is rendered at all.
+ * `icon` (function): the component to be rendered into the 48x48px space reserved for an icon.  If not set, the space is not reserved.
 
 ## Flat with Link
 
 ```jsx
 <Cards>
   <Card
+    title="A regular heading"
     href="/components/images"
-    linkLabel="Read more about images..."
-    title="A regular heading">
+    link="Read more about images...">
   This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.
   </Card>
 </Cards>
@@ -111,9 +107,9 @@ This is for illustration. The implementation can be done differently. The design
 
 <Cards>
   <Card
+    title="A regular heading"
     href="/components/images"
-    linkLabel="Read more about images..."
-    title="A regular heading">
+    link="Read more about images...">
   This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.
   </Card>
 </Cards>
@@ -125,9 +121,9 @@ This is for illustration. The implementation can be done differently. The design
 ```jsx
 <Cards active>
   <Card
+    title="A regular heading"
     href="/components/images"
-    linkLabel="Read more about images..."
-    title="A regular heading">
+    link="Read more about images...">
   This is visually eleveated, has a link to the **images (bold)** page and the complete card is a clickable target.
   </Card>
 </Cards>
@@ -137,9 +133,9 @@ This is for illustration. The implementation can be done differently. The design
 
 <Cards active>
   <Card
+    title="A regular heading"
     href="/components/images"
-    linkLabel="Read more about images..."
-    title="A regular heading">
+    link="Read more about images...">
   This is visually elevated, has a link to the **images (bold)** page and the complete card is a clickable target.
   </Card>
 </Cards>
@@ -151,7 +147,7 @@ This example assumes that the icon used here is already provided by the MDX prov
 <Warning>
 
 As discussed:
- * this would be the first place where authors have to learn full JSX syntax and not just the HTML-compatible subset.
+ * this would be the first place where authors have to learn more JSX syntax and not just the HTML-compatible subset.
  * Also, from an author experience perspective we need to be aware that referencing an icon that does not exist cannot be caught gracefully or dynamically but will cause a compilation error.
 
 </Warning>
@@ -168,9 +164,11 @@ As discussed:
 
 ### Output
 
+(no actual icon set until one is available to not break this page)
+
 <Cards smallTitle>
   <Card
-    icon={Icon.ShoppingList}
+    icon={function(){}}
     title="A smaller title">
     Example Text on a card with an icon.
   </Card>

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -141,7 +141,6 @@ As discussed:
 
 <Cards smallTitle>
   <Card
-    icon={ /* Icon.ShoppingList */ }
     title="A smaller title">Example Text on a card with an icon.</Card>
 </Cards>
 

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -3,7 +3,7 @@ title: Cards
 ---
 
  * The actual card content is markdown
- * Title have no linkable / hover anchor like section headings
+ * Card titles are not links
  * Card titles never become entries in the page index nav like section headings
  * Either an icon or an image path can be set, but not both.
    * To start with, Images are _not_ supported for free-form in-content cards, only in places that are fully designed and implemented by developers. An Image is sized into the width of the card.

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -4,21 +4,47 @@ title: Cards
 
 <Info>This describes variations that use the maximum extent of the feature set, all can be used with less and need to render</Info>
 
-Cards typically need to be embedded into a flexbox-ish overflow wrapper that defines the responsive behavior and defines whether it's two aside or three aside if necessary.
-
- * All content including headings is markdown (blank lines needed but that has to be learnt for all components)
- * Headings have no linkable / hover anchor.
- * Headings can never become entries in the page index nav if used in a content page
- * `#` for the larger heading variant ("H3" in the design)?
- * `##` or higher levels for the smaller heading variant ("H4" in the design)?
- * Either an icon or an image path can be set, but not both. An Image is sized into the width of the card, an icon is sized into a fixed 48x48px square.
+ * The actual card content is markdown
+ * Title have no linkable / hover anchor like section headings
+ * Titles never become entries in the page index nav like section headings
+ * Either an icon or an image path can be set, but not both.
+   * To start with, Images are _not_ supported for free-form in-content cards, only in places that are fully designed and implemented by developers. An Image is sized into the width of the card.
+   * Icons are supported anywhere but only those that are officially provided by the kit. An icon is sized into a fixed 48x48px square.
  * Cards can occur in two interaction variants, "active" (visually elevated) and "flat" (visually an outline only).
+ * Cards must be embedded into a wrapper component that defines the responsive sizes (two aside / three aside) and parameters that must be identical in a give row or grid (active card area, the heading size)
 
+# "Cards" Wrapper
 
-# Wrapper
+ * Component: `<Cards>`
+ * Properties (for authors):
+   * `active` (boolean): if set, the whole area of all child cards is a link, the card is elevated and has a hover effect if a link url is set.
+   * `narrow` (boolean): by default, two cards are shown side by side (except mobile viewports). if `narrow` is passed, the minimum card width is reduced so that three cards fit the content width on microsite landing pages.
+   * `smallTitle` (boolean): lets all cards have a smaller
+
+## Minimal form
 
 ```jsx
-<Cards narrow>
+<Cards>
+  <Card>foo</Card>
+  <Card>bar</Card>
+  <Card>next row unless three aside (narrow) prop passed?</Card>
+  <Card>next row in any case</Card>
+</Cards>
+```
+### Output
+
+<Cards>
+  <Card>foo</Card>
+  <Card>bar</Card>
+  <Card>next row unless three aside (narrow) prop passed?</Card>
+  <Card>next row in any case</Card>
+</Cards>
+
+
+## All options configured
+
+```jsx
+<Cards active narrow smallTitle>
   <Card>foo</Card>
   <Card>bar</Card>
   <Card>next row unless three aside (narrow) prop passed?</Card>
@@ -26,7 +52,20 @@ Cards typically need to be embedded into a flexbox-ish overflow wrapper that def
 </Cards>
 ```
 
+### Output
+
+<Cards active narrow smallTitle>
+  <Card>foo</Card>
+  <Card>bar</Card>
+  <Card>next row unless three aside (narrow) prop passed?</Card>
+  <Card>next row in any case</Card>
+</Cards>
+
+
 ## Pseudo-CSS:
+
+This is for illustration. The implementation can be done differently. The design intent matches the CSS flexbox intent, but CSS grid might be more powerful although not originally being intended for rows with floating overflow.
+
 ```css
 .cards {
 	width: 100%;
@@ -39,72 +78,103 @@ Cards typically need to be embedded into a flexbox-ish overflow wrapper that def
 	flex-basis: 332px; /* the minimum width to never be three in a row */
 	flex-grow: 1;
 	flex-shrink: 1;
-	/* No maximum width possible here in flexbox, i.e. there could be one card taking full width (not intended, but acceptable)
-     Worth trying to abuse CSS grid as a single-row, auto-growing hack with explicit responsive breakpoints?
-  */
+	/* No maximum width possible here in flexbox, i.e. there could be one card taking full width (not intended, but acceptable)  */
 }
 .cards.narrow > * {
 	flex-basis: 250px; /* the minimum width to never be four in a row */
 }
 ```
 
-## Output
+# "Card": the actual card
+
+ * Component: `<Card>`
+ * Properties (for authors):
+  * `title` (string): the card title, no markdown allowed.
+  * `href` (string): the link target of the bottom link and, if "active", the whole card. `href` has no effect when neither `active` or `link` are set.
+  * `link` (string): the bottom link text. If not set, no bottom link is rendered at all.
+  * `icon` (function): the component to be rendered into the 48x48px space reserved for an icon.  If not set, the space is not reserved.
+
+## Flat with Link
+
+```jsx
+<Cards>
+  <Card
+    href="/components/images"
+    linkLabel="Read more about images..."
+    title="A regular heading">
+  This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.
+  </Card>
+</Cards>
+```
+
+### Output
 
 <Cards>
-  <Card>foo</Card>
-  <Card>bar</Card>
-  <Card>next row unless three aside prop passed?</Card>
-  <Card>next row in any case</Card>
+  <Card
+    href="/components/images"
+    linkLabel="Read more about images..."
+    title="A regular heading">
+  This is visually flat, has a link to the **images (bold)** page and only the link is a clickable target.
+  </Card>
 </Cards>
 
-# Flat
+## Active with Link
 
-Flat cards have one card-level link target (href) and can have other links in the content, too, or no linking at all.
-The link target (href) is only useful if a link label for the bottom of the card is set.
-
-## Flat with Image and Link
-
-### MDX
+<Info>Active cards must have a href set. If not that is an error condition in development mode</Info>
 
 ```jsx
-<Card
-  href="/components/images"
-  linkLabel="Read more about images..."
-  image="/images/200.jpg">
-## Example Small Heading
-This links to the images page and has an image and a read more link.
-</Card>
+<Cards active>
+  <Card
+    href="/components/images"
+    linkLabel="Read more about images..."
+    title="A regular heading">
+  This is visually eleveated, has a link to the **images (bold)** page and the complete card is a clickable target.
+  </Card>
+</Cards>
 ```
 
 ### Output
 
-<Card
-  href="/components/images"
-  linkLabel="Read more about images..."
-  image="/images/200.jpg">
-## Example Small Heading
-This links to the images page and has an image and a read more link.
-</Card>
+<Cards active>
+  <Card
+    href="/components/images"
+    linkLabel="Read more about images..."
+    title="A regular heading">
+  This is visually elevated, has a link to the **images (bold)** page and the complete card is a clickable target.
+  </Card>
+</Cards>
 
-## Flat with Icon and no Link
+## Flat with Icon
 
-### MDX
+This example assumes that the icon used here is already provided by the MDX provider anyways.  But since it's MDX, alternative or site-specific icons can be provided by adding an `import` statement in the MDX.
+
+<Warning>
+
+As discussed:
+ * this would be the first place where authors have to learn full JSX syntax and not just the HTML-compatible subset.
+ * Also, from an author experience perspective we need to be aware that referencing an icon that does not exist cannot be caught gracefully or dynamically but will cause a compilation error.
+
+</Warning>
 
 ```jsx
-<Card icon="/images/200.jpg">
-# Example Large Heading
-This links to the images page and has an image and a read more link.
-</Card>
+<Cards smallTitle>
+  <Card
+    icon={Icon.ShoppingList}
+    title="A smaller title">
+    Example Text on a card with an icon.
+  </Card>
+</Cards>
 ```
-The `href` property can be set but will have no effect when neither `active` or `linkLabel` are set.
 
 ### Output
 
-<Card icon="/images/200.jpg">
-# Example Large Heading
-This links to the images page and has an image and a read more link.
-</Card>
-
+<Cards smallTitle>
+  <Card
+    icon={Icon.ShoppingList}
+    title="A smaller title">
+    Example Text on a card with an icon.
+  </Card>
+</Cards>
 
 # Active
 
@@ -112,61 +182,9 @@ Active cards have one card-level link target (href) and no other links in the co
 They are visually elevated and elevate even more when hovered.
 The link target (href) can be repeated as a link at the bottom by setting a card link label.
 
-## Active with Image and Link
-
-### MDX
-
-```jsx
-<Card active
-  href="/components/images"
-  linkLabel="Read more about images..."
-  image="/images/200.jpg">
-# Example Large Heading
-This links to the images page and has an image and a read more link.
-</Card>
-```
-
-### Output
-
-<Card active
-  href="/components/images"
-  linkLabel="Read more about images..."
-  image="/images/200.jpg">
-# Example Large Heading
-This links to the images page and has an image and a read more link.
-</Card>
-
-## Active with Icon and no Link
-
-### MDX
-
-```jsx
-<Card active
-  href="/components/images"
-  icon="/images/200.jpg">
-## Example Small Heading
-This links to the images page and has an image and a read more link.
-</Card>
-```
-
-### Output
-
-<Card active
-  href="/components/images"
-  icon="/images/200.jpg">
-## Example Small Heading
-This links to the images page and has an image and a read more link.
-</Card>
-
 # Embedded MDX in the Component Body
 
-<Warning>this (really??) cannot be prevented but should not be used</Warning>
-
-Since the MD(X) spec allows embedding markdown into JSX without a custom rendering by leaving blank lines, authors can use that pattern to place arbitrary article body content that would render in a way that is not card compatible.
-
-If possible we should either embrace it or try to block it and warn the user.
-
-### MDX
+The MDX spec and implementation allows for putting two blank lines to allow fully rendered markdown inside a JSX component. Because the cards must render markdown in the body differently than the same markdown would be rendered in the page body the implementation must either block the situation (e.g. detecting that the children aren't text but finished components) or override the renderer to use the MD fragment renderer instead.
 
 ```jsx
 <Card>
@@ -182,6 +200,16 @@ would | work   |
 </Card>
 ```
 
-### Output
+## Output
 
-(breaks until implemented?)
+<Card>
+
+## Disallowed Subsection Heading
+This would render like the full page body and should be prevented or not done
+
+Even  | Tables |
+------|--------|
+would | work   |
+
+
+</Card>

--- a/websites/docs-smoke-test/src/data/navigation.yaml
+++ b/websites/docs-smoke-test/src/data/navigation.yaml
@@ -21,6 +21,8 @@
       path: /components/images
     - title: Code Examples
       path: /components/code-examples
+    - title: Cards
+      path: /components/cards
 - chapter-title: Chapter 9999 With a Longer Multi-Word Name that Wraps
   pages:
     - title: Page with some very long title too much for our innocent API to handle


### PR DESCRIPTION
This is Step one to resolve / #414 / 

It's in a first brainstorming phase, don't take it as a fixed definition - it's useful to force us taking some technical design decisions (like allowing markdown in the content or not) and then approve this as the test case page for the implementation. 