### PR TITLE
refactor: set correct height for searchbox placeholder

### DIFF
--- a/.changeset/plenty-chicken-yell.md
+++ b/.changeset/plenty-chicken-yell.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+'@commercetools-docs/ui-kit': patch
+---
+
+Change height of searchbox field to 58px

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
@@ -138,7 +138,7 @@ const SearchInputBox = styled.div`
 `;
 
 const Blank = styled.div`
-  height: 60px;
+  height: ${designSystem.dimensions.heights.pageSearchboxSpace};
 `;
 
 const LayoutPageNavigation = (props) => {

--- a/packages/ui-kit/src/design-system.js
+++ b/packages/ui-kit/src/design-system.js
@@ -128,7 +128,7 @@ export const dimensions = {
     inputSearchPrimary: '32px',
     inputSearchSecondary: '26px',
     childSectionNavLink: '28px',
-    pageSearchboxSpace: '60px',
+    pageSearchboxSpace: '58px',
   },
   widths: {
     pageContent: pageWidth,


### PR DESCRIPTION
I noticed that there is a two-pixel difference between the placeholder and the searchbox container that you can see during the animation when the search box disappears again. Now the placeholder has the exact same height as the searchbox container.