### PR TITLE
fix(renovate): keep major dep updates separated from aggregated updates

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -5,12 +5,14 @@
     "schedule:weekly"
   ],
   "separateMajorMinor": true,
-  "groupName": "all dependencies",
-  "groupSlug": "all",
   "packageRules": [
     {
       "packagePatterns": [
         "*"
+      ],
+      "updateTypes": [
+        "minor",
+        "patch"
       ],
       "groupName": "all dependencies",
       "groupSlug": "all"


### PR DESCRIPTION
As suggested by the creator of Renovate, the major deps updates should not be aggregated, as there might seem to be interference with the overall config, causing deps update PRs to be closed.

More info here: https://github.com/renovatebot/config-help/issues/632#issuecomment-626916487