### PR TITLE
fix: missing readmes

### DIFF
--- a/.changeset/rude-crabs-fetch.md
+++ b/.changeset/rude-crabs-fetch.md
@@ -1,0 +1,12 @@
+---
+"@commercetools-docs/gatsby-theme-api-docs": patch
+"@commercetools-docs/gatsby-theme-code-examples": patch
+"@commercetools-docs/gatsby-theme-constants": patch
+"@commercetools-docs/gatsby-theme-docs": patch
+"@commercetools-docs/gatsby-transformer-mdx-introspection": patch
+"@commercetools-docs/gatsby-transformer-raml": patch
+"@commercetools-docs/ui-kit": patch
+"@commercetools-docs/writing-style": patch
+---
+
+Point READMEs to new documentation website.

--- a/packages/gatsby-theme-api-docs/README.md
+++ b/packages/gatsby-theme-api-docs/README.md
@@ -1,0 +1,3 @@
+# Gatsby Theme Add-On for API docs
+
+See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-api-docs).

--- a/packages/gatsby-theme-api-docs/package.json
+++ b/packages/gatsby-theme-api-docs/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-theme-api-docs"
   },
+  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-api-docs",
   "keywords": [
     "gatsby",
     "gatsby-plugin",

--- a/packages/gatsby-theme-code-examples/README.md
+++ b/packages/gatsby-theme-code-examples/README.md
@@ -1,0 +1,3 @@
+# Gatsby Theme Add-On for Code Examples
+
+See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-code-examples).

--- a/packages/gatsby-theme-code-examples/package.json
+++ b/packages/gatsby-theme-code-examples/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-theme-code-examples"
   },
+  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-code-examples",
   "keywords": ["gatsby", "gatsby-plugin", "gatsby-theme", "code", "examples"],
   "dependencies": {
     "@commercetools-docs/ui-kit": "18.1.0",

--- a/packages/gatsby-theme-constants/README.md
+++ b/packages/gatsby-theme-constants/README.md
@@ -1,0 +1,3 @@
+# Gatsby Theme Add-On for Constants
+
+See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-constants).

--- a/packages/gatsby-theme-constants/package.json
+++ b/packages/gatsby-theme-constants/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-theme-constants"
   },
+  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-constants",
   "keywords": ["gatsby", "gatsby-plugin", "gatsby-theme", "yaml", "constants"],
   "dependencies": {
     "@commercetools-docs/ui-kit": "18.1.0",

--- a/packages/gatsby-theme-docs/README.md
+++ b/packages/gatsby-theme-docs/README.md
@@ -1,0 +1,3 @@
+# Gatsby Theme Docs
+
+See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/setup).

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-theme-docs"
   },
+  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/setup",
   "bin": {
     "create-docs-release-note": "bin/create-release-note.js"
   },

--- a/packages/gatsby-transformer-mdx-introspection/README.md
+++ b/packages/gatsby-transformer-mdx-introspection/README.md
@@ -1,0 +1,3 @@
+# Gatsby Transformer MDX Introspection
+
+See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/plugins#gatsby-transformer-mdx-introspection).

--- a/packages/gatsby-transformer-mdx-introspection/package.json
+++ b/packages/gatsby-transformer-mdx-introspection/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-transformer-mdx-introspection"
   },
+  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/plugins#gatsby-transformer-mdx-introspection",
   "keywords": ["gatsby", "gatsby-plugin", "mdx"],
   "dependencies": {
     "@babel/parser": "7.16.8",

--- a/packages/gatsby-transformer-raml/README.md
+++ b/packages/gatsby-transformer-raml/README.md
@@ -1,0 +1,3 @@
+# Gatsby Transformer RAML
+
+See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/plugins#gatsby-transformer-raml).

--- a/packages/gatsby-transformer-raml/package.json
+++ b/packages/gatsby-transformer-raml/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-transformer-raml"
   },
+  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/plugins#gatsby-transformer-raml",
   "keywords": ["gatsby", "gatsby-plugin", "gatsby-transformer", "raml"],
   "dependencies": {
     "firstline": "^2.0.2",

--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -1,0 +1,3 @@
+# UI Components Library
+
+See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/packages#ui-components-library).

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/ui-kit"
   },
+  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/packages#ui-components-library",
   "main": "dist/commercetools-docs-ui-kit.cjs.js",
   "module": "dist/commercetools-docs-ui-kit.esm.js",
   "files": ["dist", "package.json", "LICENSE", "README.md"],

--- a/packages/writing-style/README.md
+++ b/packages/writing-style/README.md
@@ -1,0 +1,3 @@
+# commercetools Writing Style Linter
+
+See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/packages#commercetools-writing-style-linter).

--- a/packages/writing-style/package.json
+++ b/packages/writing-style/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/writing-style"
   },
+  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/packages#commercetools-writing-style-linter",
   "bin": {
     "commercetools-vale": "./bin/commercetools-vale.js",
     "commercetools-vale-bin": "./bin/commercetools-vale-bin.js"


### PR DESCRIPTION
Caused by #1122

PS: The readmes contain links to the new documentation pages. It's important to have the actual file so that in the NPM website you can at least see something and click on the link.