### PR TITLE
fix: move site-title id to actual site title

### DIFF
--- a/.changeset/tiny-pandas-chew.md
+++ b/.changeset/tiny-pandas-chew.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Fix css bug in search dialog.

--- a/.changeset/tiny-pandas-chew.md
+++ b/.changeset/tiny-pandas-chew.md
@@ -2,4 +2,4 @@
 '@commercetools-docs/gatsby-theme-docs': patch
 ---
 
-Fix css bug in search dialog.
+Use another element to select the site-title for algolia search. This should fix the issue with having wrong content in the search results.

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -351,10 +351,10 @@ const Sidebar = (props) => {
         <WebsiteTitle theme={theme}>
           <SpacingsStack scale="xs">
             <div>{props.isGlobalBeta && <BetaFlag />}</div>
-            <WebsiteTitleLink as={Link} id="site-title" to="/" theme={theme}>
+            <WebsiteTitleLink as={Link} to="/" theme={theme}>
               <SpacingsInline scale="s">
                 <SiteIcon />
-                <span>{props.siteTitle}</span>
+                <span id="site-title">{props.siteTitle}</span>
               </SpacingsInline>
             </WebsiteTitleLink>
           </SpacingsStack>


### PR DESCRIPTION
is part of #1053 

In the docsearch config, we point to the `#site-title` id in order to find the header sections for the result list. Since we implemented the icons next to the site titles, we should move the id only to the actual title and not together with the icon.