### PR TITLE
chore: add outline to string literals

### DIFF
--- a/.changeset/real-carpets-fry.md
+++ b/.changeset/real-carpets-fry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/ui-kit': patch
+---
+
+String literals were given an outline for better visibility.

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -220,9 +220,9 @@ const TableHeader = styled.th`
 `;
 
 const InlineCode = styled.code`
-  outline: 1px solid ${colors.light.borderSecondary};
   background-color: ${colors.light.surfaceInlineCode};
   border: 1px solid ${colors.light.surfaceInfo};
+  border-color: ${colors.light.borderSecondary};
   border-radius: ${dimensions.spacings.xs};
   color: ${colors.light.textCode};
   font-family: ${typography.fontFamilies.code};

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -220,6 +220,7 @@ const TableHeader = styled.th`
 `;
 
 const InlineCode = styled.code`
+  outline: 1px solid ${colors.light.borderSecondary};
   background-color: ${colors.light.surfaceInlineCode};
   border: 1px solid ${colors.light.surfaceInfo};
   border-radius: ${dimensions.spacings.xs};

--- a/packages/ui-kit/src/components/markdown.js
+++ b/packages/ui-kit/src/components/markdown.js
@@ -221,8 +221,7 @@ const TableHeader = styled.th`
 
 const InlineCode = styled.code`
   background-color: ${colors.light.surfaceInlineCode};
-  border: 1px solid ${colors.light.surfaceInfo};
-  border-color: ${colors.light.borderSecondary};
+  border: 1px solid ${colors.light.borderSecondary};
   border-radius: ${dimensions.spacings.xs};
   color: ${colors.light.textCode};
   font-family: ${typography.fontFamilies.code};


### PR DESCRIPTION
closes #797 

@Shecki link to an example: https://commercetools-docs-kit-git-add-outline-to-string-literals.commercetools.vercel.app/docs-smoke-test/views/links