### PR TITLE
fix: Misleading Query Parameter Type Rendering

### DIFF
--- a/.changeset/query-parameter.md
+++ b/.changeset/query-parameter.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-api-docs': patch
+---
+
+fix: query parameters of type array now renderd as string with additional auto-generated description of usage

--- a/packages/gatsby-theme-api-docs/.eslintrc.yml
+++ b/packages/gatsby-theme-api-docs/.eslintrc.yml
@@ -1,1 +1,2 @@
-{}
+rules:
+  'react/react-in-jsx-scope': 'off'

--- a/packages/gatsby-theme-api-docs/src/components/info.js
+++ b/packages/gatsby-theme-api-docs/src/components/info.js
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+import { colors, dimensions, typography } from '../design-system';
+
+const Info = styled.span`
+  display: inline-block;
+  border: 1px solid ${colors.light.borderInfo};
+  background-color: ${colors.light.surfaceInfo};
+  padding: ${dimensions.spacings.xxs} ${dimensions.spacings.xs};
+  font-size: ${typography.fontSizes.small};
+`;
+
+export default Info;

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
@@ -14,6 +13,7 @@ import Url from './url';
 import Scopes from './scopes';
 import Responses from './responses';
 import Parameters from './parameters';
+import QueryParameters from './query-parameters';
 import RequestRepresentation from './request-representation';
 import { DescriptionParagraph } from '../../description';
 import RequestResponseExamples from './request-response-examples';
@@ -96,10 +96,10 @@ const Method = ({
               )}
 
               {method.queryParameters && (
-                <Parameters
+                <QueryParameters
                   apiKey={apiKey}
                   title={'Query parameters'}
-                  parameters={method.queryParameters}
+                  queryParameters={method.queryParameters}
                 />
               )}
 

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/parameters.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/parameters.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import {
@@ -6,12 +5,12 @@ import {
   designSystem as uiKitDesignSystem,
 } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
-import { useTypeLocations } from '../../../hooks/use-type-locations';
-import generateTypeToRender from '../../../utils/generate-type-to-render';
+import useTypeToRender from '../../../hooks/use-type-to-render';
 import Required from '../../required';
 import Table from '../../table';
 import Title from './title';
 import { DescriptionText } from '../../description';
+import Info from '../../info';
 
 // inline-blocks inside a block are wrapped first before wrapping inline.
 // this implements a wrapping behavior where property name and type are separated
@@ -26,47 +25,18 @@ const PropertyType = styled.div`
 `;
 
 const Parameters = (props) => {
-  const typeLocations = useTypeLocations();
-
   return (
     <SpacingsStack scale="xs">
       {props.title && <Title>{props.title}:</Title>}
       <Table>
         <tbody>
           {props.parameters.map((parameter) => {
-            const typeToRender = generateTypeToRender({
-              typeLocations,
-              property: parameter,
-              apiKey: props.apiKey,
-            });
-
             return (
-              <tr key={parameter.name}>
-                <td>
-                  <PropertyName className="name-type">
-                    <Markdown.InlineCode>{parameter.name}</Markdown.InlineCode>
-                    {parameter.required && <Required />}
-                  </PropertyName>
-                  <PropertyType className="name name-type">
-                    {typeToRender.displayPrefix && (
-                      <span className="name">{typeToRender.displayPrefix}</span>
-                    )}
-
-                    {typeof typeToRender.type === 'string' ? (
-                      <span className="name">{typeToRender.type}</span>
-                    ) : (
-                      typeToRender.type
-                    )}
-                  </PropertyType>
-                </td>
-                <td>
-                  {parameter.description ? (
-                    <DescriptionText markdownString={parameter.description} />
-                  ) : (
-                    '-'
-                  )}
-                </td>
-              </tr>
+              <ParameterRow
+                key={parameter.name}
+                apiKey={props.apiKey}
+                parameter={parameter}
+              />
             );
           })}
         </tbody>
@@ -74,11 +44,78 @@ const Parameters = (props) => {
     </SpacingsStack>
   );
 };
-
 Parameters.propTypes = {
   apiKey: PropTypes.string,
   title: PropTypes.string,
-  parameters: PropTypes.arrayOf(PropTypes.object).isRequired,
+  parameters: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+      required: PropTypes.bool,
+      description: PropTypes.string,
+      items: PropTypes.shape({
+        type: PropTypes.string,
+      }),
+    }).isRequired
+  ).isRequired,
 };
+Parameters.displayName = 'Parameters';
+
+function ParameterRow(props) {
+  const typeToRender = useTypeToRender({
+    property: props.parameter,
+    apiKey: props.apiKey,
+    isParameter: true,
+  });
+  return (
+    <tr key={props.parameter.name}>
+      <td>
+        <PropertyName className="name-type">
+          <Markdown.InlineCode>{props.parameter.name}</Markdown.InlineCode>
+          {props.parameter.required && <Required />}
+        </PropertyName>
+        <PropertyType className="name name-type">
+          {typeToRender.displayPrefix && (
+            <span className="name">{typeToRender.displayPrefix}</span>
+          )}
+
+          {typeof typeToRender.type === 'string' ? (
+            <span className="name">{typeToRender.type}</span>
+          ) : (
+            typeToRender.type
+          )}
+        </PropertyType>
+      </td>
+      <td>
+        <SpacingsStack scale="xs">
+          {props.parameter.description ? (
+            <DescriptionText markdownString={props.parameter.description} />
+          ) : (
+            '-'
+          )}
+          {props.parameter.additionalDescription && (
+            <div>
+              <Info>{props.parameter.additionalDescription}</Info>
+            </div>
+          )}
+        </SpacingsStack>
+      </td>
+    </tr>
+  );
+}
+ParameterRow.propTypes = {
+  apiKey: PropTypes.string,
+  parameter: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    required: PropTypes.bool,
+    description: PropTypes.string,
+    additionalDescription: PropTypes.string,
+    items: PropTypes.shape({
+      type: PropTypes.string,
+    }),
+  }).isRequired,
+};
+ParameterRow.displayName = 'ParameterRow';
 
 export default Parameters;

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/query-parameters.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/query-parameters.js
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types';
+import Parameters from './parameters';
+
+function transformQueryParameterDescriptions(queryParameters) {
+  return queryParameters.map((parameter) => {
+    if (parameter.type === 'array' && parameter.items) {
+      parameter.additionalDescription =
+        'The parameter can be passed multiple times.';
+    }
+
+    return parameter;
+  });
+}
+
+function QueryParameters(props) {
+  const parameters = transformQueryParameterDescriptions(props.queryParameters);
+  return (
+    <Parameters
+      apiKey={props.apiKey}
+      title={props.title}
+      parameters={parameters}
+    />
+  );
+}
+
+QueryParameters.propTypes = {
+  apiKey: PropTypes.string,
+  title: PropTypes.string,
+  queryParameters: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+      required: PropTypes.bool,
+      description: PropTypes.string,
+      items: PropTypes.shape({
+        type: PropTypes.string,
+      }),
+    }).isRequired
+  ).isRequired,
+};
+QueryParameters.displayName = 'QueryParameters';
+
+export default QueryParameters;

--- a/packages/gatsby-theme-api-docs/src/components/type/properties/rows/description.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/properties/rows/description.js
@@ -1,28 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { Markdown, useISO310NumberFormatter } from '@commercetools-docs/ui-kit';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
-import { colors, dimensions, typography } from '../../../../design-system';
 import extractAdditionalInfo from '../../../../utils/extract-additional-info';
 import capitalizeFirst from '../../../../utils/capitalize-first';
 import { useApiTypeByApiKeyAndDisplayName } from '../../../../hooks/use-api-types';
 import { DescriptionText } from '../../../description';
+import Info from '../../../info';
 
 const customCodeStyle = css`
   border: none;
   background-color: unset;
   padding: 0;
-`;
-
-const Info = styled.span`
-  display: inline-block;
-  border: 1px solid ${colors.light.borderInfo};
-  background-color: ${colors.light.surfaceInfo};
-  padding: ${dimensions.spacings.xxs} ${dimensions.spacings.xs};
-  font-size: ${typography.fontSizes.small};
 `;
 
 const ConstantLikeEnumDescription = (props) => {

--- a/packages/gatsby-theme-api-docs/src/components/type/properties/rows/name-type.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/properties/rows/name-type.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
@@ -6,8 +5,7 @@ import { designSystem, Markdown } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import { BetaFlag } from '@commercetools-docs/gatsby-theme-docs';
 import { typography } from '../../../../design-system';
-import { useTypeLocations } from '../../../../hooks/use-type-locations';
-import generateTypeToRender from '../../../../utils/generate-type-to-render';
+import useTypeToRender from '../../../../hooks/use-type-to-render';
 import Required from '../../../required';
 
 // inline-blocks inside a block are wrapped first before wrapping inline.
@@ -21,12 +19,10 @@ const BetaWrapper = styled.span`
   font-size: ${typography.fontSizes.body};
 `;
 
-const NameType = ({ apiKey, property }) => {
-  const typeLocations = useTypeLocations();
-  const typeToRender = generateTypeToRender({
-    typeLocations,
-    property,
-    apiKey,
+const NameType = (props) => {
+  const typeToRender = useTypeToRender({
+    property: props.property,
+    apiKey: props.apiKey,
   });
 
   const isRegex = (string) =>
@@ -39,7 +35,7 @@ const NameType = ({ apiKey, property }) => {
   return (
     <SpacingsStack scale="xs">
       <PropertyName className="name-type">
-        {isRegex(property.name) ? (
+        {isRegex(props.property.name) ? (
           <Markdown.InlineCode>
             <span
               css={css`
@@ -48,7 +44,7 @@ const NameType = ({ apiKey, property }) => {
             >
               /
             </span>
-            {getExpressionInsideSlashes(property.name)[1]}
+            {getExpressionInsideSlashes(props.property.name)[1]}
             <span
               css={css`
                 color: ${designSystem.colors.light.textInfo};
@@ -58,10 +54,10 @@ const NameType = ({ apiKey, property }) => {
             </span>
           </Markdown.InlineCode>
         ) : (
-          <Markdown.InlineCode>{property.name}</Markdown.InlineCode>
+          <Markdown.InlineCode>{props.property.name}</Markdown.InlineCode>
         )}
-        {property.required && <Required />}
-        {property.beta && (
+        {props.property.required && <Required />}
+        {props.property.beta && (
           <BetaWrapper>
             <BetaFlag />
           </BetaWrapper>
@@ -71,7 +67,7 @@ const NameType = ({ apiKey, property }) => {
         {typeToRender.displayPrefix && (
           <span className="name">{typeToRender.displayPrefix}</span>
         )}
-        {isRegex(property.name) ? (
+        {isRegex(props.property.name) ? (
           <span className="name">
             Any property matching regular expression above
           </span>

--- a/packages/gatsby-theme-api-docs/src/hooks/use-type-to-render.js
+++ b/packages/gatsby-theme-api-docs/src/hooks/use-type-to-render.js
@@ -1,0 +1,14 @@
+import { useTypeLocations } from './use-type-locations';
+import generateTypeToRender from '../utils/generate-type-to-render';
+
+function useTypeToRender({ property, apiKey, isParameter } = {}) {
+  const typeLocations = useTypeLocations();
+  return generateTypeToRender({
+    typeLocations,
+    property,
+    apiKey,
+    isParameter,
+  });
+}
+
+export default useTypeToRender;

--- a/packages/gatsby-theme-api-docs/src/utils/generate-type-to-render.js
+++ b/packages/gatsby-theme-api-docs/src/utils/generate-type-to-render.js
@@ -1,13 +1,18 @@
 import capitalizeFirst from './capitalize-first';
 import renderTypeAsLink from './render-type-as-link';
 
-function generateTypeToRender({ typeLocations, property, apiKey }) {
+function generateTypeToRender({
+  typeLocations,
+  property,
+  apiKey,
+  isParameter,
+}) {
   let displayPrefix;
   let type;
 
   if (property.type === 'array' && property.items) {
     type = property.items.type;
-    displayPrefix = 'Array of ';
+    displayPrefix = isParameter ? '' : 'Array of ';
   } else if (isConstantLikeAndIsNotPrimitiveType(property)) {
     type = property.builtinType;
   } else {

--- a/websites/api-docs-smoke-test/package.json
+++ b/websites/api-docs-smoke-test/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "yarn develop",
-    "predevelop": "yarn generate-ramldoc:test",
+    "predevelop": "yarn generate-ramldoc",
     "develop": "npx gatsby develop",
     "serve": "npx gatsby serve --prefix-paths -o",
     "clean": "npx gatsby clean",
@@ -15,7 +15,8 @@
     "build:analyze": "ANALYZE_BUNDLE=true yarn build",
     "prebuild": "yarn clean && yarn predevelop",
     "postbuild": "rm -rf ../../public/api-docs-smoke-test && mkdir -p ../../public && mv public ../../public/api-docs-smoke-test",
-    "generate-ramldoc": "yarn generate-ramldoc:test",
+    "generate-ramldoc": "yarn generate-ramldoc:test && yarn generate-ramldoc:api",
+    "generate-ramldoc:api": "npx rmf-codegen generate ../../api-specs/api/api.raml --output-folder ./src/api-specs/api --target RAML_DOC",
     "generate-ramldoc:test": "npx rmf-codegen generate ../../api-specs/test/api.raml --output-folder ./src/api-specs/test --target RAML_DOC"
   },
   "dependencies": {

--- a/websites/api-docs-smoke-test/src/content/endpoints/methods.mdx
+++ b/websites/api-docs-smoke-test/src/content/endpoints/methods.mdx
@@ -126,3 +126,21 @@ import { ApiEndpoint } from "/shortcodes"
   resource="/{projectKey}/resource/{id}"
   method="DELETE"
 />
+
+# Query Parameters with multiple instances
+
+The types of `expand`, `sort`, `where`, and `/^var[.][a-zA-Z0-9]+$/` will be rendered as a `String`. An additional description will be auto-generated to illustrate usage.
+
+```jsx
+<ApiEndpoint
+  apiKey="api"
+  resource="/{projectKey}/api-clients"
+  method="GET"
+/>
+```
+
+<ApiEndpoint
+  apiKey="api"
+  resource="/{projectKey}/api-clients"
+  method="GET"
+/>


### PR DESCRIPTION
Closes #1019 

Replaces #1022 


See the query parameters at https://commercetools-docs-kit-git-ao-query-parameter-v2-commercetools.vercel.app/api-docs-smoke-test/endpoints/methods#query-parameters-with-multiple-instances for rendered type and additional description. In this case `sort`, `where` and `/^var[.][a-zA-Z0-9]+$/` has the additional descriptions.