### PR TITLE
fix: regression in Firefox about autoprefixer for height: fit-content

### DIFF
--- a/.changeset/stupid-bugs-press.md
+++ b/.changeset/stupid-bugs-press.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Fix regression in Firefox about autoprefixer for `height: fit-content`

--- a/packages/gatsby-theme-docs/src/components/search-dialog.js
+++ b/packages/gatsby-theme-docs/src/components/search-dialog.js
@@ -70,6 +70,7 @@ const Content = styled.div`
 
   /* stylelint-disable declaration-block-no-duplicate-properties */
   height: 100%; /* For browsers that do not support this property yet */
+  height: -moz-fit-content;
   height: fit-content;
   /* stylelint-enable */
 

--- a/packages/gatsby-theme-docs/src/components/top-menu.js
+++ b/packages/gatsby-theme-docs/src/components/top-menu.js
@@ -28,6 +28,7 @@ const Content = styled.div`
 
   /* stylelint-disable declaration-block-no-duplicate-properties */
   height: 100%; /* For browsers that do not support this property yet */
+  height: -moz-fit-content;
   height: fit-content;
   /* stylelint-enable */
 `;


### PR DESCRIPTION
See https://github.com/thysultan/stylis.js/issues/245