### PR TITLE
refactor: use fontsource instead of typeface package

### DIFF
--- a/.changeset/wet-walls-brake.md
+++ b/.changeset/wet-walls-brake.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Use `fontsource` instead of (deprecated) `typeface` package for fonts.

--- a/packages/gatsby-theme-docs/gatsby-browser.js
+++ b/packages/gatsby-theme-docs/gatsby-browser.js
@@ -5,8 +5,12 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
-import 'typeface-roboto';
-import 'typeface-roboto-mono';
+import 'fontsource-roboto/latin-400.css';
+import 'fontsource-roboto/latin-500.css';
+import 'fontsource-roboto/latin-700.css';
+import 'fontsource-roboto-mono/latin-400.css';
+import 'fontsource-roboto-mono/latin-500.css';
+import 'fontsource-roboto-mono/latin-700.css';
 import React from 'react';
 import Prism from 'prism-react-renderer/prism';
 import { CacheProvider } from '@emotion/core';

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -32,6 +32,8 @@
     "create-emotion-server": "10.0.27",
     "docsearch.js": "2.6.3",
     "emotion-theming": "^10.0.27",
+    "fontsource-roboto": "3.0.3",
+    "fontsource-roboto-mono": "3.0.3",
     "gatsby-plugin-hubspot": "1.3.4",
     "gatsby-image": "2.4.21",
     "gatsby-plugin-emotion": "4.3.15",
@@ -69,8 +71,6 @@
     "remark-parse": "9.0.0",
     "remark-react": "8.0.0",
     "slugify": "1.4.6",
-    "typeface-roboto": "1.1.13",
-    "typeface-roboto-mono": "1.1.13",
     "unified": "9.2.0",
     "unist-util-filter": "2.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10751,6 +10751,16 @@ follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
+fontsource-roboto-mono@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fontsource-roboto-mono/-/fontsource-roboto-mono-3.0.3.tgz#5897326b144543e8587ec6edd0cce7162ad27874"
+  integrity sha512-DhrrZR6CXyH8uKoSGTH6BEomGb8x9RqYq2QSHft+ALMTsx1UlnuIYIn2PW/3aS19KIs4YxjaTjIFAPKSyywIiA==
+
+fontsource-roboto@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fontsource-roboto/-/fontsource-roboto-3.0.3.tgz#99c312babeabce22b3e933b3edf2951d4508f4f7"
+  integrity sha512-kfsC9qAP6XhwnSDAhg2lhWeaUJfLGXZh7GcLxFiz/4lXdkV2pVhWv2Xp9ES3b3BHdc9UuPrWXXLOphzHIStcOw==
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -22383,16 +22393,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typeface-roboto-mono@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/typeface-roboto-mono/-/typeface-roboto-mono-1.1.13.tgz#2af8662db8f9119c00efd55d6ed8877d2a69ec94"
-  integrity sha512-pnzDc70b7ywJHin/BUFL7HZX8DyOTBLT2qxlJ92eH1UJOFcENIBXa9IZrxsJX/gEKjbEDKhW5vz/TKRBNk/ufQ==
-
-typeface-roboto@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-1.1.13.tgz#9c4517cb91e311706c74823e857b4bac9a764ae5"
-  integrity sha512-YXvbd3a1QTREoD+FJoEkl0VQNJoEjewR2H11IjVv4bp6ahuIcw0yyw/3udC4vJkHw3T3cUh85FTg8eWef3pSaw==
 
 uglify-js@^3.1.4:
   version "3.11.3"


### PR DESCRIPTION
The typeface package is deprecated

<img width="882" alt="image" src="https://user-images.githubusercontent.com/1110551/99505697-6f508500-2981-11eb-975c-375bc64daa32.png">
