### PR TITLE
chore: use version range for peer deps

### DIFF
--- a/.changeset/calm-wasps-begin.md
+++ b/.changeset/calm-wasps-begin.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-docs/gatsby-theme-api-docs': patch
+'@commercetools-docs/gatsby-theme-code-examples': patch
+'@commercetools-docs/gatsby-theme-constants': patch
+---
+
+Use version range for gatsby docs peer deps

--- a/packages/gatsby-theme-api-docs/package.json
+++ b/packages/gatsby-theme-api-docs/package.json
@@ -36,7 +36,7 @@
     "react-dom": "16.13.1"
   },
   "peerDependencies": {
-    "@commercetools-docs/gatsby-theme-docs": "7.0.0",
+    "@commercetools-docs/gatsby-theme-docs": "7.x",
     "@emotion/core": "10.x",
     "@emotion/styled": "10.x",
     "gatsby": "2.x",

--- a/packages/gatsby-theme-code-examples/package.json
+++ b/packages/gatsby-theme-code-examples/package.json
@@ -29,7 +29,7 @@
     "react-dom": "16.13.1"
   },
   "peerDependencies": {
-    "@commercetools-docs/gatsby-theme-docs": "7.0.0",
+    "@commercetools-docs/gatsby-theme-docs": "7.x",
     "gatsby": "2.x",
     "gatsby-source-filesystem": "2.x",
     "react": "16.x",

--- a/packages/gatsby-theme-constants/package.json
+++ b/packages/gatsby-theme-constants/package.json
@@ -26,7 +26,7 @@
     "react-dom": "16.13.1"
   },
   "peerDependencies": {
-    "@commercetools-docs/gatsby-theme-docs": "7.0.0",
+    "@commercetools-docs/gatsby-theme-docs": "7.x",
     "gatsby": "2.x",
     "react": "16.x",
     "react-dom": "16.x"


### PR DESCRIPTION
Might be related to what we observed about a major version being bumped.
Possible related issue: https://github.com/atlassian/changesets/issues/380