### PR TITLE
fix: global notification overlap with scroll top anchor positions

### DIFF
--- a/.changeset/wild-files-drop.md
+++ b/.changeset/wild-files-drop.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+'@commercetools-docs/ui-kit': patch
+---
+
+Improve layout of global notification, especially the relation with scroll top anchor positions to not overlap with notification.

--- a/packages/gatsby-theme-docs/src/components/global-notification.js
+++ b/packages/gatsby-theme-docs/src/components/global-notification.js
@@ -45,6 +45,8 @@ const Container = styled.div`
     }
   }};
   padding: ${designSystem.dimensions.spacings.s};
+  max-height: ${designSystem.dimensions.heights.globalNotificationContent};
+  overflow: hidden;
 
   @media screen and (${designSystem.dimensions.viewports.desktop}) {
     padding: ${designSystem.dimensions.spacings.s}

--- a/packages/gatsby-theme-docs/src/layouts/content-homepage.js
+++ b/packages/gatsby-theme-docs/src/layouts/content-homepage.js
@@ -20,7 +20,10 @@ const LayoutContentHomepage = (props) => {
   const siteData = useSiteData();
 
   return (
-    <LayoutApplication websitePrimaryColor={props.pageData.websitePrimaryColor}>
+    <LayoutApplication
+      websitePrimaryColor={props.pageData.websitePrimaryColor}
+      globalNotification={props.pageData.globalNotification}
+    >
       <LayoutSidebar
         {...layoutState.sidebar}
         {...layoutState.searchDialog}

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -28,7 +28,10 @@ const LayoutContent = (props) => {
   const siteData = useSiteData();
 
   return (
-    <LayoutApplication websitePrimaryColor={props.pageData.websitePrimaryColor}>
+    <LayoutApplication
+      websitePrimaryColor={props.pageData.websitePrimaryColor}
+      globalNotification={props.pageData.globalNotification}
+    >
       <LayoutSidebar
         {...layoutState.sidebar}
         {...layoutState.searchDialog}

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
@@ -13,6 +13,11 @@ const Root = styled.div`
   overflow-y: auto;
   -webkit-overflow-scrolling: touch; /* enables "momentum" style scrolling */
 
+  scroll-padding-top: ${(props) =>
+    props.isGlobalNotificationVisible
+      ? `calc(${designSystem.dimensions.heights.globalNotificationContent} + ${designSystem.dimensions.spacings.s} * 3)`
+      : designSystem.dimensions.spacings.s};
+
   @media only screen and (${designSystem.dimensions.viewports.tablet}) {
     height: 100vh;
   }
@@ -44,7 +49,11 @@ const LayoutApplication = (props) => (
       websitePrimaryColor: props.websitePrimaryColor,
     }}
   >
-    <Root role="application" id="application">
+    <Root
+      role="application"
+      id="application"
+      isGlobalNotificationVisible={Boolean(props.globalNotification)}
+    >
       <Container {...props} />
     </Root>
     <div id="modal-portal" />
@@ -52,6 +61,10 @@ const LayoutApplication = (props) => (
 );
 LayoutApplication.propTypes = {
   websitePrimaryColor: PropTypes.string.isRequired,
+  globalNotification: PropTypes.shape({
+    notificationType: PropTypes.oneOf(['info', 'warning']).isRequired,
+    content: PropTypes.string.isRequired,
+  }),
 };
 
 export default LayoutApplication;

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-global-notification.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-global-notification.js
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
+import { designSystem } from '@commercetools-docs/ui-kit';
 
 const LayoutGlobalNotification = styled.div`
   grid-area: global-notification;
   padding: 0;
   position: sticky;
   top: 0;
+  z-index: ${designSystem.dimensions.stacks.base};
 `;
 
 export default LayoutGlobalNotification;

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
@@ -82,6 +82,7 @@ const ToggleMenuButton = styled.div`
   );
   right: ${designSystem.dimensions.spacings.m};
   cursor: pointer;
+  z-index: ${designSystem.dimensions.stacks.base};
 
   @media screen and (${designSystem.dimensions.viewports.largeTablet}) {
     display: none;

--- a/packages/ui-kit/src/design-system.js
+++ b/packages/ui-kit/src/design-system.js
@@ -129,6 +129,7 @@ export const dimensions = {
     inputSearchSecondary: '26px',
     childSectionNavLink: '28px',
     pageSearchboxSpace: '58px',
+    globalNotificationContent: '36px',
   },
   widths: {
     pageContent: pageWidth,


### PR DESCRIPTION
Follow up of #1202 

Solution for the scroll anchor position has been taken from here: https://getpublii.com/blog/one-line-css-solution-to-prevent-anchor-links-from-scrolling-behind-a-sticky-header.html