### PR TITLE
refactor(changeset): link only gatsby theme packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,8 @@
   "commit": false,
   "linked": [
     [
-      "@commercetools-docs/*"
+      "@commercetools-docs/gatsby-theme-*",
+      "@commercetools-docs/ui-kit"
     ]
   ],
   "access": "restricted",


### PR DESCRIPTION
Just to see if changeset gets less confused when bumping package versions, as sometimes we get major bumps where it's not clear what the reason was.