### PR TITLE
fix(theme): render links for static files as static HTML links

### DIFF
--- a/.changeset/seven-glasses-admire.md
+++ b/.changeset/seven-glasses-admire.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+'@commercetools-website/docs-smoke-test': patch
+---
+
+Fix rendering of links for static files as static HTML links

--- a/cypress/integration/docs-smoke-test/links.js
+++ b/cypress/integration/docs-smoke-test/links.js
@@ -12,6 +12,59 @@ const scenarios = [
     },
   },
   {
+    title: 'Link pointing to static files',
+    expectationMessage:
+      'It renders a static link to the given file "hello.txt"',
+    linkSelector: () => {
+      // See how to test external domains: https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__tab-handling-links/cypress/integration/tab_handling_anchor_links_spec.js
+      cy.get('a')
+        .eq(1)
+        .contains('Link')
+        .should(
+          'have.prop',
+          'href',
+          `${Cypress.config().baseUrl}${URL_DOCS_SMOKE_TEST}downloads/hello.txt`
+        );
+    },
+    expected: {},
+  },
+  {
+    title: 'Link pointing to static files',
+    expectationMessage:
+      'It renders a static link to the given file "hello.json"',
+    linkSelector: () => {
+      // See how to test external domains: https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__tab-handling-links/cypress/integration/tab_handling_anchor_links_spec.js
+      cy.get('a')
+        .eq(2)
+        .contains('Link')
+        .should(
+          'have.prop',
+          'href',
+          `${
+            Cypress.config().baseUrl
+          }${URL_DOCS_SMOKE_TEST}downloads/hello.json`
+        );
+    },
+    expected: {},
+  },
+  {
+    title: 'Link pointing to static files',
+    expectationMessage:
+      'It renders a static link to the given file "hello.html"',
+    linkSelector: () => {
+      // See how to test external domains: https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__tab-handling-links/cypress/integration/tab_handling_anchor_links_spec.js
+      cy.get('a')
+        .eq(3)
+        .contains('Link')
+        .should(
+          'have.prop',
+          'href',
+          `${Cypress.config().baseUrl}${URL_DOCS_SMOKE_TEST}html/hello.html`
+        );
+    },
+    expected: {},
+  },
+  {
     title: 'Link pointing to a different website',
     expectationMessage:
       'It should work and be an OutboundLink that tracks via google analytics',

--- a/cypress/integration/docs-smoke-test/static-pages.js
+++ b/cypress/integration/docs-smoke-test/static-pages.js
@@ -1,0 +1,13 @@
+import { URL_DOCS_SMOKE_TEST } from '../../support/urls';
+import { isCI } from '../../support/env';
+
+if (isCI) {
+  // NOTE: serving static HTML pages does not work in development mode.
+  // https://github.com/gatsbyjs/gatsby/issues/13072
+  describe('rendering static HTML pages', () => {
+    it('/html/hello.html', () => {
+      cy.visit(`${URL_DOCS_SMOKE_TEST}html/hello.html`);
+      cy.findByText('Hello World!').should('exist');
+    });
+  });
+}

--- a/packages/gatsby-theme-docs/README.md
+++ b/packages/gatsby-theme-docs/README.md
@@ -46,13 +46,15 @@ The project structure should contain at least the following files and folders:
 ├── .eslintrc.yml
 ├── gatsby-config.js
 ├── package.json
-└── src
-    ├── content
-    │   ├── files
-    │   └── index.mdx
-    ├── images
-    └── data
-        └── navigation.yaml
+├── src
+│   ├── content
+│   │   ├── files
+│   │   └── index.mdx
+│   ├── images
+│   └── data
+│       └── navigation.yaml
+└── static
+    └── downloads
 ```
 
 - `.eslintrc.yaml`: in case you're using a monorepository, you need to provide this file with an empty object `{}`, otherwise provide a valid ESLint configuration.
@@ -148,6 +150,11 @@ These are required directories:
       # another page, and so on...
   - chapter-title: {} # another chapter, and so on...
   ```
+
+- `static`: this folder should contain files that do not need to be processed by Gatsby and will be served as-is. See [Gatsby static folder](https://www.gatsbyjs.com/docs/static-folder/).<br/>
+  Note that any `.html` file that is referenced as a link within the `*.mdx` content files is opened as a "static" HTML link, so when clicking on it the browser opens the link as a normal page.
+
+- `static/downloads`: this folder should contain static files that can be referenced in the links within the `*.mdx` content files. All links starting with `/downloads` will be rendered as "static" HTML links, so when clicking on it the browser opens the link as a normal page.
 
 ## Writing Content Pages
 

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -26,6 +26,8 @@ exports.onPreBootstrap = (gatsbyApi, themeOptions) => {
     'src/content',
     'src/content/files',
     'src/releases',
+    'static',
+    'static/downloads',
   ];
   requiredDirectories.forEach((dir) => {
     if (!fs.existsSync(dir)) {

--- a/packages/gatsby-theme-docs/src/components/link.js
+++ b/packages/gatsby-theme-docs/src/components/link.js
@@ -108,6 +108,7 @@ const PureLink = (extendedProps) => {
     siteData.pathPrefix
   );
   const hrefWithoutPrefix = withoutPrefix(props.href, siteData.pathPrefix);
+
   // Construct an URL object for the given `href` and provide a "dummy" base origin
   // from the current website location url with the sole purpose of resolving
   // the correct pathname in case the `href` is a filesystem-relative path.
@@ -116,7 +117,22 @@ const PureLink = (extendedProps) => {
     `https://${dummyHostname}${pathnameWithoutPrefix}${location.hash || ''}`
   );
 
-  // Case 1: the link points to an external website.
+  // Case 1: the link points to a static file/page, so it should not be processed by Gatsby.
+  // Note that all files that should be served statically MUST be defined in the `/static` folder
+  // of the website.
+  // As a convention, we only match links to those files that respect the following rules:
+  // - the files are within the `/downloads` folder
+  // - any HTML file (file path ending with `.html`)
+  if (
+    hrefObject.pathname.startsWith('/downloads') ||
+    // NOTE: serving static HTML pages does not work in development mode.
+    // https://github.com/gatsbyjs/gatsby/issues/13072
+    hrefObject.pathname.endsWith('.html')
+  ) {
+    return <StyledExternalSiteLink {...props} data-link-type="static-link" />;
+  }
+
+  // Case 2: the link points to an external website.
   const isExternalLink =
     /^https?/.test(props.href) || (props.target && props.target === '_blank');
   if (
@@ -156,7 +172,7 @@ const PureLink = (extendedProps) => {
     );
   }
 
-  // Case 2: the link points to the exact same page. We use only the `hash` parameter
+  // Case 3: the link points to the exact same page. We use only the `hash` parameter
   // to avoids Gatsby to add the `pathPrefix`.
   const isAnchorLink = hrefWithoutPrefix.startsWith('#');
   const isLinkToSamePage = hrefObject.pathname === pathnameWithoutPrefix;
@@ -173,7 +189,7 @@ const PureLink = (extendedProps) => {
     );
   }
 
-  // Case 3: the link points to the same site but to a different page. We use the Gatsby link
+  // Case 4: the link points to the same site but to a different page. We use the Gatsby link
   // to take advantage of the history navigation.
   const isUsingUndocumentedNotationToLinkToAnotherDocsSite = hrefWithoutPrefix.startsWith(
     '/../'

--- a/packages/gatsby-theme-docs/src/components/link.spec.js
+++ b/packages/gatsby-theme-docs/src/components/link.spec.js
@@ -39,6 +39,18 @@ describe('rendering', () => {
       expected: { 'data-link-type': 'image-link' },
     },
     {
+      title: 'static link in /downloads folder',
+      props: { href: '/downloads/hello.html' },
+      location: { pathname: '/page-1' },
+      expected: { 'data-link-type': 'static-link' },
+    },
+    {
+      title: 'static link ending with .html',
+      props: { href: '/any/folder/hello.html' },
+      location: { pathname: '/page-1' },
+      expected: { 'data-link-type': 'static-link' },
+    },
+    {
       title: 'external link',
       props: {
         href: 'https://github.com/commercetools/commercetools-docs-kit',

--- a/websites/docs-smoke-test/src/content/views/links.mdx
+++ b/websites/docs-smoke-test/src/content/views/links.mdx
@@ -126,6 +126,20 @@ title: Links
 | -------------------------- | --------------- | ------------------------------------------------------------ |
 | [Link](/../site-template/) | `internal-link` | It should be a normal html link (only in `production` mode). |
 
+### Link pointing to static files
+
+```md
+[Link](/downloads/hello.txt)
+[Link](/downloads/hello.json)
+[Link](/html/hello.html)
+```
+
+| Link     | Type          | Expected outcome                           |
+| -------- | ------------- | ------------------------------------------ |
+| [Link](/downloads/hello.txt) | `static-link` | It renders a normal HTML link pointing to the `hello.txt` page |
+| [Link](/downloads/hello.json) | `static-link` | It renders a normal HTML link pointing to the `hello.json` page |
+| [Link](/html/hello.html) | `static-link` | It renders a normal HTML link pointing to the `hello.html` page (HTML pages do not work in development mode) |
+
 ## Last Heading
 
 This paragraph just serves as a link target. The Anchor ID should be `#last-heading`

--- a/websites/docs-smoke-test/static/downloads/hello.json
+++ b/websites/docs-smoke-test/static/downloads/hello.json
@@ -1,0 +1,1 @@
+{"message": "Hello World"}

--- a/websites/docs-smoke-test/static/downloads/hello.txt
+++ b/websites/docs-smoke-test/static/downloads/hello.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/websites/docs-smoke-test/static/html/hello.html
+++ b/websites/docs-smoke-test/static/html/hello.html
@@ -1,0 +1,10 @@
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hello HTML page</title>
+</head>
+<body>
+  Hello World!
+</body>
+</html>


### PR DESCRIPTION
Fixes #680 

> Note that serving static `.html` pages does not work in development mode. See https://github.com/gatsbyjs/gatsby/issues/13072

This PR settle on a convention that links referencing files, according to the following rules, are rendered as "static" HTML links.

- all files within the `/downloads` folder
- any HTML file (file path ending with `.html`)

Those files MUST be located in the `static` folder (https://www.gatsbyjs.com/docs/static-folder/).

> In the API docs, we already have the files located in the `static` folder.