### PR TITLE
feat: change schedule of renovate to every second Wednesday

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,9 +1,9 @@
 {
   "extends": [
     "config:base",
-    ":pinOnlyDevDependencies",
-    "schedule:weekly"
+    ":pinOnlyDevDependencies"
   ],
+  "schedule": ["on the 1st and 3rd day instance on Wednesday after 3am"],
   "separateMajorMinor": true,
   "packageRules": [
     {


### PR DESCRIPTION
This PR changes the renovate schedule config to receive dependency updates every second Wednesday.

Config documentation:
https://docs.renovatebot.com/presets-schedule

The library behind it:
https://bunkat.github.io/later/parsers.html#text