### PR TITLE
chore(renovate): preserve semver ranges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    ":pinOnlyDevDependencies"
+    ":preserveSemverRanges"
   ],
   "schedule": ["on the 1st and 3rd day instance on Wednesday after 3am"],
   "separateMajorMinor": true,


### PR DESCRIPTION
* Moves renovate config into `.github` folder
* Uses `preserveSemverRanges` instead of `pinOnlyDevDependencies`

Just so that we keep things consistent with other repos.