### PR TITLE
Update writing style checker

### DIFF
--- a/.changeset/shy-wombats-wink.md
+++ b/.changeset/shy-wombats-wink.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/writing-style": patch
+---
+
+Update writing style checker

--- a/packages/writing-style/styles/commercetools/Acronyms.yml
+++ b/packages/writing-style/styles/commercetools/Acronyms.yml
@@ -71,6 +71,7 @@ exceptions:
   - SSL
   - SSO
   - TLS # does not make sense to allow SSL but not TLS
+  - TSV
   - SVG
   - TCP
   - UPS

--- a/packages/writing-style/styles/commercetools/Acronyms.yml
+++ b/packages/writing-style/styles/commercetools/Acronyms.yml
@@ -26,6 +26,7 @@ exceptions:
   - DOM
   - EUR
   - FAQ
+  - GBP
   - GET
   - GIF
   - GDPR
@@ -39,6 +40,7 @@ exceptions:
   - IMPEX
   - JAR
   - JPEG # Do not use JPG, use JPEG
+  - JPY
   - JSON
   - JSX
   - JVM

--- a/packages/writing-style/styles/commercetools/Acronyms.yml
+++ b/packages/writing-style/styles/commercetools/Acronyms.yml
@@ -15,6 +15,7 @@ exceptions:
   - ASCII # will only get worse when spelled out
   - AWS
   - CDN # "content delivery network" does not make it more understandable
+  - CHF
   - CLI
   - CORS
   - CPU


### PR DESCRIPTION
Adds
- TSV
- CHF
- JPY
- GBP
to list of allowed commercetools acronyms. 