### PR TITLE
chore: enable gatsby dev flags to improve development performance

### DIFF
--- a/.changeset/twelve-shirts-help.md
+++ b/.changeset/twelve-shirts-help.md
@@ -1,0 +1,8 @@
+---
+"@commercetools-docs/gatsby-theme-docs": patch
+"@commercetools-website/api-docs-smoke-test": patch
+"@commercetools-website/docs-smoke-test": patch
+"@commercetools-website/site-template": patch
+---
+
+Fix SSR warnings, use experimental flags for development.

--- a/packages/gatsby-theme-docs/src/components/card.js
+++ b/packages/gatsby-theme-docs/src/components/card.js
@@ -106,7 +106,7 @@ const BodyContent = (props) => {
 };
 BodyContent.displayName = 'BodyContent';
 BodyContent.propTypes = {
-  clickable: PropTypes.bool.isRequired,
+  clickable: PropTypes.bool,
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
 };
 
@@ -122,7 +122,7 @@ WrapWith.propTypes = {
 const Card = (props) => (
   <Container {...props}>
     <WrapWith
-      condition={props.clickable && props.href}
+      condition={Boolean(props.clickable && props.href)}
       wrapper={(children) => (
         <Link href={props.href} noUnderline>
           {children}

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -15,6 +15,14 @@ import LayoutHeaderLogo from './layout-header-logo';
 
 const ReleaseNotesIcon = createStyledIcon(ReleaseNotesSvgIcon);
 
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser. We need useLayoutEffect because we want
+// `connect` to perform sync updates to a ref to save the latest props after
+// a render is actually committed to the DOM.
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
 const trimTrailingSlash = (url) => url.replace(/(\/?)$/, '');
 
 const scrollContainerId = 'navigation-scroll-container';
@@ -178,7 +186,7 @@ const SidebarLinkWrapper = (props) => {
   // We need to restore the scroll position as soon as possible, therefore we
   // use `useLayoutEffect` instead of `useEffect` as it fires synchronously after
   // all DOM mutations.
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const isActive = linkRef.current.getAttribute('aria-current') === 'page';
     // In case there was no scroll position saved in the location, and the link
     // is the active one, make sure that the chapter is "visible".

--- a/websites/api-docs-smoke-test/gatsby-config.js
+++ b/websites/api-docs-smoke-test/gatsby-config.js
@@ -5,6 +5,13 @@ const {
 const colorPresets = require('@commercetools-docs/gatsby-theme-docs/color-presets');
 
 module.exports = {
+  // https://www.gatsbyjs.com/docs/reference/release-notes/v2.28/#feature-flags-in-gatsby-configjs
+  // https://www.gatsbyjs.com/docs/reference/release-notes/v2.30
+  flags: {
+    DEV_SSR: true,
+    FAST_REFRESH: true,
+    PRESERVE_WEBPACK_CACHE: true,
+  },
   pathPrefix: '/api-docs-smoke-test',
   siteMetadata: {
     title: 'API Docs Smoke Test',

--- a/websites/docs-smoke-test/gatsby-config.js
+++ b/websites/docs-smoke-test/gatsby-config.js
@@ -5,6 +5,13 @@ const {
 } = require('@commercetools-docs/gatsby-theme-docs/configure-theme');
 
 module.exports = {
+  // https://www.gatsbyjs.com/docs/reference/release-notes/v2.28/#feature-flags-in-gatsby-configjs
+  // https://www.gatsbyjs.com/docs/reference/release-notes/v2.30
+  flags: {
+    DEV_SSR: true,
+    FAST_REFRESH: true,
+    PRESERVE_WEBPACK_CACHE: true,
+  },
   pathPrefix: '/docs-smoke-test',
   siteMetadata: {
     title: 'Docs Smoke Test',

--- a/websites/site-template/gatsby-config.js
+++ b/websites/site-template/gatsby-config.js
@@ -1,6 +1,13 @@
 const isProd = process.env.NODE_ENV === 'production';
 
 module.exports = {
+  // https://www.gatsbyjs.com/docs/reference/release-notes/v2.28/#feature-flags-in-gatsby-configjs
+  // https://www.gatsbyjs.com/docs/reference/release-notes/v2.30
+  flags: {
+    DEV_SSR: true,
+    FAST_REFRESH: true,
+    PRESERVE_WEBPACK_CACHE: true,
+  },
   pathPrefix: '/site-template',
   siteMetadata: {
     title: 'CHANGE-ME',


### PR DESCRIPTION
This PR proposes to enable the following Gatsby feature flags:

- `DEV_SSR: true`
- `FAST_REFRESH: true`
- `PRESERVE_WEBPACK_CACHE: true`

According to Gatsby, this should help improving the performance for local development.

Note that the `DEV_SSR` allows to ensure that a page is correctly rendered on the server (see some of the fixes in the PR as a result of that).

I suggest to checkout the branch and start the websites locally, to make sure that things work fine.