### PR TITLE
Make "chapter" legal.

### DIFF
--- a/packages/writing-style/styles/commercetools/WordList.yml
+++ b/packages/writing-style/styles/commercetools/WordList.yml
@@ -19,7 +19,6 @@ swap:
   autoupdate: automatically update
   cellular data: mobile data
   cellular network: mobile network
-  chapter: document|page|section
   check box: checkbox
   command line: command-line
   click on: click|click in


### PR DESCRIPTION
In the new documentation website, we have not only sections, subsection and pages, but also chapters. Thus, we (docs-lectors) would like to stop Vale complaining about the usage of this word, chapter.