### PR TITLE
refactor: render non string card body in typography container

### DIFF
--- a/.changeset/good-dryers-worry.md
+++ b/.changeset/good-dryers-worry.md
@@ -1,0 +1,6 @@
+---
+"@commercetools-docs/gatsby-theme-docs": minor
+"@commercetools-website/docs-smoke-test": patch
+---
+
+This change ensures non string contents of cards are rendered with appropriate styles.

--- a/packages/gatsby-theme-docs/src/components/card.js
+++ b/packages/gatsby-theme-docs/src/components/card.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import css from '@emotion/css';
-import { designSystem } from '@commercetools-docs/ui-kit';
+import { designSystem, Markdown } from '@commercetools-docs/ui-kit';
 import markdownFragmentToReact from '../utils/markdown-fragment-to-react';
 import Link from './link';
 
@@ -137,7 +137,11 @@ const Card = (props) => {
         : markdownFragmentToReact(props.children);
     }
 
-    return props.children;
+    return (
+      <Markdown.TypographyContainer>
+        {props.children}
+      </Markdown.TypographyContainer>
+    );
   }
 };
 

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -252,20 +252,24 @@ Icons on **narrow** cards are aligned to the left of the card regardless of whet
 
 ```jsx
 <Cards>
-  <Card title="Bullet List Body">
-    - Item 1
-    - Item 2
-    - Item 3
-  </Card>
+<Card title="Bullet List Body">
+
+* Item 1
+* Item 2
+* Item 3
+
+</Card>
 </Cards>
 ```
 
 <Cards>
-  <Card title="Bullet List Body">
-    - Item 1
-    - Item 2
-    - Item 3
-  </Card>
+<Card title="Bullet List Body">
+
+* Item 1
+* Item 2
+* Item 3
+
+</Card>
 </Cards>
 
 ## Link in Body of a Flat Card

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -319,26 +319,3 @@ Icons on **narrow** cards are aligned to the left of the card regardless of whet
     This [link](/views/code-blocks) should **not** render as a link.
   </Card>
 </Cards>
-
-
-# Embedded MDX in the Component Body
-
-The MDX spec and implementation allows for putting two blank lines to allow fully rendered markdown inside a JSX component. Because the cards must render markdown in the body differently than the same markdown would be rendered in the page body the implementation must either block the situation (for example detecting that the children aren't text but finished components) or override the renderer to use the MD fragment renderer instead.
-
-```jsx
-<Card>
-
-## Disallowed Subsection Heading
-This would render like the full page body and should be prevented or not done
-
-Even  | Tables |
-------|--------|
-would | work   |
-
-
-</Card>
-```
-
-**Output**
-
-(breaks the build until card is implemented)


### PR DESCRIPTION
This is a follow up to https://github.com/commercetools/commercetools-docs-kit/pull/454