### PR TITLE
fix: export <Overlay> and <TopMenu> from core theme

### DIFF
--- a/.changeset/calm-geese-collect.md
+++ b/.changeset/calm-geese-collect.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Export `<Overlay>` and `<TopMenu>` from core theme.

--- a/packages/gatsby-theme-docs/index.js
+++ b/packages/gatsby-theme-docs/index.js
@@ -6,12 +6,14 @@ export { default as Footer } from './src/layouts/internals/footer';
 export {
   BetaFlag,
   ErrorBoundary,
-  Link,
   ExternalSiteLink,
-  SEO,
-  ThemeProvider,
-  SideBySide,
   FullWidthContainer,
+  Link,
+  Overlay,
+  SEO,
+  SideBySide,
+  TopMenu,
+  ThemeProvider,
 } from './src/components';
 export * from './src/hooks/use-site-data';
 export * from './src/hooks/use-page-data';


### PR DESCRIPTION
Closes #900 