### PR TITLE
Use mdx transclusion in a tested page

### DIFF
--- a/websites/docs-smoke-test/src/content/views/markdown.mdx
+++ b/websites/docs-smoke-test/src/content/views/markdown.mdx
@@ -26,14 +26,9 @@ Second paragraph. _Italic_, **bold**, **_italic and bold_**, ~~strikethrough~~ a
 
 ## List items
 
-Itemized lists look like:
+import ListItems from "../../topics/list-items.mdx"
 
-- this one
-- that one
-- the other one
-
-Note that --- not considering the asterisk --- the actual text
-content starts at 4-columns in.
+<ListItems />
 
 ## Blockquotes
 
@@ -53,18 +48,10 @@ Blockquotes can be nested (that is a blockquote-in-a-blockquote) by adding addit
 
 Blockquotes can contain other Markdown elements, including headers, lists, and code blocks:
 
-> ## This is a header.
->
-> 1.  This is the first list item.
-> 2.  This is the second list item.
->
-> Here's some example code:
->
->     return shell_exec("echo $input | $markdown_script");
+import ComplexBlockQuote from "../../topics/complex-blockquote.mdx"
 
-Use 3 dashes for an em-dash. Use 2 dashes for ranges (ex., "it's all
-in chapters 12--14"). Three dots ... are converted to an ellipsis.
-Unicode is supported. ☺
+<ComplexBlockQuote />
+
 
 ## Subsection (first level)
 

--- a/websites/docs-smoke-test/src/topics/complex-blockquote.mdx
+++ b/websites/docs-smoke-test/src/topics/complex-blockquote.mdx
@@ -1,0 +1,12 @@
+> ## This is a header.
+>
+> 1.  This is the first list item.
+> 2.  This is the second list item.
+>
+> Here's some example code:
+>
+>     return shell_exec("echo $input | $markdown_script");
+
+Use 3 dashes for an em-dash. Use 2 dashes for ranges (ex., "it's all
+in chapters 12--14"). Three dots ... are converted to an ellipsis.
+Unicode is supported. ☺

--- a/websites/docs-smoke-test/src/topics/list-items.mdx
+++ b/websites/docs-smoke-test/src/topics/list-items.mdx
@@ -1,0 +1,8 @@
+Itemized lists look like:
+
+- this one
+- that one
+- the other one
+
+Note that --- not considering the asterisk --- the actual text
+content starts at 4-columns in.


### PR DESCRIPTION
This addresses #473 

It's working fine here but I'm still worried why I experience unformatted transcluded documents in the content repository when using a canary kit build.  