### PR TITLE
chore: add directory in repository field for each package

### DIFF
--- a/packages/gatsby-theme-api-docs/package.json
+++ b/packages/gatsby-theme-api-docs/package.json
@@ -10,7 +10,8 @@
   "bugs": "https://github.com/commercetools/commercetools-docs-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/commercetools-docs-kit.git"
+    "url": "https://github.com/commercetools/commercetools-docs-kit.git",
+    "directory": "packages/gatsby-theme-api-docs"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-theme-code-examples/package.json
+++ b/packages/gatsby-theme-code-examples/package.json
@@ -10,7 +10,8 @@
   "bugs": "https://github.com/commercetools/commercetools-docs-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/commercetools-docs-kit.git"
+    "url": "https://github.com/commercetools/commercetools-docs-kit.git",
+    "directory": "packages/gatsby-theme-code-examples"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-theme-constants/package.json
+++ b/packages/gatsby-theme-constants/package.json
@@ -1,13 +1,18 @@
 {
   "name": "@commercetools-docs/gatsby-theme-constants",
+  "description": "Gatsby theme for commercetools documentation providing the functionalities to render constants values in MDX defined in configuration files",
   "version": "9.0.0",
   "license": "MIT",
   "private": false,
   "publishConfig": {
     "access": "public"
   },
-  "description": "Gatsby theme for commercetools documentation providing the functionalities to render constants values in MDX defined in configuration files",
-  "homepage": "https://github.com/commercetools/commercetools-docs-kit/tree/master/packages/gatsby-theme-constants",
+  "bugs": "https://github.com/commercetools/commercetools-docs-kit/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/commercetools-docs-kit.git",
+    "directory": "packages/gatsby-theme-constants"
+  },
   "keywords": [
     "gatsby",
     "gatsby-plugin",

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -10,7 +10,8 @@
   "bugs": "https://github.com/commercetools/commercetools-docs-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/commercetools-docs-kit.git"
+    "url": "https://github.com/commercetools/commercetools-docs-kit.git",
+    "directory": "packages/gatsby-theme-docs"
   },
   "dependencies": {
     "@commercetools-docs/ui-kit": "9.0.0",

--- a/packages/gatsby-transformer-mdx-introspection/package.json
+++ b/packages/gatsby-transformer-mdx-introspection/package.json
@@ -1,20 +1,23 @@
 {
   "name": "@commercetools-docs/gatsby-transformer-mdx-introspection",
+  "description": "Exposes what JSX component tags are placed on what MDX page with what attributes",
   "version": "3.0.5",
   "license": "MIT",
   "private": false,
-  "description": "Exposes what JSX component tags are placed on what MDX page with what attributes",
   "publishConfig": {
     "access": "public"
   },
-  "author": "commercetools GmbH <support@commercetools.com>",
-  "homepage": "https://github.com/commercetools/commercetools-docs-kit/tree/master/packages/gatsby-transformer-mdx-introspection#readme",
+  "bugs": "https://github.com/commercetools/commercetools-docs-kit/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/commercetools-docs-kit.git",
+    "directory": "packages/gatsby-transformer-mdx-introspection"
+  },
   "keywords": [
     "gatsby",
     "gatsby-plugin",
     "mdx"
   ],
-  "scripts": {},
   "dependencies": {
     "@babel/parser": "7.12.3",
     "@mdx-js/mdx": "1.6.18",

--- a/packages/gatsby-transformer-raml-legacy/package.json
+++ b/packages/gatsby-transformer-raml-legacy/package.json
@@ -1,16 +1,19 @@
 {
   "name": "@commercetools-docs/gatsby-transformer-raml-legacy",
+  "description": "Exposes RAML 1.0 APIs on the gatsbyJS GraphQL (using the legacy RAML JS parser)",
   "version": "3.0.2",
   "license": "MIT",
   "private": false,
   "publishConfig": {
     "access": "public"
   },
-  "description": "Exposes RAML 1.0 APIs on the gatsbyJS GraphQL (using the legacy RAML JS parser)",
-  "author": "commercetools GmbH <support@commercetools.com>",
-  "homepage": "https://github.com/commercetools/commercetools-docs-kit/tree/master/packages/gatsby-transformer-raml-legacy#readme",
+  "bugs": "https://github.com/commercetools/commercetools-docs-kit/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/commercetools-docs-kit.git",
+    "directory": "packages/gatsby-transformer-raml-legacy"
+  },
   "keywords": ["gatsby", "gatsby-plugin", "raml", "deprecated"],
-  "scripts": {},
   "dependencies": {
     "firstline": "^2.0.2",
     "raml-1-parser": "^1.1.52",

--- a/packages/gatsby-transformer-raml/package.json
+++ b/packages/gatsby-transformer-raml/package.json
@@ -1,21 +1,24 @@
 {
   "name": "@commercetools-docs/gatsby-transformer-raml",
+  "description": "Exposes RAML 1.0 APIs on the gatsbyJS GraphQL",
   "version": "9.0.0",
   "license": "MIT",
   "private": false,
   "publishConfig": {
     "access": "public"
   },
-  "description": "Exposes RAML 1.0 APIs on the gatsbyJS GraphQL",
-  "author": "commercetools GmbH <support@commercetools.com>",
-  "homepage": "https://github.com/commercetools/commercetools-docs-kit/tree/master/packages/gatsby-transformer-raml#readme",
+  "bugs": "https://github.com/commercetools/commercetools-docs-kit/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/commercetools-docs-kit.git",
+    "directory": "packages/gatsby-transformer-raml"
+  },
   "keywords": [
     "gatsby",
     "gatsby-plugin",
     "gatsby-transformer",
     "raml"
   ],
-  "scripts": {},
   "dependencies": {
     "firstline": "^2.0.2",
     "js-yaml": "^3.13.1"

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -10,7 +10,8 @@
   "bugs": "https://github.com/commercetools/commercetools-docs-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/commercetools-docs-kit.git"
+    "url": "https://github.com/commercetools/commercetools-docs-kit.git",
+    "directory": "packages/ui-kit"
   },
   "main": "./dist/ui-kit.cjs.js",
   "module": "./dist/ui-kit.es.js",

--- a/packages/writing-style/package.json
+++ b/packages/writing-style/package.json
@@ -11,7 +11,8 @@
   "bugs": "https://github.com/commercetools/commercetools-docs-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/commercetools-docs-kit.git"
+    "url": "https://github.com/commercetools/commercetools-docs-kit.git",
+    "directory": "packages/writing-style"
   },
   "bin": {
     "commercetools-vale": "./bin/commercetools-vale.js",


### PR DESCRIPTION
To keep things consistent, and to point to the directory of the monorepo where the package lives