### PR TITLE
refactor(linkinator): exclude static assets from being checked

### DIFF
--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -2,6 +2,7 @@
   "recurse": true,
   "silent": true,
   "skip": [
+    ".(json|js|png|jpg|svg|css)(\\?(.*)+)?$",
     "https://docs.commercetools.com",
     "https://commercetools.com/",
     "https://support.commercetools.com",


### PR DESCRIPTION
I don't think it makes sense to include in the link checker the static assets generated by Gatsby. For example:

```
  [SKP] http://localhost:5757/docs-smoke-test/component---packages-gatsby-theme-docs-src-templates-release-notes-list-js-906fbc4cbdfdc28f1849.js
  [SKP] http://localhost:5757/docs-smoke-test/page-data/releases/page-data.json
  [SKP] http://localhost:5757/docs-smoke-test/page-data/sq/d/590814825.json
  [SKP] http://localhost:5757/docs-smoke-test/static/587804a5968509430a052a1d8f11f257/47498/1200x300.jpg
  [SKP] http://localhost:5757/docs-smoke-test/static/29b5057b12f2e61e010113a49551d5e0/79056/transparent-bkg.png
  [SKP] http://localhost:5757/docs-smoke-test/static/03fedb3125cfc6d36d3de3a46a7434bf/f836f/200.jpg
  [SKP] http://localhost:5757/docs-smoke-test/static/587804a5968509430a052a1d8f11f257/5a944/1200x300.jpg
```