### PR TITLE
fix(theme): back to docs link from release notes pages

### DIFF
--- a/.changeset/bright-gorillas-chew.md
+++ b/.changeset/bright-gorillas-chew.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Fix back to docs link when in release notes pages

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -122,7 +122,7 @@ const SidebarLink = (props) => {
         return (
           <Link
             {...forwardProps}
-            to={trimTrailingSlash(props.to)}
+            to={props.to === '/' ? props.to : trimTrailingSlash(props.to)}
             getProps={({ href }) => {
               // Manually check that the link is the active one, even with trailing slashes.
               // The gatsby link is by default configured to match the exact path, therefore we


### PR DESCRIPTION
Otherwise we get an empty string as the link.