### PR TITLE
fix: deprecated link for product newsletter page

### DIFF
--- a/.changeset/pink-carpets-attack.md
+++ b/.changeset/pink-carpets-attack.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Use new link for product newsletter page

--- a/packages/gatsby-theme-docs/src/components/release-notes-subscribe-links.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-subscribe-links.js
@@ -38,7 +38,7 @@ const ReleaseNotesSubscribeLinks = () => (
       </SpacingsInline>
     </ExternalSiteLink>
     <ExternalSiteLink
-      href="https://ok.commercetools.com/product-newsletter"
+      href="https://commercetools.com/newsletter/product"
       css={linkStyles}
     >
       <SpacingsInline scale="xs" alignItems="center">


### PR DESCRIPTION
Since we have a new marketing website, the url for the product newsletter page has changed. We need to use the new one to avoid broken links.