### PR TITLE
Fix overlapping entries in child section nav

### DIFF
--- a/.changeset/silly-actors-remain.md
+++ b/.changeset/silly-actors-remain.md
@@ -3,4 +3,4 @@
 '@commercetools-website/docs-smoke-test': patch
 ---
 
-A bug was fixed in the child section navigator.
+Fix overflowing issue with long words in `<ChildSectionNav>`

--- a/.changeset/silly-actors-remain.md
+++ b/.changeset/silly-actors-remain.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+'@commercetools-website/docs-smoke-test': patch
+---
+
+A bug was fixed in the child section navigator.

--- a/packages/gatsby-theme-docs/src/components/child-sections-nav.js
+++ b/packages/gatsby-theme-docs/src/components/child-sections-nav.js
@@ -92,6 +92,7 @@ const Container = styled.div`
   column-gap: ${designSystem.dimensions.spacings.l};
 `;
 const ColumnContainer = styled.div`
+  overflow: scroll;
   break-inside: avoid-column;
   margin-bottom: ${designSystem.dimensions.spacings.s};
 `;

--- a/packages/gatsby-theme-docs/src/components/child-sections-nav.js
+++ b/packages/gatsby-theme-docs/src/components/child-sections-nav.js
@@ -100,7 +100,7 @@ const ChildrenContainer = styled.div`
   margin-top: ${designSystem.dimensions.spacings.s};
 `;
 const Link = styled.a`
-  overflow-x: scroll;
+  overflow-x: hidden;
   display: flex;
   align-items: center;
   padding: ${designSystem.dimensions.spacings.xs}

--- a/packages/gatsby-theme-docs/src/components/child-sections-nav.js
+++ b/packages/gatsby-theme-docs/src/components/child-sections-nav.js
@@ -92,7 +92,6 @@ const Container = styled.div`
   column-gap: ${designSystem.dimensions.spacings.l};
 `;
 const ColumnContainer = styled.div`
-  overflow: scroll;
   break-inside: avoid-column;
   margin-bottom: ${designSystem.dimensions.spacings.s};
 `;
@@ -101,6 +100,7 @@ const ChildrenContainer = styled.div`
   margin-top: ${designSystem.dimensions.spacings.s};
 `;
 const Link = styled.a`
+  overflow-x: scroll;
   display: flex;
   align-items: center;
   padding: ${designSystem.dimensions.spacings.xs}

--- a/packages/gatsby-theme-docs/src/components/child-sections-nav.js
+++ b/packages/gatsby-theme-docs/src/components/child-sections-nav.js
@@ -100,7 +100,6 @@ const ChildrenContainer = styled.div`
   margin-top: ${designSystem.dimensions.spacings.s};
 `;
 const Link = styled.a`
-  overflow-x: hidden;
   display: flex;
   align-items: center;
   padding: ${designSystem.dimensions.spacings.xs}
@@ -108,7 +107,7 @@ const Link = styled.a`
   font-size: ${designSystem.typography.fontSizes.small};
   color: ${designSystem.colors.light.textSecondary};
   text-decoration: none;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   :hover {
     color: ${designSystem.colors.light.linkNavigation};
     background-color: ${designSystem.colors.light.surfaceSecondary1};

--- a/websites/docs-smoke-test/src/content/components/child-section-navigation.mdx
+++ b/websites/docs-smoke-test/src/content/components/child-section-navigation.mdx
@@ -33,7 +33,7 @@ navLevels: 2
 
 ### Price Selection
 
-### Set ShippingAddressAndCustomShippingMethod
+### This is a VeryLongWordThatDoesNotHaveAnySpaceAndThereforeItOverflows
 
 ### Category Order Hints
 

--- a/websites/docs-smoke-test/src/content/components/child-section-navigation.mdx
+++ b/websites/docs-smoke-test/src/content/components/child-section-navigation.mdx
@@ -33,7 +33,7 @@ navLevels: 2
 
 ### Price Selection
 
-### Attribute
+### Set ShippingAddressAndCustomShippingMethod
 
 ### Category Order Hints
 


### PR DESCRIPTION
is part of #899 
This pull request implements code to prevent the entries from overlapping if the line is too long. There is still the discussion in the issue about whether the section names are correct.

This was already discussed and approved from design @Shecki 