### PR TITLE
App Size: Remove dependency to two larger JS libs (moment and parse5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ Build the packages
 $ yarn build
 ```
 
-Start the [docs-smoke-test website](./websites/docs-smoke-test):
+Start the [docs-smoke-test website](./websites/docs-smoke-test) or the [api-docs-smoke-test website](./websites/api-docs-smoke-test):
 
 ```bash
+$ cd websites/docs-smoke-test
 $ yarn start
 ```
+
+When locally building the API docs smoke test site, a [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) based size analysis is run and automatically opened. Keep in mind that the analysis only covers the JS content, GatsbyJS GraphQL data live in separate JSON files in the `/public/page-data` folder, the `sq` subfolder contains the static query results.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ cd websites/docs-smoke-test
 $ yarn start
 ```
 
-When locally building the API docs smoke test site, a [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) based size analysis is run and automatically opened. Keep in mind that the analysis only covers the JS content, GatsbyJS GraphQL data live in separate JSON files in the `/public/page-data` folder, the `sq` subfolder contains the static query results.
+When building a production or test site, setting an environment variable `ANALYZE_BUNDLE=true` starts a [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) based size analysis after the build. Keep in mind that the analysis only covers the JS content, GatsbyJS GraphQL data live in separate JSON files in the `/public/page-data` folder and are a source of page weight, too. The `/public/page-data/sq` subfolder contains the static query results.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,17 @@ Build the packages
 $ yarn build
 ```
 
-Start the [docs-smoke-test website](./websites/docs-smoke-test) or the [api-docs-smoke-test website](./websites/api-docs-smoke-test):
+Start the [docs-smoke-test website](./websites/docs-smoke-test):
 
 ```bash
 $ cd websites/docs-smoke-test
+$ yarn start
+```
+
+Start the [api-docs-smoke-test website](./websites/api-docs-smoke-test):
+
+```bash
+$ cd websites/api-docs-smoke-test
 $ yarn start
 ```
 

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -4,8 +4,15 @@ const fs = require('fs');
 const path = require('path');
 const slugify = require('slugify');
 const prompts = require('prompts');
-const { parseIsoDate } = require('@commercetools-docs/ui-kit/src/utils/dates');
 const { cosmiconfigSync } = require('cosmiconfig');
+
+const parseIsoDate = (dateString) => {
+  const UTCDateString = dateString + 'T00:00:00.000Z';
+  const date = new Date(UTCDateString);
+  return !isNaN(date.valueOf()) && /^\d{4}-\d{2}-\d{2}$/.test(dateString)
+    ? date
+    : false;
+};
 
 const moduleName = 'docs-release-notes-config';
 const explorerSync = cosmiconfigSync(moduleName, {

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const slugify = require('slugify');
 const prompts = require('prompts');
-const { parseIsoDate } = require('@commercetools-docs/ui-kit');
+const { parseIsoDate } = require('@commercetools-docs/ui-kit/src/utils/dates');
 const { cosmiconfigSync } = require('cosmiconfig');
 
 const moduleName = 'docs-release-notes-config';

--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const slugify = require('slugify');
 const prompts = require('prompts');
-const moment = require('moment');
+const { parseIsoDate } = require('@commercetools-docs/ui-kit');
 const { cosmiconfigSync } = require('cosmiconfig');
 
 const moduleName = 'docs-release-notes-config';
@@ -48,8 +48,9 @@ const selectQuestions = (customizedQuestions) => {
       name: 'date',
       message: 'Insert the release date with the following format: YYYY-MM-DD',
       validate: (date) => {
-        const checkDateFormat = moment(date, 'YYYY-MM-DD', true);
-        return checkDateFormat.isValid() ? true : 'Please use a valid format!';
+        return parseIsoDate(date) !== false
+          ? true
+          : 'Please use a valid ISO Date format!';
       },
     },
     {

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -66,7 +66,6 @@
     "hast-util-heading": "1.0.5",
     "intersection-observer": "0.12.0",
     "lodash.throttle": "4.1.1",
-    "moment": "2.29.1",
     "prism-react-renderer": "1.2.1",
     "prismjs": "1.23.0",
     "prompts": "^2.4.0",

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import moment from 'moment';
-import { designSystem } from '@commercetools-docs/ui-kit';
+import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import DateInput from '@commercetools-uikit/date-input';
 import useReleaseNotesFilterParams from '../hooks/use-release-notes-filter-params';
@@ -20,7 +19,7 @@ const DateLabel = styled.label`
 
 const ReleaseNotesFilterDates = () => {
   const [filterParams, setFilterParams] = useReleaseNotesFilterParams();
-  const maximumDate = moment().format('YYYY-MM-DD');
+  const maximumDate = IsoDateFormat.format(new Date());
 
   return (
     <SpacingsStack scale="s">

--- a/packages/gatsby-theme-docs/src/hooks/use-filtered-release-notes.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-filtered-release-notes.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import { parseIsoDate } from '@commercetools-docs/ui-kit';
 import { useLocation } from '@reach/router';
 import { decode } from 'qss';
 
@@ -17,17 +17,14 @@ const useFilteredReleaseNotes = (releaseNotesNodes) => {
     let foundTopicInFilter = true;
 
     if (queryParams.fromFilterDate) {
-      releaseNoteDateIsSameOrAfterFromFilterDate = moment(
-        releaseNote.date,
-        'D MMMM YYYY'
-      ).isSameOrAfter(moment(queryParams.fromFilterDate, 'YYYY-MM-DD'));
+      releaseNoteDateIsSameOrAfterFromFilterDate =
+        new Date(releaseNote.isoDate) >=
+        parseIsoDate(queryParams.fromFilterDate);
     }
 
     if (queryParams.toFilterDate) {
-      releaseNoteDateIsSameOrBeforeToFilterDate = moment(
-        releaseNote.date,
-        'D MMMM YYYY'
-      ).isSameOrBefore(moment(queryParams.toFilterDate, 'YYYY-MM-DD'));
+      releaseNoteDateIsSameOrBeforeToFilterDate =
+        new Date(releaseNote.isoDate) <= parseIsoDate(queryParams.toFilterDate);
     }
 
     if (queryParams.filterTopics && Array.isArray(queryParams.filterTopics)) {

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
@@ -156,7 +156,10 @@ const LayoutPageNavigation = (props) => {
     return null;
 
   const searchContainer = (
-    <SearchBox excludeFromSearchIndex={props.excludeFromSearchIndex}>
+    <SearchBox
+      key="search-container"
+      excludeFromSearchIndex={props.excludeFromSearchIndex}
+    >
       {props.isSearchBoxInView ? (
         <Blank />
       ) : (
@@ -174,6 +177,7 @@ const LayoutPageNavigation = (props) => {
 
   const navigationContainer = (
     <nav
+      key="search-container"
       aria-label="Page Table of Contents Navigation"
       css={{
         marginBottom: designSystem.dimensions.spacings.l,

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
@@ -177,7 +177,7 @@ const LayoutPageNavigation = (props) => {
 
   const navigationContainer = (
     <nav
-      key="search-container"
+      key="navigation-container"
       aria-label="Page Table of Contents Navigation"
       css={{
         marginBottom: designSystem.dimensions.spacings.l,

--- a/packages/gatsby-theme-docs/src/plugins/rehype-mdx-section.js
+++ b/packages/gatsby-theme-docs/src/plugins/rehype-mdx-section.js
@@ -4,7 +4,7 @@ const isHeading = (node) => {
   if (node.type === 'jsx') {
     // will will later want to introspect here and consider certain of our Api generation JSX
     // as section delimiting "headings" that cause a new section to be started.
-    // this requires parsing the node.value string into a DOM (parse5, see MDX introspection plugin)
+    // this requires parsing the node.value string into a DOM (see MDX introspection plugin)
   }
   return isHastHeading(node);
 };

--- a/packages/gatsby-theme-docs/src/templates/release-notes-list.js
+++ b/packages/gatsby-theme-docs/src/templates/release-notes-list.js
@@ -105,6 +105,7 @@ export const query = graphql`
         slug
         title
         date(formatString: "D MMMM YYYY")
+        isoDate: date
         description
         type
         topics

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -31,7 +31,6 @@
     "@emotion/styled": "^11.0.0",
     "lodash.escape": "4.0.1",
     "lodash.throttle": "4.1.1",
-    "moment": "2.29.1",
     "parse5": "6.0.1",
     "prism-react-renderer": "1.2.1",
     "prop-types": "15.7.2",

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -31,7 +31,6 @@
     "@emotion/styled": "^11.0.0",
     "lodash.escape": "4.0.1",
     "lodash.throttle": "4.1.1",
-    "parse5": "6.0.1",
     "prism-react-renderer": "1.2.1",
     "prop-types": "15.7.2",
     "react-intl": "^5.7.0",

--- a/packages/ui-kit/src/components/rss-feed-table.js
+++ b/packages/ui-kit/src/components/rss-feed-table.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import moment from 'moment';
+import { DocsDateFormat } from '@commercetools-docs/ui-kit';
 import Link from './link';
 import ContentNotifications from './content-notifications';
 import { colors, tokens, dimensions } from '../design-system';
@@ -61,7 +61,7 @@ const RssFeedTable = (props) => {
                       text-decoration: none;
                     `}
                   >
-                    {moment(item.pubDate).format('D MMMM YYYY')}
+                    {DocsDateFormat.format(new Date(item.pubDate))}
                   </Link>
                 </DateWrapper>
               </td>

--- a/packages/ui-kit/src/components/rss-feed-table.js
+++ b/packages/ui-kit/src/components/rss-feed-table.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { DocsDateFormat } from '@commercetools-docs/ui-kit';
+import { DocsDateFormat } from '../utils/dates';
 import Link from './link';
 import ContentNotifications from './content-notifications';
 import { colors, tokens, dimensions } from '../design-system';

--- a/packages/ui-kit/src/index.js
+++ b/packages/ui-kit/src/index.js
@@ -34,6 +34,7 @@ export { default as CodeBlock } from './components/code-block';
 // utils
 export { default as createStyledIcon } from './utils/create-styled-icon';
 export { default as SafeHTMLElement } from './utils/safe-html-element';
+export { parseIsoDate, IsoDateFormat, DocsDateFormat } from './utils/dates';
 
 // hooks
 export { default as useISO310NumberFormatter } from './hooks/use-iso310-number-formatter';

--- a/packages/ui-kit/src/utils/code-block-parse-options.js
+++ b/packages/ui-kit/src/utils/code-block-parse-options.js
@@ -24,6 +24,12 @@ export default function parseCodeBlockOptions(props = {}) {
   // implementation does not support values with whitespaces.
   // https://github.com/mdx-js/mdx/blob/e95e2c114bead01164a8af068ae052cebf1534c2/packages/mdx/mdx-ast-to-mdx-hast.js#L38-L46
   // We mostly need this for things like `title="This is a title"`.
+
+  // TODO parse5 is too large, we could safe enough parse the values with a regex:
+  // (?<attribute>\w*)=(["](?<value_doublequote>.*?)["]|['](?<value_singlequote>.*?)[']|(?<value_noquote>\S*))
+  // it returns one match per attribute-value pair, containing named capture groups
+  // "attribute" and either one of the "value_*" groups
+
   const parsedOptions = parseFragment(`<x ${props.metastring} >`);
   if (!parsedOptions || parsedOptions.childNodes === 0) return intialOptions;
 

--- a/packages/ui-kit/src/utils/code-block-parse-options.js
+++ b/packages/ui-kit/src/utils/code-block-parse-options.js
@@ -1,12 +1,11 @@
-import { parseFragment } from 'parse5';
 import parseNumericRange from './parse-numeric-range';
 
 const getLinesForRange = (value) => {
-  if (!value) return [];
+  if (!value || typeof value !== 'string') return [];
   return parseNumericRange(value.trim()).filter((n) => n > 0);
 };
 
-const intialOptions = {
+const initialOptions = {
   title: undefined,
   highlightLines: [],
   noPromptLines: [],
@@ -15,35 +14,43 @@ const intialOptions = {
 
 const getOptionName = (name) =>
   // NOTE: parsed attribute names are all lowercase
-  Object.keys(intialOptions).find((key) => key.toLowerCase() === name) || name;
+  Object.keys(initialOptions).find((key) => key.toLowerCase() === name) || name;
+
+// returns one match per attribute-value pair, containing named capture groups
+// "attribute" and either one of the "value_*" groups
+// Saved here for testing and editing: https://regex101.com/r/DKJjaO/1
+const parseOptionsRegex =
+  /(?<attribute>\w+)(=["](?<value_doublequote>.*?)["]|=['](?<value_singlequote>.*?)[']|=(?<value_noquote>\S*)|)/g;
+
+const parseOptionsString = (optionsString) => {
+  const parsedOptions = {};
+  const matches = Array.from(optionsString.matchAll(parseOptionsRegex));
+  for (const match of matches) {
+    parsedOptions[getOptionName(match.groups.attribute)] =
+      match.groups.value_doublequote ||
+      match.groups.value_singlequote ||
+      match.groups.value_noquote ||
+      true;
+  }
+  return parsedOptions;
+};
 
 export default function parseCodeBlockOptions(props = {}) {
-  if (!props.metastring) return intialOptions;
+  if (!props.metastring) return initialOptions;
 
   // We need to parse the `metastring` value on our own as the default
-  // implementation does not support values with whitespaces.
+  // MDX implementation does not support values with whitespaces.
   // https://github.com/mdx-js/mdx/blob/e95e2c114bead01164a8af068ae052cebf1534c2/packages/mdx/mdx-ast-to-mdx-hast.js#L38-L46
   // We mostly need this for things like `title="This is a title"`.
+  const normalizedOptions = {
+    ...initialOptions,
+    ...parseOptionsString(props.metastring),
+  };
 
-  // TODO parse5 is too large, we could safe enough parse the values with a regex:
-  // (?<attribute>\w*)=(["](?<value_doublequote>.*?)["]|['](?<value_singlequote>.*?)[']|(?<value_noquote>\S*))
-  // it returns one match per attribute-value pair, containing named capture groups
-  // "attribute" and either one of the "value_*" groups
-
-  const parsedOptions = parseFragment(`<x ${props.metastring} >`);
-  if (!parsedOptions || parsedOptions.childNodes === 0) return intialOptions;
-
-  const normalizedOptions = parsedOptions.childNodes[0].attrs.reduce(
-    (normalizedAttributes, attribute) => ({
-      ...normalizedAttributes,
-      [getOptionName(attribute.name)]: attribute.value,
-    }),
-    {}
-  );
   return {
     title: normalizedOptions.title,
     highlightLines: getLinesForRange(normalizedOptions.highlightLines),
     noPromptLines: getLinesForRange(normalizedOptions.noPromptLines),
-    secondaryTheme: typeof normalizedOptions.secondaryTheme === 'string',
+    secondaryTheme: normalizedOptions.secondaryTheme,
   };
 }

--- a/packages/ui-kit/src/utils/dates.js
+++ b/packages/ui-kit/src/utils/dates.js
@@ -1,7 +1,10 @@
+// This file is written as a CommonJS module because it's also used
+// without a build step in local utility scripts
+
 const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
 // if the date does not contain timezone, JS Date() is fine
-export const parseIsoDate = (dateString) => {
+exports.parseIsoDate = (dateString) => {
   // as an extra safety net enforce UTC midnight
   const UTCDateString = dateString + 'T00:00:00.000Z';
   const date = new Date(UTCDateString);
@@ -10,14 +13,14 @@ export const parseIsoDate = (dateString) => {
 
 // Canada has adopted ISO-8601 so it's used as a replacement for the missing
 // explicit ISO format support in Javascript Intl
-export const IsoDateFormat = new Intl.DateTimeFormat('en-CA', {
+exports.IsoDateFormat = new Intl.DateTimeFormat('en-CA', {
   month: '2-digit',
   day: '2-digit',
   year: 'numeric',
 });
 
 // For docs content we have adopted the British style "4 December 1970" format.
-export const DocsDateFormat = new Intl.DateTimeFormat('en-GB', {
+exports.DocsDateFormat = new Intl.DateTimeFormat('en-GB', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',

--- a/packages/ui-kit/src/utils/dates.js
+++ b/packages/ui-kit/src/utils/dates.js
@@ -1,10 +1,7 @@
-// This file is written as a CommonJS module because it's also used
-// without a build step in local utility scripts
-
 const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
 // if the date does not contain timezone, JS Date() is fine
-exports.parseIsoDate = (dateString) => {
+export const parseIsoDate = (dateString) => {
   // as an extra safety net enforce UTC midnight
   const UTCDateString = dateString + 'T00:00:00.000Z';
   const date = new Date(UTCDateString);
@@ -13,14 +10,14 @@ exports.parseIsoDate = (dateString) => {
 
 // Canada has adopted ISO-8601 so it's used as a replacement for the missing
 // explicit ISO format support in Javascript Intl
-exports.IsoDateFormat = new Intl.DateTimeFormat('en-CA', {
+export const IsoDateFormat = new Intl.DateTimeFormat('en-CA', {
   month: '2-digit',
   day: '2-digit',
   year: 'numeric',
 });
 
 // For docs content we have adopted the British style "4 December 1970" format.
-exports.DocsDateFormat = new Intl.DateTimeFormat('en-GB', {
+export const DocsDateFormat = new Intl.DateTimeFormat('en-GB', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',

--- a/packages/ui-kit/src/utils/dates.js
+++ b/packages/ui-kit/src/utils/dates.js
@@ -1,0 +1,27 @@
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+// if the date does not contain timezone, JS Date() is fine
+export const parseIsoDate = (dateString) => {
+  // as an extra safety net enforce UTC midnight
+  const UTCDateString = dateString + 'T00:00:00.000Z';
+  const date = new Date(UTCDateString);
+  return !isNaN(date.valueOf()) && isoDateRegex.test(dateString) ? date : false;
+};
+
+// Canada has adopted ISO-8601 so it's used as a replacement for the missing
+// explicit ISO format support in Javascript Intl
+export const IsoDateFormat = new Intl.DateTimeFormat('en-CA', {
+  month: '2-digit',
+  day: '2-digit',
+  year: 'numeric',
+});
+
+// For docs content we have adopted the British style "4 December 1970" format.
+export const DocsDateFormat = new Intl.DateTimeFormat('en-GB', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+// if you have to parse such a "docs" date, you likely have a different root problem,
+// formatted dates should never have to be parsed.
+// Worst case use Luxon. Do not use moment.js any more. It's unmaintained and too large.

--- a/websites/api-docs-smoke-test/gatsby-config.js
+++ b/websites/api-docs-smoke-test/gatsby-config.js
@@ -1,4 +1,5 @@
 const isProd = process.env.NODE_ENV === 'production';
+const isCi = process.env.CI ? true : false;
 const {
   configureThemeWithAddOns,
 } = require('@commercetools-docs/gatsby-theme-docs/configure-theme');
@@ -46,5 +47,12 @@ module.exports = {
         },
       ],
     }),
+    {
+      resolve: 'gatsby-plugin-webpack-bundle-analyser-v2',
+      options: {
+        devMode: false,
+        disable: isCi,
+      },
+    },
   ],
 };

--- a/websites/api-docs-smoke-test/gatsby-config.js
+++ b/websites/api-docs-smoke-test/gatsby-config.js
@@ -47,12 +47,5 @@ module.exports = {
         },
       ],
     }),
-    {
-      resolve: 'gatsby-plugin-webpack-bundle-analyser-v2',
-      options: {
-        devMode: false,
-        disable: isCi,
-      },
-    },
   ],
 };

--- a/websites/api-docs-smoke-test/package.json
+++ b/websites/api-docs-smoke-test/package.json
@@ -11,6 +11,7 @@
     "clean:develop": "yarn clean && yarn develop",
     "create-docs-release-note": "npx create-docs-release-note",
     "build": "npx gatsby build --prefix-paths",
+    "build:analyze": "ANALYZE_BUNDLE=true yarn build",
     "prebuild": "yarn clean && yarn predevelop",
     "postbuild": "rm -rf ../../public/api-docs-smoke-test && mkdir -p ../../public && mv public ../../public/api-docs-smoke-test",
     "generate-ramldoc": "npx rmf-codegen generate ./source-raml/test/api.raml --output-folder ./src/api-specs/test --target RAML_DOC"
@@ -23,8 +24,5 @@
     "gatsby-source-filesystem": "3.6.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"
-  },
-  "devDependencies": {
-    "gatsby-plugin-webpack-bundle-analyser-v2": "^1.1.22"
   }
 }

--- a/websites/api-docs-smoke-test/package.json
+++ b/websites/api-docs-smoke-test/package.json
@@ -23,5 +23,8 @@
     "gatsby-source-filesystem": "3.6.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"
+  },
+  "devDependencies": {
+    "gatsby-plugin-webpack-bundle-analyser-v2": "^1.1.22"
   }
 }

--- a/websites/api-docs-smoke-test/package.json
+++ b/websites/api-docs-smoke-test/package.json
@@ -11,6 +11,7 @@
     "clean:develop": "yarn clean && yarn develop",
     "create-docs-release-note": "npx create-docs-release-note",
     "build": "npx gatsby build --prefix-paths",
+    "build:serve": "npx gatsby build --prefix-paths && npx gatsby serve --prefix-paths -o",
     "build:analyze": "ANALYZE_BUNDLE=true yarn build",
     "prebuild": "yarn clean && yarn predevelop",
     "postbuild": "rm -rf ../../public/api-docs-smoke-test && mkdir -p ../../public && mv public ../../public/api-docs-smoke-test",

--- a/websites/docs-smoke-test/package.json
+++ b/websites/docs-smoke-test/package.json
@@ -11,6 +11,7 @@
     "create-docs-release-note": "npx create-docs-release-note",
     "build": "npx gatsby build --prefix-paths",
     "build:serve": "npx gatsby build --prefix-paths && npx gatsby serve --prefix-paths -o",
+    "build:analyze": "ANALYZE_BUNDLE=true yarn build",
     "prebuild": "yarn clean",
     "postbuild": "rm -rf ../../public/docs-smoke-test && mkdir -p ../../public && mv public ../../public/docs-smoke-test",
     "generate-icons": "svgr -d src/icons/generated src/icons/svg"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11218,7 +11218,7 @@ gatsby-plugin-utils@^1.6.0:
   dependencies:
     joi "^17.2.1"
 
-gatsby-plugin-webpack-bundle-analyser-v2@1.1.22, gatsby-plugin-webpack-bundle-analyser-v2@^1.1.22:
+gatsby-plugin-webpack-bundle-analyser-v2@1.1.22:
   version "1.1.22"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-webpack-bundle-analyser-v2/-/gatsby-plugin-webpack-bundle-analyser-v2-1.1.22.tgz#472887ea94a7934d8b609beb9b1cba46b86eab28"
   integrity sha512-ZhUBv+7GnunHoYzAUQKxD2TEOwtqE1fiu1UX9d1a4+GgYbQEtXDhduJHmeqJxCGyRPKmJPItGtExpoFVEPdMwA==
@@ -16049,7 +16049,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@2.29.1, moment@^2.27.0:
+moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11218,7 +11218,7 @@ gatsby-plugin-utils@^1.6.0:
   dependencies:
     joi "^17.2.1"
 
-gatsby-plugin-webpack-bundle-analyser-v2@1.1.22:
+gatsby-plugin-webpack-bundle-analyser-v2@1.1.22, gatsby-plugin-webpack-bundle-analyser-v2@^1.1.22:
   version "1.1.22"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-webpack-bundle-analyser-v2/-/gatsby-plugin-webpack-bundle-analyser-v2-1.1.22.tgz#472887ea94a7934d8b609beb9b1cba46b86eab28"
   integrity sha512-ZhUBv+7GnunHoYzAUQKxD2TEOwtqE1fiu1UX9d1a4+GgYbQEtXDhduJHmeqJxCGyRPKmJPItGtExpoFVEPdMwA==


### PR DESCRIPTION
Following our discussion concerning the size and performance,  this PR does 

 * tweak documentation and start scripts on how to do the bundle size analysis. you can run `yarn build:analyze` as a shortcut to run the bundle analysis on 
 * remove the dependency on the full HTML parser "parse5" by doing the metaproperty parsing of code blocks with an own regex based implementation.  (I know, I voted for using the parser, but that was at a time when we needed it for other purposes anyways)
 * remove dependency on moment.js  (time library).  It's only gone from our code now but still in some bundle because it's used in the UI Kit calendar widget.   But it's not in all bundles any more now (it was due the RSS feature) but only in the release notes list. 
