### PR TITLE
fix: broken links to release notes samples

### DIFF
--- a/.changeset/afraid-coins-deliver.md
+++ b/.changeset/afraid-coins-deliver.md
@@ -1,5 +1,0 @@
----
-"@commercetools-docs/gatsby-theme-docs": patch
----
-
-fix: broken links to release notes samples

--- a/.changeset/afraid-coins-deliver.md
+++ b/.changeset/afraid-coins-deliver.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/gatsby-theme-docs": patch
+---
+
+fix: broken links to release notes samples

--- a/packages/gatsby-theme-docs/README.md
+++ b/packages/gatsby-theme-docs/README.md
@@ -214,7 +214,7 @@ The available JSX components are:
 
 Release notes files follow a different specification and their file location does not imply the URL so they can be reorganized without changing the permanent release note URL.
 
-Take a look at [typical example template](../websites/docs-smoke-test/src/releases/release-note-template.mdx) or read the [specification by example file](../websites/docs-smoke-test/src/releases/release-format-definition.mdx) to learn the complete format.
+Take a look at [typical example template](../../websites/docs-smoke-test/src/releases/release-note-template.mdx) or read the [specification by example file](../../websites/docs-smoke-test/src/releases/release-format-definition.mdx) to learn the complete format.
 
 ## Using Theme with Add-Ons
 


### PR DESCRIPTION
Closes https://github.com/commercetools/commercetools-docs-kit/issues/689