### PR TITLE
feat(markdown): refactor content spacing to better render enclosed fragments

### DIFF
--- a/.changeset/refactor-content-spacing.md
+++ b/.changeset/refactor-content-spacing.md
@@ -1,0 +1,8 @@
+---
+"@commercetools-docs/ui-kit": minor
+"@commercetools-website/docs-smoke-test": patch
+---
+
+Markdown UI Kit: refactor content spacing to be able to render markdown inside
+
+Markdown UI Kit: refactor content spacing to be able to render markdown inside

--- a/.changeset/refactor-content-spacing.md
+++ b/.changeset/refactor-content-spacing.md
@@ -1,6 +1,6 @@
 ---
-"@commercetools-docs/ui-kit": minor
-"@commercetools-website/docs-smoke-test": patch
+'@commercetools-docs/ui-kit': minor
+'@commercetools-website/docs-smoke-test': minor
 ---
 
 Markdown UI Kit: refactor content spacing to be able to render markdown inside

--- a/.changeset/refactor-content-spacing.md
+++ b/.changeset/refactor-content-spacing.md
@@ -4,5 +4,3 @@
 ---
 
 Markdown UI Kit: refactor content spacing to be able to render markdown inside
-
-Markdown UI Kit: refactor content spacing to be able to render markdown inside

--- a/packages/ui-kit/src/components/content-notifications.js
+++ b/packages/ui-kit/src/components/content-notifications.js
@@ -7,6 +7,7 @@ import {
   WarningIcon,
   ErrorIcon,
 } from '@commercetools-uikit/icons';
+import { TypographyContainer } from './markdown';
 import { colors, tokens, dimensions } from '../design-system';
 
 const getIconByType = (type) => {
@@ -81,7 +82,7 @@ const ContentNotification = (props) => {
 
           </Info>
         */}
-        <div>{props.children}</div>
+        <TypographyContainer>{props.children}</TypographyContainer>
       </SpacingsInline>
     </Container>
   );

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -3,12 +3,13 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import RibbonIcon from '../icons/ribbon-icon.svg';
 import { colors, dimensions, typography, tokens } from '../design-system';
-import { CodeBlockMarkdownWrapper as CodeBlock } from './multi-code-block';
+import {
+  CodeBlockMarkdownWrapper as CodeBlock,
+  Container as CodeBlockContainer,
+} from './multi-code-block';
 
 const headerStyles = () => css`
-  font-weight: ${typography.fontWeights.medium};
   line-height: 1.3;
-  margin: ${dimensions.spacings.m} 0 ${dimensions.spacings.s};
 `;
 
 const Paragraph = styled.p`
@@ -17,28 +18,28 @@ const Paragraph = styled.p`
 const H1 = styled.h1`
   ${headerStyles};
   font-size: ${typography.fontSizes.h1};
-  margin: 0 0 ${dimensions.spacings.s};
   font-weight: ${typography.fontWeights.regular};
   line-height: 1.15;
   color: ${(props) => props.theme.colors.light.primary};
+  /* H1 is the page title and used outside the Typography wrappers so it directly has a margin */
+  margin: 0 0 ${dimensions.spacings.s};
 `;
 const H2 = styled.h2`
   ${headerStyles};
-  border-bottom: 1px solid ${colors.light.borderPrimary};
   font-size: ${typography.fontSizes.h2};
   font-weight: ${typography.fontWeights.bold};
-  margin: ${dimensions.spacings.huge} 0 ${dimensions.spacings.m};
+  border-bottom: 1px solid ${colors.light.borderPrimary};
   padding-bottom: ${dimensions.spacings.s};
 `;
 const H3 = styled.h3`
   ${headerStyles};
   font-size: ${typography.fontSizes.h3};
-  margin: ${dimensions.spacings.big} 0 0;
+  font-weight: ${typography.fontWeights.medium};
 `;
 const H4 = styled.h4`
   ${headerStyles};
   font-size: ${typography.fontSizes.h4};
-  margin: ${dimensions.spacings.xl} 0 0;
+  font-weight: ${typography.fontWeights.medium};
 `;
 const H5 = styled.h5`
   ${headerStyles};
@@ -60,12 +61,6 @@ Heading margins are not set here because headings can and should not be used ins
 const containerStyles = () => css`
   > * + * {
     margin-top: ${dimensions.spacings.m};
-  }
-  > :first-child {
-    margin-top: 0;
-  }
-  > :last-child {
-    margin-bottom: 0;
   }
 `;
 
@@ -240,11 +235,29 @@ const TypographyPage = styled.div`
   section > * + * {
     margin-top: ${dimensions.spacings.m};
   }
+  section > ${H2} {
+    margin: ${dimensions.spacings.huge} 0 ${dimensions.spacings.m};
+  }
+  section > ${H3} {
+    margin: ${dimensions.spacings.big} 0 0;
+  }
+  section > ${H4} {
+    margin: ${dimensions.spacings.xl} 0 0;
+  }
+  section > ${H5} {
+    margin: ${dimensions.spacings.m} 0 ${dimensions.spacings.s};
+  }
+  section > ${H6} {
+    margin: ${dimensions.spacings.m} 0 ${dimensions.spacings.s};
+  }
   section > ${Blockquote} {
     margin: ${dimensions.spacings.l} ${dimensions.spacings.xxl};
   }
   section > ${Ul}, section > ${Ol} {
     margin: ${dimensions.spacings.s} 0 ${dimensions.spacings.xxl};
+  }
+  section > ${CodeBlockContainer} {
+    margin-bottom: ${dimensions.spacings.xxl};
   }
 `;
 

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -21,6 +21,7 @@ const H1 = styled.h1`
   font-weight: ${typography.fontWeights.regular};
   line-height: 1.15;
   color: ${(props) => props.theme.colors.light.primary};
+
   /* H1 is the page title and used outside the Typography wrappers so it directly has a margin */
   margin: 0 0 ${dimensions.spacings.s};
 `;

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -60,7 +60,6 @@ Heading margins are not set here because headings can and should not be used ins
 const containerStyles = () => css`
   > * + * {
     margin-top: ${dimensions.spacings.m};
-    margin-bottom: ${dimensions.spacings.m};
   }
   > :first-child {
     margin-top: 0;

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -5,17 +5,6 @@ import RibbonIcon from '../icons/ribbon-icon.svg';
 import { colors, dimensions, typography, tokens } from '../design-system';
 import { CodeBlockMarkdownWrapper as CodeBlock } from './multi-code-block';
 
-const TypographyPage = styled.div`
-  font-family: ${typography.fontFamilies.primary};
-  font-size: ${typography.fontSizes.body};
-  font-weight: ${typography.fontWeights.regular};
-  line-height: 1.5;
-  word-spacing: 2px;
-
-  section > * + * {
-    margin-top: ${dimensions.spacings.m};
-  }
-`;
 const headerStyles = () => css`
   font-weight: ${typography.fontWeights.medium};
   line-height: 1.3;
@@ -62,46 +51,57 @@ const H6 = styled.h6`
   font-weight: ${typography.fontWeights.regular};
   line-height: 1.4;
 `;
+
+/*
+The "container" styles have to be applied to containers that render markdown inside a surrounding
+visual box like a blockquote, notification box, card, or Subtitle.
+Heading margins are not set here because headings can and should not be used inside such containers.
+*/
+const containerStyles = () => css`
+  > * + * {
+    margin-top: ${dimensions.spacings.m};
+    margin-bottom: ${dimensions.spacings.m};
+  }
+  > :first-child {
+    margin-top: 0;
+  }
+  > :last-child {
+    margin-bottom: 0;
+  }
+`;
+
 const ThematicBreak = styled.hr`
   display: none;
 `;
 const Blockquote = styled.blockquote`
+  ${containerStyles};
   background-color: ${colors.light.surfaceQuote};
   border-left: 1px solid ${colors.light.borderHighlight};
   border-radius: 0 ${tokens.borderRadiusForBlockquote}
     ${tokens.borderRadiusForBlockquote} 0;
   color: ${colors.light.textFaded};
   font-size: ${typography.fontSizes.small};
-  margin: ${dimensions.spacings.l} ${dimensions.spacings.xxl};
   padding: ${dimensions.spacings.xs} ${dimensions.spacings.s};
-
-  > :first-of-type {
-    margin-top: 0;
-  }
-  > :last-of-type {
-    margin-bottom: 0;
-  }
 `;
 const Ul = styled.ul`
-  margin: 0 0 ${dimensions.spacings.xxl};
   padding-left: ${dimensions.spacings.xl};
   > * + * {
     margin-top: ${dimensions.spacings.s};
   }
 `;
 const Ol = styled.ol`
-  margin: 0 0 ${dimensions.spacings.xxl};
   padding-left: ${dimensions.spacings.xl};
   > * + * {
     margin-top: ${dimensions.spacings.s};
   }
 `;
 const Li = styled.li`
+  ${containerStyles};
   line-height: 1.46;
 
   > ul,
   > ol {
-    margin: 0 0 ${dimensions.spacings.m};
+    margin: ${dimensions.spacings.s} 0 ${dimensions.spacings.m};
   }
 `;
 const Dl = styled.dl`
@@ -113,6 +113,7 @@ const Dt = styled.dt`
   color: ${colors.light.textSecondary};
 `;
 const Dd = styled.dd`
+  ${containerStyles}
   padding: 0 0 0 ${dimensions.spacings.l};
 
   > * + * {
@@ -184,6 +185,7 @@ const TableRow = styled.tr`
   }
 `;
 const TableCell = styled.td`
+  ${containerStyles};
   border-bottom: 1px solid ${colors.light.borderPrimary};
   font-size: ${typography.fontSizes.small};
   padding: ${dimensions.spacings.s};
@@ -203,6 +205,7 @@ const TableCell = styled.td`
   }
 `;
 const TableHeader = styled.th`
+  ${containerStyles};
   font-size: ${typography.fontSizes.small};
   padding: ${dimensions.spacings.s};
   text-align: left;
@@ -227,6 +230,28 @@ const Delete = styled.span`
   text-decoration: line-through;
 `;
 const Hr = styled(ThematicBreak)``;
+
+const TypographyPage = styled.div`
+  font-family: ${typography.fontFamilies.primary};
+  font-size: ${typography.fontSizes.body};
+  font-weight: ${typography.fontWeights.regular};
+  line-height: 1.5;
+  word-spacing: 2px;
+
+  section > * + * {
+    margin-top: ${dimensions.spacings.m};
+  }
+  section > ${Blockquote} {
+    margin: ${dimensions.spacings.l} ${dimensions.spacings.xxl};
+  }
+  section > ${Ul}, section > ${Ol} {
+    margin: ${dimensions.spacings.s} 0 ${dimensions.spacings.xxl};
+  }
+`;
+
+const TypographyContainer = styled.div`
+  ${containerStyles};
+`;
 
 /* eslint-disable react/display-name,react/prop-types */
 const withAnchorLink = (Component) => (props) => {
@@ -261,6 +286,7 @@ const withAnchorLink = (Component) => (props) => {
 
 export {
   TypographyPage,
+  TypographyContainer,
   Paragraph,
   H1,
   H2,

--- a/packages/ui-kit/src/components/multi-code-block.js
+++ b/packages/ui-kit/src/components/multi-code-block.js
@@ -6,10 +6,10 @@ import { colors, dimensions, typography, tokens } from '../design-system';
 import codeBlockParseOptions from '../utils/code-block-parse-options';
 import CodeBlock from './code-block';
 
-const Container = styled.div`
+// exported to be able to refer to it in conditional styling of wrapper components.
+export const Container = styled.div`
   border: 1px solid ${colors.light.surfaceCodeHighlight};
   border-radius: ${tokens.borderRadiusForCodeBlock};
-  margin: 0 0 ${dimensions.spacings.xxl};
 `;
 const Header = styled.div`
   background-color: ${colors.light.textPrimary};

--- a/packages/ui-kit/src/components/subtitle.js
+++ b/packages/ui-kit/src/components/subtitle.js
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 import { typography } from '../design-system';
+import { TypographyContainer } from './markdown';
 
-const Subtitle = styled.div`
+const Subtitle = styled(TypographyContainer)`
   font-size: ${typography.fontSizes.h3};
 `;
 

--- a/refactor-content-spacing.md
+++ b/refactor-content-spacing.md
@@ -1,8 +1,0 @@
----
-"@commercetools-docs/ui-kit": minor
-"@commercetools-website/docs-smoke-test": patch
----
-
-Markdown UI Kit: Refactor content spacing to be able to render markdown inside visual boxes using a new `TypographyContainer` wrapper.
-
-Markdown UI Kit: Adjust margins of lists

--- a/refactor-content-spacing.md
+++ b/refactor-content-spacing.md
@@ -1,0 +1,8 @@
+---
+"@commercetools-docs/ui-kit": minor
+"@commercetools-website/docs-smoke-test": patch
+---
+
+Markdown UI Kit: Refactor content spacing to be able to render markdown inside visual boxes using a new `TypographyContainer` wrapper.
+
+Markdown UI Kit: Adjust margins of lists

--- a/websites/docs-smoke-test/src/content/components/content-notifications.mdx
+++ b/websites/docs-smoke-test/src/content/components/content-notifications.mdx
@@ -23,8 +23,80 @@ A long text - lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer a
 
 </Error>
 
+<Info>(Default) With little content, no extra blank lines.</Info>
+
 <Info>
 
-(Default) With little content.
+* a bullet
+* list that should not have extra spacing
+
+</Info>
+
+<Info>
+
+1. an ordered
+1. list
+
+</Info>
+
+<Info>
+
+```md
+> a code block
+```
+
+</Info>
+
+<Info>
+
+A paragraph, followed by
+
+Another paragraph
+
+</Info>
+
+<Info>
+
+A paragraph, followed by
+
+> a block quote
+
+</Info>
+
+<Info>
+
+Table | Column B | Column C
+---------|----------|---------
+ A1 | B1 | C1
+ A2 | B2 | C2
+ A3 | B3 | C3
+
+</Info>
+
+<Info>
+
+Table | Column B | Column C
+---------|----------|---------
+ A1 | B1 | C1
+ A2 | B2 | C2
+ A3 | B3 | C3
+
+</Info>
+
+<Info>
+
+with a paragraph
+
+</Info>
+
+<Info>
+
+1. an ordered
+1. list
+
+* a bullet
+* list that should not have extra spacing
+
+a paragraph
 
 </Info>

--- a/websites/docs-smoke-test/src/content/components/content-notifications.mdx
+++ b/websites/docs-smoke-test/src/content/components/content-notifications.mdx
@@ -53,6 +53,8 @@ A paragraph, followed by
 
 Another paragraph
 
+Followed by another paragraph to see all situations
+
 </Info>
 
 <Info>


### PR DESCRIPTION
Resolves #451 

---

As a counterpart to the `TypographyPage` wrapper, the Markdown UI components now export a `TypographyContainer` wrapper which is supposed to be used in use cases like Cards, Notifications, Subtitle, Table Cells etc. - overall, in places where markdown content is rendered not in the main body flow but inside a visual enclosure. 

In such enclosures the standard spacing is too large and some of it (like bottom margins) should never applied at all.  

Spacing that is specific to the main page content typography is pulled out of the specific components into the wrappers.  

The TypographyPage wrapper is to be applied to Card content, too once merged

---

In addition, this makes a small adjustment to the spacing of nested lists and lists:  Lists previously had very different spacing to the content above them depending on whether they are a a sub-list in a list or a list in the top body content.  Esp. sub-lists looked like a bug because there was zero spacing. 

because tech writers demanded that lists be visually "Bounded" to the paragraph  above or parent list item, which is usually the name of the list,  they now have a small spacing in both situations. 
