### PR TITLE
fix(theme): render release notes filters in overlay for small screens

### DIFF
--- a/.changeset/warm-kids-sparkle.md
+++ b/.changeset/warm-kids-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Render release notes filters in overlay for small screens

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
@@ -1,10 +1,16 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { IntlProvider } from 'react-intl';
+import { keyframes } from '@emotion/core';
 import styled from '@emotion/styled';
 import { createStyledIcon, designSystem } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
+import IconButton from '@commercetools-uikit/icon-button';
+import SecondaryIconButton from '@commercetools-uikit/secondary-icon-button';
+import { CloseIcon } from '@commercetools-uikit/icons';
 import UnstyledStackedLinesIndentedIcon from '../../icons/stacked-lines-indented-icon.svg';
+import { Overlay } from '../../components';
 import ReleaseNotesFilterDates from '../../components/release-notes-filter-dates';
 import ReleaseNotesFilterTopics from '../../components/release-notes-filter-topics';
 
@@ -12,6 +18,18 @@ const StackedLinesIndentedIcon = createStyledIcon(
   UnstyledStackedLinesIndentedIcon
 );
 
+const slideInAnimation = keyframes`
+  from { margin-right: -100%; }
+  to { margin-right: 0; }
+`;
+const SlidingContainer = styled.div`
+  background-color: ${designSystem.colors.light.surfacePrimary};
+  animation: ${slideInAnimation} 0.5s ease-out alternate;
+  width: calc(${designSystem.dimensions.widths.pageNavigation});
+  padding: ${designSystem.dimensions.spacings.m};
+  height: 100%;
+  overflow: auto;
+`;
 const GridContainer = styled.div`
   display: none;
   border-left: 1px solid ${designSystem.colors.light.borderPrimary};
@@ -52,29 +70,88 @@ const ReleasesTitleLink = styled.a`
     outline-width: 0;
   }
 `;
+const ToggleMenuButton = styled.div`
+  position: fixed;
+  top: calc(
+    ${designSystem.dimensions.heights.header} +
+      ${designSystem.dimensions.spacings.m}
+  );
+  right: ${designSystem.dimensions.spacings.m};
+  cursor: pointer;
+
+  @media screen and (${designSystem.dimensions.viewports.largeTablet}) {
+    display: none;
+  }
+`;
 
 const LayoutPageReleaseNotesFilters = () => {
-  return (
+  const [isMenuOpen, setMenuOpen] = React.useState(false);
+  const [modalPortalNode, setModalPortalNode] = React.useState();
+  React.useEffect(() => {
+    setModalPortalNode(document.getElementById('modal-portal'));
+  }, []);
+
+  const filtersContainer = (
     <IntlProvider locale="en">
-      <GridContainer>
-        <StickyContainer>
-          <SpacingsStack scale="m">
-            <ReleasesTitleLink href="#top">
-              <SpacingsInline scale="s" alignItems="center">
-                <div>Releases</div>
-                <div>
-                  <StackedLinesIndentedIcon color="textSecondary" />
-                </div>
-              </SpacingsInline>
-            </ReleasesTitleLink>
-
-            <ReleaseNotesFilterDates />
-
-            <ReleaseNotesFilterTopics />
-          </SpacingsStack>
-        </StickyContainer>
-      </GridContainer>
+      <SpacingsStack scale="m">
+        <SpacingsInline
+          scale="s"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <ReleasesTitleLink href="#top">
+            <SpacingsInline scale="s" alignItems="center">
+              <div>Releases</div>
+              <div>
+                <StackedLinesIndentedIcon color="textSecondary" />
+              </div>
+            </SpacingsInline>
+          </ReleasesTitleLink>
+          <SecondaryIconButton
+            icon={<CloseIcon size="medium" />}
+            label="Close release notes filters"
+            onClick={() => {
+              setMenuOpen(false);
+            }}
+          />
+        </SpacingsInline>
+        <ReleaseNotesFilterDates />
+        <ReleaseNotesFilterTopics />
+      </SpacingsStack>
     </IntlProvider>
+  );
+
+  if (isMenuOpen) {
+    return modalPortalNode
+      ? ReactDOM.createPortal(
+          <Overlay
+            justifyContent="flex-end"
+            // onClick={() => {
+            //   // setMenuOpen(false);
+            // }}
+          >
+            <SlidingContainer>{filtersContainer}</SlidingContainer>
+          </Overlay>,
+          modalPortalNode
+        )
+      : null;
+  }
+
+  return (
+    <>
+      <ToggleMenuButton>
+        <IconButton
+          icon={<StackedLinesIndentedIcon theme="textSecondary" />}
+          label="Open release notes filters"
+          onClick={() => {
+            setMenuOpen(true);
+          }}
+        />
+      </ToggleMenuButton>
+      <GridContainer>
+        <StickyContainer>{filtersContainer}</StickyContainer>
+      </GridContainer>
+    </>
   );
 };
 LayoutPageReleaseNotesFilters.displayName = 'LayoutPageReleaseNotesFilters';

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
@@ -51,7 +51,7 @@ const StickyContainer = styled.div`
   position: sticky;
   top: ${designSystem.dimensions.spacings.xxl};
   margin: 0 0 ${designSystem.dimensions.spacings.s};
-  padding-left: ${designSystem.dimensions.spacings.m};
+  padding: ${designSystem.dimensions.spacings.m};
 `;
 const ReleasesTitleLink = styled.a`
   color: ${designSystem.colors.light.textSecondary};
@@ -107,13 +107,15 @@ const LayoutPageReleaseNotesFilters = () => {
               </div>
             </SpacingsInline>
           </ReleasesTitleLink>
-          <SecondaryIconButton
-            icon={<CloseIcon size="medium" />}
-            label="Close release notes filters"
-            onClick={() => {
-              setMenuOpen(false);
-            }}
-          />
+          {isMenuOpen && (
+            <SecondaryIconButton
+              icon={<CloseIcon size="medium" />}
+              label="Close release notes filters"
+              onClick={() => {
+                setMenuOpen(false);
+              }}
+            />
+          )}
         </SpacingsInline>
         <ReleaseNotesFilterDates />
         <ReleaseNotesFilterTopics />
@@ -126,11 +128,17 @@ const LayoutPageReleaseNotesFilters = () => {
       ? ReactDOM.createPortal(
           <Overlay
             justifyContent="flex-end"
-            // onClick={() => {
-            //   // setMenuOpen(false);
-            // }}
+            onClick={() => {
+              setMenuOpen(false);
+            }}
           >
-            <SlidingContainer>{filtersContainer}</SlidingContainer>
+            <SlidingContainer
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+            >
+              {filtersContainer}
+            </SlidingContainer>
           </Overlay>,
           modalPortalNode
         )


### PR DESCRIPTION
<img width="622" alt="image" src="https://user-images.githubusercontent.com/1110551/82152265-47f8ee00-9860-11ea-9b9e-40e5e5252c64.png">
