### PR TITLE
CI: disable renovate lock file maintanance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,7 @@
     }
   ],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": false
   },
   "labels": ["🤖 Type: Dependencies"],
   "ignoreDeps": ["gatsby-remark-relative-images"]


### PR DESCRIPTION
To reduce the amount of CI, vercel, people and Percy time
we're using due to automated dependency update PRs
this turns of the "lock file maintenance" feature of renovate .

We do not use ranged versions in our packages and also run
automated updates on all dependencies regularly (which implicitly
updates the transitive dependencies, too).  The separate step
of updating transitive dependencies does not provide sufficient value
in this context.  Maybe a few days or one week earlier for some indirect
dependency, but not worth the effort.