### PR TITLE
Remove unnecessary date filter from RSS feed query

### DIFF
--- a/.changeset/dirty-kids-walk.md
+++ b/.changeset/dirty-kids-walk.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/ui-kit': patch
+---
+
+Don't wrap the date in RSS feed component

--- a/.changeset/odd-flowers-jump.md
+++ b/.changeset/odd-flowers-jump.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Fix RSS feeds being empty in some sites

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -246,7 +246,7 @@ module.exports = (themeOptions = {}) => {
               query: `
               {
                 allReleaseNotePage(
-                  limit: 5, sort: { order: DESC, fields: date }, filter: {date: {gt: "1999-01-01"}},
+                  limit: 5, sort: { order: DESC, fields: date },
                 ) {
                     nodes {
                       description

--- a/packages/ui-kit/src/components/rss-feeds.js
+++ b/packages/ui-kit/src/components/rss-feeds.js
@@ -41,6 +41,10 @@ const Table = styled.table`
   }
 `;
 
+const DateWrapper = styled.span`
+  white-space: nowrap;
+`;
+
 const RssFeeds = (props) => {
   if (!props.url) {
     const message = 'Must pass prop url to RssFeeds component.';
@@ -84,14 +88,16 @@ const RssFeeds = (props) => {
             {data.items.map((item, index) => (
               <tr key={`${item.title}${index}`}>
                 <td>
-                  <Link
-                    href={item.link}
-                    css={css`
-                      text-decoration: none;
-                    `}
-                  >
-                    {moment(item.pubDate).format('D MMMM YYYY')}
-                  </Link>
+                  <DateWrapper>
+                    <Link
+                      href={item.link}
+                      css={css`
+                        text-decoration: none;
+                      `}
+                    >
+                      {moment(item.pubDate).format('D MMMM YYYY')}
+                    </Link>
+                  </DateWrapper>
                 </td>
                 <td>{item.title}</td>
               </tr>

--- a/websites/docs-smoke-test/src/content/components/rss-feeds.mdx
+++ b/websites/docs-smoke-test/src/content/components/rss-feeds.mdx
@@ -6,9 +6,6 @@ import { RssFeeds } from '@commercetools-docs/ui-kit'
 
 # Release Notes
 
-<RssFeeds url="https://new-commercetools-docs.now.sh/api/releases/feed.xml" />
+<Info>The RSS feed is only generated in production builds so this test fails in development mode.</Info>
 
-<RssFeeds
-  url="https://new-commercetools-docs.now.sh/merchant-center/releases/feed.xml"
-  title="Merchant Center"
-/>
+<RssFeeds url="/docs-smoke-test/releases/feed.xml" />


### PR DESCRIPTION
fixes #589 

 * the starting from filter for RSS feeds was only an artifact from development setups.  It caused issues because GatsbyJS or MDX seems to be unstable concerning date parsing in YAML frontmatter.  Gatsby releases switch back and forth between parsing as date or not. 
 * changes the VRT setup to point to a stable feed (the local one of the test site) that does never change. 
 * avoids breaking line inside the date to provide stable layouts independent of the text content of the RSS feed (still readable  enough in mobile views.
 