### PR TITLE
fix: code block tooltip to read from theme using hook

### DIFF
--- a/.changeset/tasty-crews-complain.md
+++ b/.changeset/tasty-crews-complain.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/ui-kit': patch
+---
+
+Fix code block tooltip to explicitly read from emotion theme

--- a/packages/ui-kit/src/components/code-block.js
+++ b/packages/ui-kit/src/components/code-block.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { css, ThemeProvider } from '@emotion/react';
+import { css, ThemeProvider, useTheme } from '@emotion/react';
 import Tooltip from '@commercetools-uikit/tooltip';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import { ClipboardIcon } from '@commercetools-uikit/icons';
@@ -47,14 +47,21 @@ const CopyArea = styled.div`
 `;
 const TooltipWrapperComponent = (props) =>
   ReactDOM.createPortal(props.children, document.body);
-const TooltipBodyComponent = styled.div`
-  background-color: ${(props) =>
-    props.theme.codeBlockColors.surfaceCopyTooltip};
-  border-radius: ${tokens.borderRadiusForTooltip};
-  color: ${(props) => props.theme.codeBlockColors.textCopyTooltip};
-  font-size: ${typography.fontSizes.extraSmall};
-  padding: ${dimensions.spacings.xs} ${dimensions.spacings.s};
-`;
+const TooltipBodyComponent = (props) => {
+  const theme = useTheme();
+  return (
+    <div
+      css={css`
+        background-color: ${theme.codeBlockColors.surfaceCopyTooltip};
+        border-radius: ${tokens.borderRadiusForTooltip};
+        color: ${theme.codeBlockColors.textCopyTooltip};
+        font-size: ${typography.fontSizes.extraSmall};
+        padding: ${dimensions.spacings.xs} ${dimensions.spacings.s};
+      `}
+      {...props}
+    />
+  );
+};
 
 const getLineStyles = (theme, options) => {
   let promptLineStyles;


### PR DESCRIPTION
Fixes #790 (even though it's not reproducible in this repo).

TL;DR: recently we had seen issues related to styled components (emotion) not getting the theme context, even though the theme is correctly defined in the React context. As a workaround we manually read the theme using `useTheme`, and explicitly pass the `theme` as a prop.
This is a leftover of other related changes.