### PR TITLE
fix(theme): restore SVG loader for webpack

### DIFF
--- a/.changeset/curvy-hats-float.md
+++ b/.changeset/curvy-hats-float.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Restore SVG Webpack loader

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -447,6 +447,41 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }, themeOptions) => {
   const pluginOptions = { ...defaultOptions, ...themeOptions };
 
   const config = getConfig();
+  config.module.rules = [
+    ...config.module.rules.map((rule) => ({
+      ...rule,
+      test:
+        // Strip out the svg files from the following built-in rule
+        // See https://github.com/zabute/gatsby-plugin-svgr/blob/5087926076e61a0d5681c842af42c73d55a89653/gatsby-node.js#L10-L21
+        String(rule.test) ===
+        String(/\.(ico|svg|jpg|jpeg|png|gif|webp)(\?.*)?$/)
+          ? /\.(ico|jpg|jpeg|png|gif|webp)(\?.*)?$/
+          : rule.test,
+    })),
+    {
+      // Fix for react-intl
+      // https://github.com/formatjs/formatjs/issues/143#issuecomment-518774786
+      test: /\.mjs$/,
+      type: 'javascript/auto',
+    },
+    {
+      test: /\.svg$/,
+      include: /icons/,
+      use: [
+        {
+          loader: require.resolve('@svgr/webpack'),
+          options: {
+            // NOTE: disable this and manually add `removeViewBox: false` in the SVGO plugins list
+            // See related PR: https://github.com/smooth-code/svgr/pull/137
+            icon: false,
+            svgoConfig: {
+              plugins: [{ removeViewBox: false }, { cleanupIDs: true }],
+            },
+          },
+        },
+      ],
+    },
+  ];
   config.resolve = {
     ...config.resolve,
     // Add support for absolute imports


### PR DESCRIPTION
Caused by #758 

I accidentally removed it, but we still need it because a website can still decide to load SVG files.