### PR TITLE
Fix spacing and word wrap in child navigation and lists

### DIFF
--- a/.changeset/twenty-impalas-tease.md
+++ b/.changeset/twenty-impalas-tease.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+'@commercetools-docs/ui-kit': patch
+---
+
+Fix spacing above lists and inside the child section navigator

--- a/packages/gatsby-theme-docs/src/components/child-sections-nav.js
+++ b/packages/gatsby-theme-docs/src/components/child-sections-nav.js
@@ -10,7 +10,7 @@ const Container = styled.div`
   padding: ${designSystem.dimensions.spacings.m};
   border-radius: ${designSystem.tokens.borderRadiusForChildSectionNav};
   columns: auto ${designSystem.dimensions.widths.pageNavigationSmall};
-  column-gap: ${designSystem.dimensions.spacings.m};
+  column-gap: ${designSystem.dimensions.spacings.l};
 `;
 const ColumnContainer = styled.div`
   margin-bottom: ${designSystem.dimensions.spacings.s};
@@ -25,6 +25,7 @@ const Link = styled.a`
   font-size: ${designSystem.typography.fontSizes.extraSmall};
   color: ${designSystem.colors.light.textSecondary};
   text-decoration: none;
+  overflow-wrap: break-word;
   :hover {
     color: ${designSystem.colors.light.linkNavigation};
   }

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -262,7 +262,7 @@ const TypographyPage = styled.div`
     margin: ${dimensions.spacings.l} ${dimensions.spacings.xxl};
   }
   section > ${Ul}, section > ${Ol} {
-    margin: ${dimensions.spacings.s} 0 ${dimensions.spacings.xxl};
+    margin-bottom: ${dimensions.spacings.xxl};
   }
   section > ${CodeBlockContainer} {
     margin-bottom: ${dimensions.spacings.xxl};

--- a/websites/docs-smoke-test/src/content/views/two-level-index-nav.mdx
+++ b/websites/docs-smoke-test/src/content/views/two-level-index-nav.mdx
@@ -30,6 +30,8 @@ The navigation component below  is intended to be used for long lists of subsect
 
 <ChildSectionsNav parent="l2-subsection-21-deep"/>
 
+ * an unordered list below the component.
+
 ### L3 Sub-Subsection (no nav)
 
 Content.
@@ -38,7 +40,7 @@ Content.
 
 Content
 
-#### L4 Sub-Subsection (no nav)
+#### L4SubSubsectionWithAVeryVeryVeryWeirdlyLongTypeName (no nav)
 
 Content.
 
@@ -50,7 +52,7 @@ Content.
 
 Content.
 
-### L3 Sub-Subsection (no nav)
+### L3SubSubSectionWithAVeryWeirdlyLongTypeName (no nav)
 
 Content.
 


### PR DESCRIPTION
This addresses two issues

 * fixes a regression that gave lists too small top spacing (introduced when refactoring the spacing)
 * fixes problems with very long words in headings flowing into the next column in the child section navigator component
 * gives the child section navigator component more column gap to improve readability in nested scenarios. 