### PR TITLE
refactor: allow cards to accept arbitrary children in non mdx files

### DIFF
--- a/.changeset/violet-numbers-begin.md
+++ b/.changeset/violet-numbers-begin.md
@@ -1,0 +1,7 @@
+---
+"@commercetools-docs/gatsby-theme-docs": patch
+---
+
+refactor: allow cards to accept arbitrary children in non mdx files
+
+The removed check fixes issues of UI elements breaking in some cases.

--- a/packages/gatsby-theme-docs/src/components/cards.js
+++ b/packages/gatsby-theme-docs/src/components/cards.js
@@ -40,12 +40,6 @@ const Cards = (props) => {
           ) {
             // this is created in mdx but it is not a card
             throwErrorMessage(child.props.mdxType);
-          } else if (
-            child.type.displayName !== 'MDXCreateElement' &&
-            child.type.name !== 'Card'
-          ) {
-            // this is not created in mdx but it is not a card
-            throwErrorMessage(child.type.name);
           }
 
           return React.cloneElement(


### PR DESCRIPTION
The removed check fixes issues of UI elements breaking in some cases.