### PR TITLE
Upgrade rmf-codegen to version 0.18

### DIFF
--- a/.changeset/little-gifts-remember.md
+++ b/.changeset/little-gifts-remember.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/rmf-codegen': minor
+---
+
+upgrade rmf-codegen to 0.18

--- a/.changeset/little-gifts-remember.md
+++ b/.changeset/little-gifts-remember.md
@@ -1,5 +1,7 @@
 ---
 '@commercetools-docs/rmf-codegen': minor
+'@commercetools-docs/gatsby-theme-docs': patch
 ---
 
-upgrade rmf-codegen to 0.18
+- upgrade rmf-codegen to 0.18
+- bug fix

--- a/packages/gatsby-theme-docs/src/layouts/content-homepage.js
+++ b/packages/gatsby-theme-docs/src/layouts/content-homepage.js
@@ -42,6 +42,7 @@ const LayoutContentHomepage = (props) => {
           {...layoutState.topMenu}
           siteTitle={siteData.siteMetadata.title}
           excludeFromSearchIndex={props.pageData.excludeFromSearchIndex}
+          allowWideContentLayout={props.pageData.allowWideContentLayout}
         />
         <LayoutPageWrapper>
           <LayoutPageWithHero
@@ -76,6 +77,7 @@ LayoutContentHomepage.propTypes = {
     beta: PropTypes.bool.isRequired,
     isGlobalBeta: PropTypes.bool.isRequired,
     excludeFromSearchIndex: PropTypes.bool.isRequired,
+    allowWideContentLayout: PropTypes.bool.isRequired,
   }).isRequired,
   heroBackground: PropTypes.shape({
     publicURL: PropTypes.string.isRequired,

--- a/packages/gatsby-theme-docs/src/templates/homepage.js
+++ b/packages/gatsby-theme-docs/src/templates/homepage.js
@@ -55,6 +55,7 @@ HomepageTemplate.propTypes = {
       beta: PropTypes.bool.isRequired,
       isGlobalBeta: PropTypes.bool.isRequired,
       excludeFromSearchIndex: PropTypes.bool.isRequired,
+      allowWideContentLayout: PropTypes.bool.isRequired,
       body: PropTypes.string.isRequired,
     }).isRequired,
     heroBackground: PropTypes.shape({
@@ -72,6 +73,7 @@ export const query = graphql`
       beta
       isGlobalBeta
       excludeFromSearchIndex
+      allowWideContentLayout
       body
     }
     heroBackground: file(relativePath: { eq: $heroBackgroundRelativePath }) {

--- a/packages/rmf-codegen/README.md
+++ b/packages/rmf-codegen/README.md
@@ -31,6 +31,6 @@ You can provide the command globally too via `npm install -g @commercetools-docs
 
 To update the `rmf-codegen` version, update the custom `rmfCodegenVersion` property in `package.json`.
 
-Versions can be found on Bintray here - https://bintray.com/vrapio/vrapio/rmf-codegen#.
+The rmf-codegen JAR is downloaded from [the project's GitHub releases page](https://github.com/commercetools/rmf-codegen/releases).
 
-For more help on getting an appropriate version, create an issue here - https://github.com/vrapio/rmf-codegen/issues.
+For more help on getting an appropriate version, create an issue here - https://github.com/commercetools/rmf-codegen/issues.

--- a/packages/rmf-codegen/package.json
+++ b/packages/rmf-codegen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@commercetools-docs/rmf-codegen",
   "version": "12.3.0",
-  "rmfCodegenVersion": "0.1.7",
+  "rmfCodegenVersion": "0.1.8",
   "description": "Provides RMF-Codegen to javascript projects",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
This enables using the original RAML baseURI instead of the custom annotation and does not name the examples "postman" any more if they are sourced from the custom `(postman)` annotation