### PR TITLE
retrieve rmf-codegen version from maven metadata

### DIFF
--- a/packages/rmf-codegen/.gitignore
+++ b/packages/rmf-codegen/.gitignore
@@ -1,1 +1,1 @@
-bin/rmf-codegen-*.jar
+bin/rmf-codegen*.jar

--- a/packages/rmf-codegen/package.json
+++ b/packages/rmf-codegen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@commercetools-docs/rmf-codegen",
   "version": "12.4.0",
-  "rmfCodegenVersion": "0.1.10",
+  "rmfCodegenVersion": "^0.1.7",
   "description": "Provides RMF-Codegen to javascript projects",
   "license": "MIT",
   "publishConfig": {
@@ -15,5 +15,8 @@
   "bin": {
     "rmf-codegen": "bin/rmf-codegen.js"
   },
-  "dependencies": {}
+  "dependencies": {
+    "cheerio": "1.0.0-rc.10",
+    "semver": "^7.3.5"
+  }
 }

--- a/packages/rmf-codegen/scripts/download-rmf-codegen.js
+++ b/packages/rmf-codegen/scripts/download-rmf-codegen.js
@@ -5,9 +5,16 @@ const shelljs = require('shelljs');
 const { rmfCodegenVersion } = require('../package.json');
 
 const binPath = path.join(__dirname, '../bin');
-const jarName = `rmf-codegen-${rmfCodegenVersion}.jar`;
-const jarPath = path.join(binPath, jarName);
-const downloadURI = `https://github.com/commercetools/rmf-codegen/releases/download/${rmfCodegenVersion}/rmf-codegen.jar`;
+const linkPath = path.join(binPath, "rmf-codegen.jar")
+const jarName = (version) => `rmf-codegen-${version}.jar`;
+const jarPath = (version) => path.join(binPath, jarName(version));
+const downloadURI = (version) => `https://github.com/commercetools/rmf-codegen/releases/download/${version}/rmf-codegen.jar`;
+
+const cheerio = require('cheerio');
+const semver = require("semver");
+const { version } = require('react');
+const mavenRepo = "https://repo1.maven.org/maven2/com/commercetools/rmf/cli-application/"
+const mavenMeta = mavenRepo + "maven-metadata.xml"
 
 const abortIfError = (result) => {
   if (result.code > 0) {
@@ -24,10 +31,10 @@ const isJavaInstalled = () => {
   }
 };
 
-const downloadArchive = async (url) => {
+const downloadArchive = async (url, filePath) => {
   // Download the archive
   const res = await fetch(url);
-  const fileStream = fs.createWriteStream(jarPath);
+  const fileStream = fs.createWriteStream(filePath);
   await new Promise((resolve, reject) => {
     res.body.pipe(fileStream);
     res.body.on('error', (error) => {
@@ -37,8 +44,24 @@ const downloadArchive = async (url) => {
   });
 
   // Assign proper write permissions to the file
-  abortIfError(shelljs.chmod(755, jarPath));
+  abortIfError(shelljs.chmod(755, filePath));
+  abortIfError(shelljs.ln("-sf", filePath, linkPath))
 };
+
+const readMavenMeta = async (url) => {
+  const res = await fetch(url);
+  return res.text()
+}
+
+const retrieveInstallVersion = (xml) => {
+  const $ = cheerio.load(xml)
+  var versions = $("version").map(function () {
+    return $(this).text()
+  }).toArray()
+
+  const version = semver.maxSatisfying(versions, rmfCodegenVersion)
+  return version
+}
 
 if (!isJavaInstalled()) {
   console.warn(
@@ -46,19 +69,25 @@ if (!isJavaInstalled()) {
   );
 }
 console.log('[rmf-codegen] Verifying rmf-codegen installation...');
-if (fs.existsSync(jarPath)) {
-  console.log(
-    '[rmf-codegen] rmf-codegen jar already installed, skipping installation...'
-  );
-} else {
-  console.log('[rmf-codegen] Installing rmf-codegen jar..');
-  downloadArchive(downloadURI).then(
-    () => {
-      console.log('[rmf-codegen] rmf-codegen jar installed.');
-    },
-    (error) => {
-      console.error('[rmf-codegen] Error installing rmf-codegen jar', error);
-      process.exit(1);
-    }
-  );
-}
+
+readMavenMeta(mavenMeta).then(retrieveInstallVersion).then((version) => {
+  const jarFilePath = jarPath(version)
+  if (fs.existsSync(jarFilePath)) {
+    console.log(
+      '[rmf-codegen] rmf-codegen jar already installed, skipping installation...'
+    );
+  } else {
+    console.log('[rmf-codegen] Installing rmf-codegen jar..');
+    const jarUri = downloadURI(version);
+    downloadArchive(jarUri, jarFilePath).then(
+      () => {
+        console.log('[rmf-codegen] rmf-codegen jar installed.');
+      },
+      (error) => {
+        console.error('[rmf-codegen] Error installing rmf-codegen jar', error);
+        process.exit(1);
+      }
+    );
+  }
+})
+

--- a/packages/rmf-codegen/src/run.js
+++ b/packages/rmf-codegen/src/run.js
@@ -5,7 +5,7 @@ const { rmfCodegenVersion } = require('../package.json');
 function run(args) {
   const jarFile = path.resolve(
     __dirname,
-    `../bin/rmf-codegen-${rmfCodegenVersion}.jar`
+    `../bin/rmf-codegen.jar`
   );
 
   return spawn('java', ['-jar', jarFile, ...args], {


### PR DESCRIPTION
It's somewhat annoying to always update the docs-kit then update docs repo and then maybe the docs branch.

I added a function which reads the maven metadata of the codegen cli application, retrieves the latest version according to the rmfCodegenVersion based on the semver constraint. Then downloads this version and creates a symlink to the downloaded version. The symlink is then used as stable executable target for running the codegen 