### PR TITLE
fix(writing-style): vale binary installation

### DIFF
--- a/.changeset/pretty-suns-love.md
+++ b/.changeset/pretty-suns-love.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/writing-style': patch
+---
+
+Fix vale binary download

--- a/packages/writing-style/.gitignore
+++ b/packages/writing-style/.gitignore
@@ -1,3 +1,2 @@
 *.zip
 *.tar.gz
-vale-*

--- a/packages/writing-style/scripts/download-vale.js
+++ b/packages/writing-style/scripts/download-vale.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
@@ -49,6 +50,8 @@ const downloadAndExtractArchive = async (url) => {
     });
     fileStream.on('finish', resolve);
   });
+
+  shelljs.mkdir('-p', binPath);
 
   // Extract the vale binary from the downloaded archive into the "bin" folder
   const extractCommand = isWin


### PR DESCRIPTION
Caused by #665 

```
error /xxx/node_modules/@commercetools-docs/writing-style: Command failed.
Exit code: 1
Command: node scripts/download-vale.js
Arguments: 
Directory: /xxx/node_modules/@commercetools-docs/writing-style
Output:
[writing-styles] Verifying vale installation...
[writing-styles] Installing vale 2.3.4 ...
[writing-styles] Error installing vale binary Error: tar: could not chdir to '/xxx/node_modules/@commercetools-docs/writing-style/vale-bin/'


    at abortIfError (/xxx/node_modules/@commercetools-docs/writing-style/scripts/download-vale.js:38:11)
    at downloadAndExtractArchive (/xxx/node_modules/@commercetools-docs/writing-style/scripts/download-vale.js:58:3)
```