### PR TITLE
refactor: use indexes for type-locations hook

### DIFF
--- a/.changeset/modern-guests-speak.md
+++ b/.changeset/modern-guests-speak.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-api-docs': patch
+---
+
+Use index for type locations to improve performance.


### PR DESCRIPTION
is part of #984 

I have now implemented two indexes for the normal type locations and the type location overrides. After doing some testing, I think this should really improve performance.