### PR TITLE
fix: keep flexible height for global notification on small viewports

### DIFF
--- a/.changeset/tall-mugs-marry.md
+++ b/.changeset/tall-mugs-marry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Keep flexible height for global notification for small viewports (as component is not sticky).

--- a/packages/gatsby-theme-docs/src/components/global-notification.js
+++ b/packages/gatsby-theme-docs/src/components/global-notification.js
@@ -45,9 +45,11 @@ const Container = styled.div`
     }
   }};
   padding: ${designSystem.dimensions.spacings.s};
-  max-height: ${designSystem.dimensions.heights.globalNotificationContent};
-  overflow: hidden;
 
+  @media screen and (${designSystem.dimensions.viewports.tablet}) {
+    max-height: ${designSystem.dimensions.heights.globalNotificationContent};
+    overflow: hidden;
+  }
   @media screen and (${designSystem.dimensions.viewports.desktop}) {
     padding: ${designSystem.dimensions.spacings.s}
       ${designSystem.dimensions.spacings.xl};

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
@@ -108,6 +108,7 @@ const ToggleMenuButton = styled.div`
   );
   right: ${designSystem.dimensions.spacings.m};
   cursor: pointer;
+  z-index: ${designSystem.dimensions.stacks.base};
 
   @media screen and (${designSystem.dimensions.viewports.largeTablet}) {
     display: none;

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
@@ -82,7 +82,6 @@ const ToggleMenuButton = styled.div`
   );
   right: ${designSystem.dimensions.spacings.m};
   cursor: pointer;
-  z-index: ${designSystem.dimensions.stacks.base};
 
   @media screen and (${designSystem.dimensions.viewports.largeTablet}) {
     display: none;


### PR DESCRIPTION
Follow up of #1209

Hopefully this is the last change.

![2022-01-26 17 55 21](https://user-images.githubusercontent.com/1110551/151209757-e297eac3-58aa-40d6-a0bf-84ec9a8c1f9f.gif)
