### PR TITLE
fix: removes rss related warning of missing title when building

### DIFF
--- a/.changeset/spicy-hotels-buy.md
+++ b/.changeset/spicy-hotels-buy.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/gatsby-theme-docs": patch
+---
+
+fix: removes rss related warning of missing title when building

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -258,6 +258,7 @@ module.exports = (themeOptions = {}) => {
               }
             `,
               output: '/releases/feed.xml',
+              title: 'commercetools Release Notes',
             },
           ],
         },


### PR DESCRIPTION
Closes https://github.com/commercetools/commercetools-docs-kit/issues/449