### PR TITLE
fix: add missing raw-loader dependency

### DIFF
--- a/.changeset/friendly-rivers-develop.md
+++ b/.changeset/friendly-rivers-develop.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Add missing `raw-loader` dependency

--- a/packages/gatsby-theme-docs/gatsby-ssr.js
+++ b/packages/gatsby-theme-docs/gatsby-ssr.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 /**
  * Implement Gatsby's SSR (Server Side Rendering) APIs in this file.
  *
@@ -11,9 +10,9 @@ import { createContentDigest } from 'gatsby-core-utils';
 import createEmotionServer from '@emotion/server/create-instance';
 import { CacheProvider } from '@emotion/react';
 import { createDocsCache, docsCacheKey } from './utils/create-emotion-cache';
-// eslint-disable-next-line import/no-unresolved,import/extensions,import/no-webpack-loader-syntax
+// eslint-disable-next-line import/no-webpack-loader-syntax
 import iconDarkDigestRaw from '!!raw-loader!./static/favicon-dark-32x32.png';
-// eslint-disable-next-line import/no-unresolved,import/extensions,import/no-webpack-loader-syntax
+// eslint-disable-next-line import/no-webpack-loader-syntax
 import iconLightDigestRaw from '!!raw-loader!./static/favicon-light-32x32.png';
 
 const iconDarkDigest = createContentDigest(iconDarkDigestRaw);

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -71,6 +71,7 @@
     "prompts": "^2.4.0",
     "prop-types": "15.7.2",
     "qss": "2.0.3",
+    "raw-loader": "4.0.2",
     "react-helmet": "6.1.0",
     "react-intersection-observer": "8.31.0",
     "react-intl": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18668,7 +18668,7 @@ raw-body@^2.4.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-loader@^4.0.2:
+raw-loader@4.0.2, raw-loader@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
   integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==


### PR DESCRIPTION
Got this in appkit as I was trying to upgrade.

<img width="1112" alt="image" src="https://user-images.githubusercontent.com/1110551/110820704-a24fb900-828f-11eb-82e5-b145f3092f9c.png">
