### PR TITLE
fix(theme): push footer to bottom, even when content is very short

### DIFF
--- a/.changeset/empty-walls-whisper.md
+++ b/.changeset/empty-walls-whisper.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Push footer to the page bottom, even when page content is very short

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
@@ -19,6 +19,7 @@ const Root = styled.div`
 `;
 const Container = styled.div`
   position: relative;
+  height: 100%;
   display: grid;
   grid:
     [row1-start] 'main' 1fr [row1-end]


### PR DESCRIPTION
<img width="2558" alt="image" src="https://user-images.githubusercontent.com/1110551/84127784-f9dea100-aa3f-11ea-8516-5ca0a7f6725d.png">
