### PR TITLE
Terms of beta policy in writing style checks

### DIFF
--- a/.changeset/brave-impalas-watch.md
+++ b/.changeset/brave-impalas-watch.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/writing-style": patch
+---
+
+Add unused software release terms of beta policy in writing style checks

--- a/packages/writing-style/styles/commercetools/WordList.yml
+++ b/packages/writing-style/styles/commercetools/WordList.yml
@@ -36,7 +36,9 @@ swap:
   i18n: internationalization
   l10n: localization
   long press: touch & hold
+  open beta: public beta # acc. to our beta policy
   open-source: open source
+  private beta: closed beta # acc. to our beta policy
   regex: regular expression
   sign into: sign in to
   single sign on: single sign-on


### PR DESCRIPTION
Acc. to our beta policy we need to add "closed beta" and "public beta" to the automated writing style checks.