### PR TITLE
fix: make dependent gatsby plugins actual dependencies

### DIFF
--- a/.changeset/clean-ants-repair.md
+++ b/.changeset/clean-ants-repair.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-api-docs': patch
+'@commercetools-docs/gatsby-theme-constants': patch
+---
+
+Fixes the package dependency setup for gatsby plugins referred in the theme config.

--- a/packages/gatsby-theme-api-docs/package.json
+++ b/packages/gatsby-theme-api-docs/package.json
@@ -29,19 +29,18 @@
     "@commercetools-uikit/spacings-stack": "^12.2.9",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
+    "gatsby-source-filesystem": "4.6.0",
     "prop-types": "15.8.1",
     "unist-util-visit": "^4.0.0"
   },
   "devDependencies": {
     "@commercetools-docs/rmf-codegen": "13.11.0",
     "gatsby": "4.6.1",
-    "gatsby-source-filesystem": "4.6.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },
   "peerDependencies": {
     "gatsby": "4.x",
-    "gatsby-source-filesystem": "4.x",
     "react": "17.x",
     "react-dom": "17.x"
   }

--- a/packages/gatsby-theme-constants/package.json
+++ b/packages/gatsby-theme-constants/package.json
@@ -16,6 +16,7 @@
   "keywords": ["gatsby", "gatsby-plugin", "gatsby-theme", "yaml", "constants"],
   "dependencies": {
     "@commercetools-docs/ui-kit": "18.3.0",
+    "gatsby-source-filesystem": "4.6.0",
     "gatsby-transformer-yaml": "4.6.0",
     "prop-types": "15.8.1"
   },

--- a/websites/documentation/src/content/configuration/packages.mdx
+++ b/websites/documentation/src/content/configuration/packages.mdx
@@ -31,18 +31,17 @@ The exported `designSystem` object contains several top-level entries:
 - `dimensions`
 - `typography`
 
-
 ## commercetools Writing Style Linter
 
 This package provides
 
-- commercetools specific writing style and terminology rules for the configurable [vale](https://errata-ai.github.io/vale/) prose linter.
+- commercetools specific writing style and terminology rules for the configurable [vale](https://docs.errata.ai/) prose linter.
 - the `commercetools-vale` command-line tool which wraps the vale binary and calls it using the included writing style and configuration
 - the `commercetools-vale-bin` command is directly calling the vale binary without passing the commercetools configuration. The `.vale.ini` configuration location has to be passed separately via vale's `--config` flag.
 
 The base style is the [Google Developer Documentation Style Guide](https://github.com/errata-ai/Google), which is included as a copy (MIT licensed, too) and modified and partially overridden with commercetools specific rules.
 
-The configuration defaults to checking `.md`, `.mdx`, `.txt`, and `.html` files, which can be overridden by calling it with a command-line parameter `commercetools-vale --glob='*.{js,md}' ./path/to/content` passing a list of [supported file format extensions](https://errata-ai.github.io/vale/formats/#formats).
+The configuration defaults to checking `.md`, `.mdx`, `.txt`, and `.html` files, which can be overridden by calling it with a command-line parameter `commercetools-vale --glob='*.{js,md}' ./path/to/content` passing a list of [supported file format extensions](https://docs.errata.ai/vale/scoping#formats).
 
 ### Automatic vale binary download for the current platform
 
@@ -64,7 +63,7 @@ The [vale plugin](https://marketplace.visualstudio.com/items?itemName=errata-ai.
   "settings": {
     "vale.core.useCLI": true,
     "vale.valeCLI.path": "${workspaceFolder}/node_modules/.bin/commercetools-vale-bin",
-    "vale.valeCLI.config": "${workspaceFolder}/node_modules/@commercetools-docs/writing-style/.vale.ini",
+    "vale.valeCLI.config": "${workspaceFolder}/node_modules/@commercetools-docs/writing-style/.vale.ini"
   }
 }
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -3273,7 +3273,6 @@ __metadata:
     unist-util-visit: ^4.0.0
   peerDependencies:
     gatsby: 4.x
-    gatsby-source-filesystem: 4.x
     react: 17.x
     react-dom: 17.x
   languageName: unknown
@@ -3303,6 +3302,7 @@ __metadata:
   dependencies:
     "@commercetools-docs/ui-kit": 18.3.0
     gatsby: 4.6.1
+    gatsby-source-filesystem: 4.6.0
     gatsby-transformer-yaml: 4.6.0
     prop-types: 15.8.1
     react: 17.0.2


### PR DESCRIPTION
Addresses issues with user repositories running on Yarn PnP