### PR TITLE
use prettier formatter for raml files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -8,6 +8,13 @@
       "options": {
         "parser": "json"
       }
+    },
+    {
+      "files": "*.raml",
+      "options": {
+        "parser": "yaml",
+        "proseWrap": "preserve"
+      }
     }
   ]
 }


### PR DESCRIPTION
We want to use the same prettierrc config for raml files as in the docs repo.
See slack discussion [here](https://commercetools.slack.com/archives/GG00MD84Q/p1633334835001200):