### PR TITLE
auto-generate src/images/releases directory

### DIFF
--- a/.changeset/calm-masks-hunt.md
+++ b/.changeset/calm-masks-hunt.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Auto-generate `src/images/releases` directory. Authors/contributors would be directed to this directory when they need to use an image in a release note.

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -22,6 +22,7 @@ exports.onPreBootstrap = (gatsbyApi, themeOptions) => {
   const requiredDirectories = [
     'src/data',
     'src/images',
+    'src/images/releases',
     'src/content',
     'src/content/files',
     'src/releases',


### PR DESCRIPTION
For authors, all release notes images must go into the `src/images/releases` directory. So this change addresses that need.