### PR TITLE
feat(renovate): group all packages from uikit monorepo for major releases

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -7,6 +7,10 @@
   "separateMajorMinor": true,
   "packageRules": [
     {
+      "sourceUrlPrefixes": ["https://github.com/commercetools/ui-kit"],
+      "groupName": "all ui-kit packages"
+    },
+    {
       "packagePatterns": [
         "*"
       ],


### PR DESCRIPTION
To group major updates of some of our CT monorepositories, for example [like here](https://github.com/commercetools/merchant-center-graphql-explorer/pull/59).

https://docs.renovatebot.com/configuration-options/#sourceurlprefixes