### PR TITLE
fix: include commonmark in gatsby-plugin-mdx options

### DIFF
--- a/.changeset/six-peaches-hope.md
+++ b/.changeset/six-peaches-hope.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/gatsby-theme-docs": patch
+---
+
+fix: include commonmark in gatsby-plugin-mdx options, the ensures backslashes in mdx texts are transformed to new lines

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -124,6 +124,8 @@ module.exports = (themeOptions = {}) => {
             '.mdx',
             // ".md"
           ],
+          // implement commonmark for stricter compatibility, e.g. backslash transformed to newlines
+          commonmark: true,
           // List of remark plugins, that transform the markdown AST.
           remarkPlugins: [require('remark-emoji')],
           // List of rehype plugins, that transform the HTML AST.

--- a/websites/docs-smoke-test/src/content/views/markdown.mdx
+++ b/websites/docs-smoke-test/src/content/views/markdown.mdx
@@ -21,6 +21,11 @@ Paragraphs are separated by a blank line.
 
 Second paragraph. _Italic_, **bold**, **_italic and bold_**, ~~strikethrough~~ and `monospace`.
 
+### Line Break
+
+The backslash, `\`, is interpreted as a new line.\
+This sentence should appear on a new line.
+
 ## List items
 
 import ListItems from "../../topics/list-items.mdx"


### PR DESCRIPTION
Closes https://github.com/commercetools/commercetools-docs-kit/issues/770