### PR TITLE
Improve release note generator

### DIFF
--- a/.changeset/itchy-timers-lick.md
+++ b/.changeset/itchy-timers-lick.md
@@ -2,4 +2,4 @@
 '@commercetools-docs/gatsby-theme-docs': patch
 ---
 
-The release-note file generator was refactored.
+Fix an issue with release note generator CLI.

--- a/.changeset/itchy-timers-lick.md
+++ b/.changeset/itchy-timers-lick.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+The release-note file generator was refactored.

--- a/.changeset/itchy-timers-lick.md
+++ b/.changeset/itchy-timers-lick.md
@@ -1,5 +1,24 @@
 ---
-'@commercetools-docs/gatsby-theme-docs': patch
+'@commercetools-docs/gatsby-theme-docs': minor
 ---
 
 Fix an issue with release note generator CLI.
+
+How to create a release note over your console:
+
+1. Navigate to the microsite where you want to create the release note
+2. Run the following command in your terminal
+
+```
+yarn create-docs-release-note
+```
+
+3. Follow the instructions in your console.
+4. After finishing all instructions in the console, you can find the generated release note in the `src/releases` folder of your microsite.
+
+How to create a release note over over Visual Studio Code:
+
+1. Go to the `npm scripts` section and open the `package.json` file from the microsite in which you want to create a release note.
+2. Run the script `create-docs-release-note`.
+3. Follow the instructions in the console.
+4. After finishing all instructions in the console, you can find the generated release note in the `src/releases` folder of your microsite.

--- a/.changeset/itchy-timers-lick.md
+++ b/.changeset/itchy-timers-lick.md
@@ -4,21 +4,17 @@
 
 Fix an issue with release note generator CLI.
 
-How to create a release note over your console:
+If you want to configure a topic list for a microsite, create a file called `docs-release-notes-config.yml` in the microsite folder. Then you can configure topics in the following format:
 
-1. Navigate to the microsite where you want to create the release note
-2. Run the following command in your terminal
-
+```yml
+topics:
+  Carts:
+    name: Carts
+  Limits:
+    name: Limits
+  Orders:
+    name: Orders
+    description: Describe the topic here
 ```
-yarn create-docs-release-note
-```
 
-3. Follow the instructions in your console.
-4. After finishing all instructions in the console, you can find the generated release note in the `src/releases` folder of your microsite.
-
-How to create a release note over over Visual Studio Code:
-
-1. Go to the `npm scripts` section and open the `package.json` file from the microsite in which you want to create a release note.
-2. Run the script `create-docs-release-note`.
-3. Follow the instructions in the console.
-4. After finishing all instructions in the console, you can find the generated release note in the `src/releases` folder of your microsite.
+The description is optional.

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -38,7 +38,7 @@ const questions = [
   {
     type: 'text',
     name: 'date',
-    message: 'Insert the release date with the following format: 2021-01-21',
+    message: 'Insert the release date with the following format: YYYY-MM-DD',
     validate: (date) => {
       const checkDateFormat = moment(date, 'YYYY-MM-DD', true);
       return checkDateFormat.isValid() ? true : 'Please use a valid format!';
@@ -69,7 +69,8 @@ const questions = [
 ];
 
 (async () => {
-  if (!fs.existsSync(path.join(process.cwd(), `src/releases`))) {
+  const folderpath = path.join(process.cwd(), `src/releases`);
+  if (!fs.existsSync(folderpath)) {
     console.error(`No "releases" folder found in this directory`);
     process.exit();
   }
@@ -92,7 +93,7 @@ Please write the content here. To use "Read More", insert <!--more-->.
   const filemane = response.title.replace(/\s+/g, '-').toLowerCase();
 
   fs.writeFileSync(
-    path.join(process.cwd(), `src/releases/${slugify(filemane, '-')}.mdx`),
+    path.join(`${folderpath}/${slugify(filemane, '-')}.mdx`),
     template
   );
 })();

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -69,6 +69,11 @@ const questions = [
 ];
 
 (async () => {
+  if (!fs.existsSync(path.join(process.cwd(), `src/releases`))) {
+    console.error(`No "releases" folder found in this directory`);
+    process.exit();
+  }
+
   const response = await prompts(questions);
 
   const template = `---

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const slugify = require('slugify');
 const prompts = require('prompts');
+const moment = require('moment');
 
 const questions = [
   {
@@ -35,14 +36,18 @@ const questions = [
     ],
   },
   {
-    type: 'date',
+    type: 'text',
     name: 'date',
-    message: 'Pick a release date',
+    message: 'Insert the release date with the following format: 2021-01-21',
+    validate: (date) => {
+      const checkDateFormat = moment(date, 'YYYY-MM-DD', true);
+      return checkDateFormat.isValid() ? true : 'Please use a valid format!';
+    },
   },
   {
     type: 'text',
     name: 'title',
-    message: 'The title of the release note. Max 256 character plain text.',
+    message: 'Insert the title for the release note. Write it in plain text.',
     validate: (title) =>
       title.length > 256 ? 'Title is longer than 256 chars!' : true,
   },
@@ -50,8 +55,7 @@ const questions = [
     type: 'text',
     name: 'description',
     message:
-      'Key changes and their advantages. Max 256 character plain text. This text is tweet-able and used in RSS feeds.',
-    format: (val, values) => `${values.title} ${val}`,
+      'Describe the key changes and their advantages briefly. Max 256 character plain text. This text is tweet-able and used in RSS feeds.',
     validate: (description) =>
       description.length > 256 ? 'Description is longer than 256 chars!' : true,
   },
@@ -59,7 +63,7 @@ const questions = [
     type: 'list',
     name: 'topics',
     message:
-      'Write down the topics for this release note. Seperate them with commas.',
+      'Fill in the topics for this release note. Seperate them with commas.',
     separator: ',',
   },
 ];
@@ -74,21 +78,16 @@ description: |
   ${response.description}
 type: ${response.type}
 topics:
-${response.topics.map((topic) => `- ${topic}`).join('\n')}
+${response.topics.map((topic) => `  - ${topic}`).join('\n')}
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sit amet tristique arcu. Nullam et porta urna.
-Suspendisse potenti. Sed euismod eleifend sapien, et bibendum velit sollicitudin quis.
-Proin iaculis mauris in porttitor facilisis.
-
-<!--more-->
+Please write the content here. To use "Read More", insert <!--more-->.
 `;
 
+  const filemane = response.title.replace(/\s+/g, '-').toLowerCase();
+
   fs.writeFileSync(
-    path.join(
-      process.cwd(),
-      `src/releases/${slugify(response.title, '-')}.mdx`
-    ),
+    path.join(process.cwd(), `src/releases/${slugify(filemane, '-')}.mdx`),
     template
   );
 })();

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -82,22 +82,16 @@ const selectQuestions = (customizedQuestions) => {
 
   const getQuestions = () => {
     if (configFile) {
-      const topics = configFile.config.topics;
-
-      const topicChoices = (topics) => {
-        return topics.map((topic) => {
-          return {
-            title: topic.name,
-            value: topic.name,
-            description: topic.description,
-          };
-        });
-      };
+      const topics = configFile.config.topics.map((topic) => ({
+        title: topic.name,
+        value: topic.name,
+        description: topic.description,
+      }));
       const multiselectTopicQuestion = {
         type: 'multiselect',
         name: 'topics',
         message: 'Select the topics for this release note.',
-        choices: topicChoices(topics),
+        choices: topics,
       };
       return selectQuestions(multiselectTopicQuestion);
     }

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -5,68 +5,67 @@ const path = require('path');
 const slugify = require('slugify');
 const prompts = require('prompts');
 const moment = require('moment');
+const { cosmiconfigSync } = require('cosmiconfig');
 
-const questions = [
-  {
-    type: 'multiselect',
-    name: 'type',
-    message: 'Pick the type of the release note',
-    choices: [
-      {
-        title: 'enhancement',
-        value: 'enhancement',
-        description: 'for updates of existing features',
-      },
-      {
-        title: 'feature',
-        value: 'feature',
-        description: 'for the introduction of an entirely new feature',
-      },
-      {
-        title: 'fix',
-        value: 'fix',
-        description: 'for bug fixes',
-      },
-      {
-        title: 'announcement',
-        value: 'announcement',
-        description:
-          'for release notes with no product change nor immediate product change',
-      },
-    ],
-  },
-  {
-    type: 'text',
-    name: 'date',
-    message: 'Insert the release date with the following format: YYYY-MM-DD',
-    validate: (date) => {
-      const checkDateFormat = moment(date, 'YYYY-MM-DD', true);
-      return checkDateFormat.isValid() ? true : 'Please use a valid format!';
+const selectQuestions = (customizedQuestions) => {
+  return [
+    {
+      type: 'multiselect',
+      name: 'type',
+      message: 'Pick the type of the release note',
+      choices: [
+        {
+          title: 'enhancement',
+          value: 'enhancement',
+          description: 'for updates of existing features',
+        },
+        {
+          title: 'feature',
+          value: 'feature',
+          description: 'for the introduction of an entirely new feature',
+        },
+        {
+          title: 'fix',
+          value: 'fix',
+          description: 'for bug fixes',
+        },
+        {
+          title: 'announcement',
+          value: 'announcement',
+          description:
+            'for release notes with no product change nor immediate product change',
+        },
+      ],
     },
-  },
-  {
-    type: 'text',
-    name: 'title',
-    message: 'Insert the title for the release note. Write it in plain text.',
-    validate: (title) =>
-      title.length > 256 ? 'Title is longer than 256 chars!' : true,
-  },
-  {
-    type: 'text',
-    name: 'description',
-    message:
-      'Describe the key changes and their advantages briefly. Max 256 character plain text. This text is tweet-able and used in RSS feeds.',
-    validate: (description) =>
-      description.length > 256 ? 'Description is longer than 256 chars!' : true,
-  },
-  {
-    type: 'list',
-    name: 'topics',
-    message:
-      'Fill in the topics for this release note. Seperate them with commas.',
-    separator: ',',
-  },
-];
+    {
+      type: 'text',
+      name: 'date',
+      message: 'Insert the release date with the following format: YYYY-MM-DD',
+      validate: (date) => {
+        const checkDateFormat = moment(date, 'YYYY-MM-DD', true);
+        return checkDateFormat.isValid() ? true : 'Please use a valid format!';
+      },
+    },
+    {
+      type: 'text',
+      name: 'title',
+      message: 'Insert the title for the release note. Write it in plain text.',
+      validate: (title) =>
+        title.length > 256 ? 'Title is longer than 256 chars!' : true,
+    },
+    {
+      type: 'text',
+      name: 'description',
+      message:
+        'Describe the key changes and their advantages briefly. Max 256 character plain text. This text is tweet-able and used in RSS feeds.',
+      validate: (description) =>
+        description.length > 256
+          ? 'Description is longer than 256 chars!'
+          : true,
+    },
+    customizedQuestions,
+  ];
+};
 
 (async () => {
   const folderpath = path.join(process.cwd(), `src/releases`);
@@ -75,7 +74,42 @@ const questions = [
     process.exit();
   }
 
-  const response = await prompts(questions);
+  const getQuestions = () => {
+    const moduleName = 'release-note-topic-config';
+    const explorerSync = cosmiconfigSync(moduleName, {
+      searchPlaces: [`${moduleName}.yml`],
+    });
+    const configFile = explorerSync.search();
+
+    if (configFile) {
+      const topics = configFile.config;
+
+      const topicChoices = (topics) => {
+        return Object.keys(topics).map((topic) => {
+          const title = topics[topic].name;
+          const description = topics[topic].description;
+          return { title, value: title, description: description || '' };
+        });
+      };
+      const multiselectTopicQuestion = {
+        type: 'multiselect',
+        name: 'topics',
+        message: 'Select the topics for this release note.',
+        choices: topicChoices(topics),
+      };
+      return selectQuestions(multiselectTopicQuestion);
+    }
+    const listTopicQuestion = {
+      type: 'list',
+      name: 'topics',
+      message:
+        'No topic configuration found. Please fill in the topics for this release note. Seperate them with commas.',
+      separator: ',',
+    };
+    return selectQuestions(listTopicQuestion);
+  };
+
+  const response = await prompts(getQuestions());
 
   const template = `---
 date: ${response.date}

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -7,6 +7,12 @@ const prompts = require('prompts');
 const moment = require('moment');
 const { cosmiconfigSync } = require('cosmiconfig');
 
+const moduleName = 'docs-release-notes-config';
+const explorerSync = cosmiconfigSync(moduleName, {
+  searchPlaces: [`${moduleName}.yml`, `${moduleName}.yaml`],
+});
+const configFile = explorerSync.search();
+
 const selectQuestions = (customizedQuestions) => {
   return [
     {
@@ -74,21 +80,18 @@ const selectQuestions = (customizedQuestions) => {
     process.exit();
   }
 
-  const moduleName = 'docs-release-notes-config';
-  const explorerSync = cosmiconfigSync(moduleName, {
-    searchPlaces: [`${moduleName}.yml`, `${moduleName}.yaml`],
-  });
-  const configFile = explorerSync.search();
-
   const getQuestions = () => {
     if (configFile) {
       const topics = configFile.config.topics;
 
       const topicChoices = (topics) => {
-        return Object.keys(topics).map((topic) => {
-          const title = topics[topic].name;
-          const description = topics[topic].description;
-          return { title, value: title, description: description || '' };
+        console.log(topics);
+        return topics.map((topic) => {
+          return {
+            title: topic.name,
+            value: topic.name,
+            description: topic.description,
+          };
         });
       };
       const multiselectTopicQuestion = {

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -74,15 +74,15 @@ const selectQuestions = (customizedQuestions) => {
     process.exit();
   }
 
-  const getQuestions = () => {
-    const moduleName = 'release-note-topic-config';
-    const explorerSync = cosmiconfigSync(moduleName, {
-      searchPlaces: [`${moduleName}.yml`],
-    });
-    const configFile = explorerSync.search();
+  const moduleName = 'docs-release-notes-config';
+  const explorerSync = cosmiconfigSync(moduleName, {
+    searchPlaces: [`${moduleName}.yml`, `${moduleName}.yaml`],
+  });
+  const configFile = explorerSync.search();
 
+  const getQuestions = () => {
     if (configFile) {
-      const topics = configFile.config;
+      const topics = configFile.config.topics;
 
       const topicChoices = (topics) => {
         return Object.keys(topics).map((topic) => {

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -85,7 +85,6 @@ const selectQuestions = (customizedQuestions) => {
       const topics = configFile.config.topics;
 
       const topicChoices = (topics) => {
-        console.log(topics);
         return topics.map((topic) => {
           return {
             title: topic.name,

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -41,6 +41,7 @@
     "@mdx-js/react": "1.6.22",
     "@sentry/browser": "6.2.2",
     "@svgr/webpack": "5.5.0",
+    "cosmiconfig": "^7.0.0",
     "docsearch.js": "2.6.3",
     "gatsby-plugin-emotion": "6.1.0",
     "gatsby-plugin-feed": "3.1.0",

--- a/websites/api-docs-smoke-test/package.json
+++ b/websites/api-docs-smoke-test/package.json
@@ -9,7 +9,7 @@
     "serve": "npx gatsby serve --prefix-paths -o",
     "clean": "npx gatsby clean",
     "clean:develop": "yarn clean && yarn develop",
-    "create-docs-release-note": "PATH=$(npm bin):$PATH create-docs-release-note",
+    "create-docs-release-note": "npx create-docs-release-note",
     "build": "npx gatsby build --prefix-paths",
     "prebuild": "yarn clean && yarn predevelop",
     "postbuild": "rm -rf ../../public/api-docs-smoke-test && mkdir -p ../../public && mv public ../../public/api-docs-smoke-test",

--- a/websites/api-docs-smoke-test/package.json
+++ b/websites/api-docs-smoke-test/package.json
@@ -9,6 +9,7 @@
     "serve": "npx gatsby serve --prefix-paths -o",
     "clean": "npx gatsby clean",
     "clean:develop": "yarn clean && yarn develop",
+    "create-docs-release-note": "PATH=$(npm bin):$PATH create-docs-release-note",
     "build": "npx gatsby build --prefix-paths",
     "prebuild": "yarn clean && yarn predevelop",
     "postbuild": "rm -rf ../../public/api-docs-smoke-test && mkdir -p ../../public && mv public ../../public/api-docs-smoke-test",

--- a/websites/docs-smoke-test/docs-release-notes-config.yml
+++ b/websites/docs-smoke-test/docs-release-notes-config.yml
@@ -1,0 +1,8 @@
+# Provide a list of topics
+topics:
+  - name: Carts
+    description:
+  - name: Limits
+    description:
+  - name: Orders
+    description:

--- a/websites/docs-smoke-test/package.json
+++ b/websites/docs-smoke-test/package.json
@@ -8,7 +8,7 @@
     "serve": "npx gatsby serve --prefix-paths -o",
     "clean": "npx gatsby clean",
     "clean:develop": "yarn clean && yarn develop",
-    "create-docs-release-note": "PATH=$(npm bin):$PATH create-docs-release-note",
+    "create-docs-release-note": "npx create-docs-release-note",
     "build": "npx gatsby build --prefix-paths",
     "build:serve": "npx gatsby build --prefix-paths && npx gatsby serve --prefix-paths -o",
     "prebuild": "yarn clean",

--- a/websites/docs-smoke-test/package.json
+++ b/websites/docs-smoke-test/package.json
@@ -8,6 +8,7 @@
     "serve": "npx gatsby serve --prefix-paths -o",
     "clean": "npx gatsby clean",
     "clean:develop": "yarn clean && yarn develop",
+    "create-docs-release-note": "PATH=$(npm bin):$PATH create-docs-release-note",
     "build": "npx gatsby build --prefix-paths",
     "build:serve": "npx gatsby build --prefix-paths && npx gatsby serve --prefix-paths -o",
     "prebuild": "yarn clean",

--- a/websites/docs-smoke-test/release-note-topic-config.yml
+++ b/websites/docs-smoke-test/release-note-topic-config.yml
@@ -1,7 +1,0 @@
-# Provide a list of topics
-Carts:
-  name: Carts
-Limits:
-  name: Limits
-Orders:
-  name: Orders

--- a/websites/docs-smoke-test/release-note-topic-config.yml
+++ b/websites/docs-smoke-test/release-note-topic-config.yml
@@ -1,0 +1,7 @@
+# Provide a list of topics
+Carts:
+  name: Carts
+Limits:
+  name: Limits
+Orders:
+  name: Orders


### PR DESCRIPTION
closes #862 

If you want to try it out, here's how it works :)
- Open the docs-kit repo in vs code and switch to this branch
- Go to the npm scrips window and open the scripts for either the `docs-smoke-test` or the `api-docs-smoke-test` microsite
- Run the `create-docs-release-note` script. Now you can follow the instructions and create a release note

**Note:**
For showing purposes, I created the config file for the topics only for the `docs-smoke-test`. If you want to see how the script behaves without a config file, run the script in the `api-docs-smoke-test`.