### PR TITLE
Code Highlighting: tune syntax highlight color scheme

### DIFF
--- a/.changeset/sour-shirts-rest.md
+++ b/.changeset/sour-shirts-rest.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/ui-kit': minor
+---
+
+Optimize JSON syntax highlighting, tone down one color

--- a/packages/ui-kit/src/components/code-block.js
+++ b/packages/ui-kit/src/components/code-block.js
@@ -7,10 +7,10 @@ import { ThemeProvider } from 'emotion-theming';
 import Tooltip from '@commercetools-uikit/tooltip';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import { ClipboardIcon } from '@commercetools-uikit/icons';
-import themePrimary from 'prism-react-renderer/themes/nightOwl';
-import themeSecondary from 'prism-react-renderer/themes/nightOwlLight';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import { colors, dimensions, typography, tokens } from '../design-system';
+import themePrimary from '../prism-themes/commercetools';
+import themeSecondary from '../prism-themes/commercetoolsLight';
 import copyToClipboard from '../utils/copy-to-clipboard';
 
 const HighlightedContainer = styled.div`

--- a/packages/ui-kit/src/prism-themes/commercetools.js
+++ b/packages/ui-kit/src/prism-themes/commercetools.js
@@ -1,67 +1,35 @@
-import { colors } from '../design-system';
+import nightOwl from 'prism-react-renderer/themes/nightOwl';
 
-// This is a custom theme for Prism and it implements a minimal color palette
-// with commercetools colors.
-// The theme is inspired by "theme-ui" Prism preset: https://theme-ui.com/packages/prism#theme-ui-colors
-// NOTE: this theme is currently not used and is just here for reference in case we want
-// to experiment with it at some point.
-export default {
-  plain: {
-    color: colors.light.textPrimary,
-    backgroundColor: colors.light.surfacePrimary,
+const commercetoolsTheme = { ...nightOwl };
+
+// for the defaults see
+// https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/themes/nightOwl.js
+// current changes:
+// - less "neon" variation of the "string", new: rgb(192,228,139)
+// - swap "property" and "string"/"url"/"inserted"/"attr-name" to make typical code less "glaring"
+//   and to hightlight the property keys in JSON which eases understanding the structure.
+const additionalStyles = [
+  {
+    types: ['string', 'url'],
+    style: {
+      color: 'rgb(128, 203, 196)',
+    },
   },
-  styles: [
-    {
-      types: [
-        'comment',
-        'prolog',
-        'doctype',
-        'cdata',
-        'punctuation',
-        'operator',
-        'entity',
-        'url',
-      ],
-      style: {
-        color: colors.light.syntaxHighlightNeutral,
-      },
+  {
+    types: ['inserted', 'attr-name'],
+    style: {
+      color: 'rgb(128, 203, 196)',
+      fontStyle: 'italic',
     },
-    {
-      types: ['comment'],
-      style: {
-        fontStyle: 'italic',
-      },
+  },
+  {
+    types: ['property'],
+    style: {
+      color: 'rgb(192,228,139)',
     },
-    {
-      types: [
-        'property',
-        'tag',
-        'boolean',
-        'number',
-        'constant',
-        'symbol',
-        'deleted',
-        'function',
-        'class-name',
-        'regex',
-        'important',
-        'variable',
-      ],
-      style: {
-        color: colors.light.syntaxHighlightAccent,
-      },
-    },
-    {
-      types: ['atrule', 'attr-value', 'keyword'],
-      style: {
-        color: colors.light.syntaxHighlightPrimary,
-      },
-    },
-    {
-      types: ['selector', 'attr-name', 'string', 'char', 'builtin', 'inserted'],
-      style: {
-        color: colors.light.syntaxHighlightSecondary,
-      },
-    },
-  ],
-};
+  },
+];
+
+commercetoolsTheme.styles = [...nightOwl.styles, ...additionalStyles];
+
+export default commercetoolsTheme;

--- a/packages/ui-kit/src/prism-themes/commercetoolsLight.js
+++ b/packages/ui-kit/src/prism-themes/commercetoolsLight.js
@@ -1,0 +1,49 @@
+import nightOwlLight from 'prism-react-renderer/themes/nightOwlLight';
+
+const commercetoolsLightTheme = { ...nightOwlLight };
+
+// Goal: Optimize JSON, leave others alone.
+// variations:
+// - swap rgb(72, 118, 214)  and rgb(12, 150, 155) to have string literals
+//   in green in both light and dark because they occur side by side in API docs.
+// - booleans and numbers in a tone that's visually similar to the dark variant.
+const additionalStyles = [
+  {
+    types: ['operator', 'keyword', 'property', 'namespace'],
+    style: {
+      color: 'rgb(72, 118, 214)',
+    },
+  },
+  {
+    types: ['inserted', 'attr-name'],
+    style: {
+      color: 'rgb(12, 150, 155)',
+      fontStyle: 'italic',
+    },
+  },
+  {
+    types: ['string', 'builtin', 'char', 'constant', 'url'],
+    style: {
+      color: 'rgb(12, 150, 155)',
+    },
+  },
+  {
+    types: ['boolean'],
+    style: {
+      color: 'rgb(255, 20, 40)',
+    },
+  },
+  {
+    types: ['number'],
+    style: {
+      color: 'rgb(247, 70, 54)',
+    },
+  },
+];
+
+commercetoolsLightTheme.styles = [
+  ...commercetoolsLightTheme.styles,
+  ...additionalStyles,
+];
+
+export default commercetoolsLightTheme;

--- a/websites/docs-smoke-test/src/content/components/code-blocks.mdx
+++ b/websites/docs-smoke-test/src/content/components/code-blocks.mdx
@@ -20,17 +20,55 @@ Lorem ipsum dolor sit amet, his saepe graeci ne, quod expetenda nec te, at enim 
 
 **With highlighted lines**
 
-```json highlightLines="2"
+```json highlightLines="10"
 {
-  "name": "BB-8"
+  "glossary": {
+    "title": "example glossary",
+    "GlossDiv": {
+      "title": "S",
+      "GlossList": {
+        "GlossEntry": {
+          "ID": 123.45,
+          "Sort": true,
+          "GlossTerm": "Standard Generalized Markup Language",
+          "Acronym": "SGML",
+          "Abbrev": "ISO 8879:1986",
+          "GlossDef": {
+            "para": "A meta-markup language, used to create markup languages such as DocBook.",
+            "GlossSeeAlso": ["GML", "XML"]
+          },
+          "GlossSee": null
+        }
+      }
+    }
+  }
 }
 ```
 
 **With highlighted lines (secondary theme)**
 
-```json highlightLines="2" secondaryTheme
+```json highlightLines="10" secondaryTheme
 {
-  "name": "BB-8"
+  "glossary": {
+    "title": "example glossary",
+    "GlossDiv": {
+      "title": "S",
+      "GlossList": {
+        "GlossEntry": {
+          "ID": 123.45,
+          "Sort": true,
+          "GlossTerm": "Standard Generalized Markup Language",
+          "Acronym": "SGML",
+          "Abbrev": "ISO 8879:1986",
+          "GlossDef": {
+            "para": "A meta-markup language, used to create markup languages such as DocBook.",
+            "GlossSeeAlso": ["GML", "XML"]
+          },
+          "GlossSee": null
+        }
+      }
+    }
+  }
 }
 ```
 

--- a/websites/docs-smoke-test/src/content/views/code-blocks.mdx
+++ b/websites/docs-smoke-test/src/content/views/code-blocks.mdx
@@ -84,8 +84,8 @@ public class HelloWorldApp {
       "title": "S",
       "GlossList": {
         "GlossEntry": {
-          "ID": "SGML",
-          "SortAs": "SGML",
+          "ID": 123.45,
+          "Sort": true,
           "GlossTerm": "Standard Generalized Markup Language",
           "Acronym": "SGML",
           "Abbrev": "ISO 8879:1986",
@@ -93,7 +93,7 @@ public class HelloWorldApp {
             "para": "A meta-markup language, used to create markup languages such as DocBook.",
             "GlossSeeAlso": ["GML", "XML"]
           },
-          "GlossSee": "markup"
+          "GlossSee": null
         }
       }
     }


### PR DESCRIPTION
 - swap the "neon" yellow for a less agressive one provided by design
 - swap two colors to improve JSON understandability
  - homogenize numbers and bools across light / dark to ease JSON understandability

@sven this is the experimental implementation of the color code you sent me plus improving the test examples plus a try to slightly homogenize the _JSON_  highlighting across light and dark. 

JSON is 80% of the example content that is initially read and seen so optimizing for JSON stands before other languages. 

(I'll send a deeplink to the test once it's built)