### PR TITLE
fix: stop duplicating release note pages as content pages

### DIFF
--- a/.changeset/calm-suns-crash.md
+++ b/.changeset/calm-suns-crash.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+'@commercetools-docs/gatsby-theme-docs': patch
 ---
 
 fix: stop duplicating release note pages as content pages

--- a/.changeset/calm-suns-crash.md
+++ b/.changeset/calm-suns-crash.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools-docs/gatsby-theme-docs': patch
+"@commercetools-docs/gatsby-theme-docs": patch
 ---
 
 fix: stop duplicating release note pages as content pages

--- a/.changeset/calm-suns-crash.md
+++ b/.changeset/calm-suns-crash.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix: stop duplicating release note pages as content pages

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -246,6 +246,7 @@ exports.onCreateNode = (
       parent,
       child: node,
     });
+    return;
   }
 
   // If not explicitly handled, always fall back to build the page as a "content" page.


### PR DESCRIPTION
Fixes https://github.com/commercetools/commercetools-docs-kit/issues/704