### PR TITLE
fix(docs): to explicitly pass emotion theme when possible

### DIFF
--- a/.changeset/neat-glasses-argue.md
+++ b/.changeset/neat-glasses-argue.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+'@commercetools-docs/ui-kit': patch
+---
+
+It appeared that under some unknown circumstances the `props.theme` accessed from within a styled component results in an empty object when building the website in production mode. To fix that, we explicitly pass wherever possible the `theme` object after reading it from the context with `useTheme`.

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -31,7 +31,7 @@
     "@svgr/webpack": "5.4.0",
     "create-emotion-server": "10.0.27",
     "docsearch.js": "2.6.3",
-    "emotion-theming": "10.0.27",
+    "emotion-theming": "^10.0.27",
     "gatsby-plugin-hubspot": "1.3.4",
     "gatsby-image": "2.4.21",
     "gatsby-plugin-emotion": "4.3.14",

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
@@ -41,13 +41,7 @@ const LayoutApplication = (props) => (
   <UiKitThemeProvider
     theme={{
       ...designSystem.uikitTheme,
-      // Docs specific theme properties
-      colors: {
-        ...designSystem.colors,
-        light: {
-          primary: props.websitePrimaryColor,
-        },
-      },
+      websitePrimaryColor: props.websitePrimaryColor,
     }}
   >
     <Root role="application" id="application">

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-with-hero.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-with-hero.js
@@ -78,11 +78,7 @@ const LayoutPageWithHero = (props) => (
     >
       <ThemeProvider
         theme={{
-          colors: {
-            light: {
-              primary: designSystem.colors.light.textInverted,
-            },
-          },
+          websitePrimaryColor: designSystem.colors.light.textInverted,
         }}
       >
         <Title>{props.title}</Title>

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -4,6 +4,7 @@ import { Location } from '@reach/router';
 import { useStaticQuery, graphql, Link, withPrefix } from 'gatsby';
 import { css, ClassNames } from '@emotion/core';
 import styled from '@emotion/styled';
+import { useTheme } from 'emotion-theming';
 import { BackIcon } from '@commercetools-uikit/icons';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
@@ -48,13 +49,13 @@ const SidebarScrollFader = styled.div`
   position: absolute;
 `;
 const WebsiteTitle = styled.div`
-  color: ${(props) => props.theme.colors.light.primary};
+  color: ${(props) => props.theme.websitePrimaryColor};
   padding: ${designSystem.dimensions.spacings.m};
   font-size: ${designSystem.typography.fontSizes.h4};
 `;
 const WebsiteTitleLink = styled.a`
   text-decoration: none;
-  color: ${(props) => props.theme.colors.light.primary};
+  color: ${(props) => props.theme.websitePrimaryColor};
   :hover {
     text-decoration: underline;
   }
@@ -341,14 +342,15 @@ const Sidebar = (props) => {
   // - initialize the new scroll position
   // - scroll to the previous position in case it was defined
   const nextScrollPosition = useScrollPosition(scrollContainerId);
+  const theme = useTheme();
   return (
     <>
       <SidebarHeader>
         <LayoutHeaderLogo />
-        <WebsiteTitle>
+        <WebsiteTitle theme={theme}>
           <SpacingsStack scale="xs">
             <div>{props.isGlobalBeta && <BetaFlag />}</div>
-            <WebsiteTitleLink as={Link} id="site-title" to="/">
+            <WebsiteTitleLink as={Link} id="site-title" to="/" theme={theme}>
               {props.siteTitle}
             </WebsiteTitleLink>
           </SpacingsStack>

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -17,7 +17,7 @@ const H1 = styled.h1`
   font-size: ${typography.fontSizes.h1};
   font-weight: ${typography.fontWeights.regular};
   line-height: 1.15;
-  color: ${(props) => props.theme.colors.light.primary};
+  color: ${(props) => props.theme.websitePrimaryColor};
 
   /* H1 is the page title and used outside the Typography wrappers so it directly has a margin */
   margin: 0 0 ${dimensions.spacings.s};

--- a/packages/ui-kit/src/design-system.js
+++ b/packages/ui-kit/src/design-system.js
@@ -62,7 +62,7 @@ export const colors = {
     //
     //   <ThemeProvider
     //     theme={{
-    //       colors: colors.light.codeBlocks[props.secondaryTheme ? 'secondary' : 'primary'],
+    //       codeBlockColors: colors.light.codeBlocks[props.secondaryTheme ? 'secondary' : 'primary'],
     //     }}
     //   >
     //

--- a/yarn.lock
+++ b/yarn.lock
@@ -9006,7 +9006,7 @@ emoticon@^3.2.0:
   resolved "https://registry.yarnpkg.com/emoticon/-/emoticon-3.2.0.tgz#c008ca7d7620fac742fe1bf4af8ff8fed154ae7f"
   integrity sha512-SNujglcLTTg+lDAcApPNgEdudaqQFiAbJCqzjNxJkvN9vAwCGi0uu8IUVvx+f16h+V44KCY6Y2yboroc9pilHg==
 
-emotion-theming@10.0.27:
+emotion-theming@^10.0.27:
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/emotion-theming/-/emotion-theming-10.0.27.tgz#1887baaec15199862c89b1b984b79806f2b9ab10"
   integrity sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==


### PR DESCRIPTION
Fixes #682 

It appeared that under some unknown circumstances the `props.theme` accessed from within a styled component results in an empty object when building the website in production mode. To fix that, we explicitly pass wherever possible the `theme` object after reading it from the context with `useTheme`.