### PR TITLE
writing-style: upgrade to vale 2.3.4, new vscode plugin

### DIFF
--- a/.changeset/gold-mayflies-marry.md
+++ b/.changeset/gold-mayflies-marry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/writing-style': patch
+---
+
+updated vale version 2.3.4

--- a/jest.text.config.js
+++ b/jest.text.config.js
@@ -2,7 +2,7 @@ module.exports = {
   runner: 'jest-runner-executor',
   displayName: 'vale',
   moduleFileExtensions: ['md', 'mdx'],
-  modulePathIgnorePatterns: ['fixtures', 'CHANGELOG.md'],
+  modulePathIgnorePatterns: ['fixtures', 'CHANGELOG.md', 'vale-bin'],
   testMatch: ['**/*.md', '**/*.mdx'],
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-master'],
 };

--- a/packages/writing-style/.gitignore
+++ b/packages/writing-style/.gitignore
@@ -1,3 +1,2 @@
 *.zip
 *.tar.gz
-vale-*

--- a/packages/writing-style/package.json
+++ b/packages/writing-style/package.json
@@ -2,7 +2,7 @@
   "name": "@commercetools-docs/writing-style",
   "description": "Wrapped and preconfigured vale linter for the commercetools writing style rules",
   "version": "3.0.0",
-  "valeVersion": "2.1.1",
+  "valeVersion": "2.3.4",
   "license": "MIT",
   "private": false,
   "publishConfig": {

--- a/packages/writing-style/scripts/download-vale.js
+++ b/packages/writing-style/scripts/download-vale.js
@@ -29,7 +29,7 @@ const localBinaryFileName = isWin
   ? `vale-${valeVersion}.exe`
   : `vale-${valeVersion}`;
 const archivePath = path.join(__dirname, `../${archiveName}`);
-const binPath = path.join(__dirname, '../');
+const binPath = path.join(__dirname, '../vale-bin/');
 const downloadBinaryPath = path.join(binPath, binaryFileName);
 const destBinaryPath = path.join(binPath, localBinaryFileName);
 

--- a/packages/writing-style/src/run.js
+++ b/packages/writing-style/src/run.js
@@ -6,7 +6,7 @@ const { valeVersion } = require('../package.json');
 const binaryFileName =
   os.platform() === 'win32' ? `vale-${valeVersion}.exe` : `vale-${valeVersion}`;
 
-const valeBinary = path.join(__dirname, `../${binaryFileName}`);
+const valeBinary = path.join(__dirname, `../vale-bin/${binaryFileName}`);
 
 function run(commandArgs) {
   return spawn(valeBinary, commandArgs, {

--- a/packages/writing-style/vale-bin/.gitignore
+++ b/packages/writing-style/vale-bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/recommended.code-workspace
+++ b/recommended.code-workspace
@@ -38,13 +38,9 @@
         ]
       }
     },
-    "vscode-vale.path": "${workspaceFolder}/node_modules/.bin/commercetools-vale-bin",
-    "vscode-vale.configPath": "${workspaceFolder}/packages/writing-style/.vale.ini",
-    "vscode-vale.fileExtensions": [
-      "md",
-      "markdown",
-      "mdx"
-    ],
+    "vale.core.useCLI": true,
+    "vale.valeCLI.path": "${workspaceFolder}/node_modules/.bin/commercetools-vale-bin",
+    "vale.valeCLI.config": "${workspaceFolder}/node_modules/@commercetools-docs/writing-style/.vale.ini",
     "spellright.notificationClass": "warning",
     "spellright.language": [
       "en"
@@ -68,7 +64,7 @@
       "ms-vscode.vscode-typescript-tslint-plugin",
       "redhat.vscode-yaml",
       "silvenon.mdx",
-      "testthedocs.vale"
+      "errata-ai.vale-server"
     ]
   }
 }


### PR DESCRIPTION
 * adjust the vscode workspace config to new plugin
 * updates the vale version to latest (a lot of text parsing robustness has happened in the last months)

vale started to include license and readme into the release archives.
To avoid overwriting our own readme and license, the vale distribution now lives in a subfolder again