### PR TITLE
Move `globalNotification` configuration to siteMetadata

### DIFF
--- a/.changeset/stupid-donuts-grow.md
+++ b/.changeset/stupid-donuts-grow.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': major
+---
+
+BREAKING CHANGE: Moves the globalNotification configuration to the siteMetadata.
+If the global notification banner is used, the configuration needs to move out from the plugin configurations to the site metadata in the gatsby config file.

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -31,6 +31,10 @@ module.exports = (themeOptions = {}) => {
       author: 'commercetools',
       productionHostname,
       betaLink: '.',
+      globalNotification: {
+        notificationType: false,
+        content: false,
+      },
     },
     plugins: [
       /**

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -141,15 +141,6 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       enhancement
       announcement
     }
-
-    enum GlobalNotificationType {
-      info
-      warning
-    }
-    type GlobalNotification {
-      notificationType: GlobalNotificationType!
-      content: String!
-    }
   `);
 
   // Create a new type representing a Content Page
@@ -161,7 +152,6 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
         id: { type: 'ID!' },
         slug: { type: 'String!' },
         title: { type: 'String!' },
-        globalNotification: { type: 'GlobalNotification' },
         websitePrimaryColor: { type: 'String!' },
         excludeFromSearchIndex: { type: 'Boolean!' },
         isGlobalBeta: { type: 'Boolean!' },
@@ -294,7 +284,6 @@ exports.onCreateNode = (
   const contentPageFieldData = {
     slug: trimTrailingSlash(slug) || '/',
     title: node.frontmatter.title,
-    globalNotification: pluginOptions.globalNotification,
     websitePrimaryColor: colorPreset.value.primaryColor,
     isGlobalBeta: Boolean(pluginOptions.beta),
     excludeFromSearchIndex:

--- a/packages/gatsby-theme-docs/src/components/theme-provider.js
+++ b/packages/gatsby-theme-docs/src/components/theme-provider.js
@@ -17,6 +17,10 @@ const ThemeProvider = (props) => {
           author
           productionHostname
           betaLink
+          globalNotification {
+            notificationType
+            content
+          }
         }
       }
     }

--- a/packages/gatsby-theme-docs/src/layouts/content-homepage.js
+++ b/packages/gatsby-theme-docs/src/layouts/content-homepage.js
@@ -22,7 +22,7 @@ const LayoutContentHomepage = (props) => {
   return (
     <LayoutApplication
       websitePrimaryColor={props.pageData.websitePrimaryColor}
-      globalNotification={props.pageData.globalNotification}
+      globalNotification={siteData.siteMetadata.globalNotification}
     >
       <LayoutSidebar
         {...layoutState.sidebar}
@@ -52,7 +52,7 @@ const LayoutContentHomepage = (props) => {
             title={props.pageData.title}
             heroBackgroundURL={props.heroBackground.publicURL}
             heroBackgroundColor={props.pageContext.heroBackgroundColor}
-            globalNotification={props.pageData.globalNotification}
+            globalNotification={siteData.siteMetadata.globalNotification}
           >
             <LayoutPageContent>
               <PageContentInset id="body-content" maxWidth="unset">
@@ -77,10 +77,6 @@ LayoutContentHomepage.propTypes = {
   }).isRequired,
   pageData: PropTypes.shape({
     title: PropTypes.string.isRequired,
-    globalNotification: PropTypes.shape({
-      notificationType: PropTypes.oneOf(['info', 'warning']).isRequired,
-      content: PropTypes.string.isRequired,
-    }),
     websitePrimaryColor: PropTypes.string.isRequired,
     beta: PropTypes.bool.isRequired,
     isGlobalBeta: PropTypes.bool.isRequired,

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -31,7 +31,7 @@ const LayoutContent = (props) => {
   return (
     <LayoutApplication
       websitePrimaryColor={props.pageData.websitePrimaryColor}
-      globalNotification={props.pageData.globalNotification}
+      globalNotification={siteData.siteMetadata.globalNotification}
     >
       <LayoutSidebar
         {...layoutState.sidebar}
@@ -61,11 +61,13 @@ const LayoutContent = (props) => {
             allowWideContentLayout={props.pageData.allowWideContentLayout}
           >
             <LayoutGlobalNotification>
-              {props.pageData.globalNotification && (
+              {siteData.siteMetadata.globalNotification.content && (
                 <GlobalNotification
-                  type={props.pageData.globalNotification.notificationType}
+                  type={
+                    siteData.siteMetadata.globalNotification.notificationType
+                  }
                 >
-                  {props.pageData.globalNotification.content}
+                  {siteData.siteMetadata.globalNotification.content}
                 </GlobalNotification>
               )}
             </LayoutGlobalNotification>
@@ -115,10 +117,6 @@ LayoutContent.propTypes = {
   }).isRequired,
   pageData: PropTypes.shape({
     title: PropTypes.string.isRequired,
-    globalNotification: PropTypes.shape({
-      notificationType: PropTypes.oneOf(['info', 'warning']).isRequired,
-      content: PropTypes.string.isRequired,
-    }),
     websitePrimaryColor: PropTypes.string.isRequired,
     beta: PropTypes.bool.isRequired,
     isGlobalBeta: PropTypes.bool.isRequired,

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-with-hero.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-with-hero.js
@@ -76,7 +76,7 @@ const ContentWrapper = styled.div`
 const LayoutPageWithHero = (props) => (
   <Container>
     <LayoutGlobalNotification>
-      {props.globalNotification && (
+      {props.globalNotification.content && (
         <GlobalNotification type={props.globalNotification.notificationType}>
           {props.globalNotification.content}
         </GlobalNotification>

--- a/packages/gatsby-theme-docs/src/templates/homepage.js
+++ b/packages/gatsby-theme-docs/src/templates/homepage.js
@@ -51,10 +51,6 @@ HomepageTemplate.propTypes = {
   data: PropTypes.shape({
     contentPage: PropTypes.shape({
       title: PropTypes.string.isRequired,
-      globalNotification: PropTypes.shape({
-        notificationType: PropTypes.oneOf(['info', 'warning']).isRequired,
-        content: PropTypes.string.isRequired,
-      }),
       websitePrimaryColor: PropTypes.string.isRequired,
       beta: PropTypes.bool.isRequired,
       isGlobalBeta: PropTypes.bool.isRequired,
@@ -73,19 +69,11 @@ export const query = graphql`
   query QueryHomepage($slug: String!, $heroBackgroundRelativePath: String!) {
     contentPage(slug: { eq: $slug }) {
       title
-      globalNotification {
-        notificationType
-        content
-      }
       websitePrimaryColor
       beta
       isGlobalBeta
       excludeFromSearchIndex
       allowWideContentLayout
-      globalNotification {
-        notificationType
-        content
-      }
       body
     }
     heroBackground: file(relativePath: { eq: $heroBackgroundRelativePath }) {

--- a/packages/gatsby-theme-docs/src/templates/page-content.js
+++ b/packages/gatsby-theme-docs/src/templates/page-content.js
@@ -61,10 +61,6 @@ PageContentTemplate.propTypes = {
   data: PropTypes.shape({
     contentPage: PropTypes.shape({
       title: PropTypes.string.isRequired,
-      globalNotification: PropTypes.shape({
-        notificationType: PropTypes.oneOf(['info', 'warning']).isRequired,
-        content: PropTypes.string.isRequired,
-      }),
       websitePrimaryColor: PropTypes.string.isRequired,
       beta: PropTypes.bool.isRequired,
       isGlobalBeta: PropTypes.bool.isRequired,
@@ -85,10 +81,6 @@ export const query = graphql`
   query QueryContentPage($slug: String!) {
     contentPage(slug: { eq: $slug }) {
       title
-      globalNotification {
-        notificationType
-        content
-      }
       websitePrimaryColor
       beta
       isGlobalBeta

--- a/packages/gatsby-theme-docs/utils/default-options.js
+++ b/packages/gatsby-theme-docs/utils/default-options.js
@@ -12,7 +12,6 @@ const defaultOptions = {
   overrideDefaultConfigurationData: [],
   addOns: [],
   enableCanonicalUrls: true,
-  globalNotification: undefined,
 };
 
 module.exports = defaultOptions;

--- a/websites/api-docs-smoke-test/gatsby-config.js
+++ b/websites/api-docs-smoke-test/gatsby-config.js
@@ -16,6 +16,11 @@ module.exports = {
     title: 'API Docs Smoke Test',
     description: 'Documentation website for API smoke tests',
     betaLink: '',
+    globalNotification: {
+      notificationType: 'info',
+      content:
+        'This is a global notification. You can _write_ **markdown** here!',
+    },
   },
   plugins: [
     ...configureThemeWithAddOns({
@@ -49,11 +54,6 @@ module.exports = {
           },
         },
       ],
-      globalNotification: {
-        notificationType: 'info',
-        content:
-          'This is a global notification. You can _write_ **markdown** here!',
-      },
     }),
   ],
 };

--- a/websites/documentation/src/content/configuration/theme.mdx
+++ b/websites/documentation/src/content/configuration/theme.mdx
@@ -37,6 +37,28 @@ The Docs-Kit theme also receives its plugin configuration through this standard 
 
 - `enableCanonicalUrls` (_optional_): indicates that the website should use canonical URLs, pointing to the `docs.commercetools.com` domain. **Default: `true`**
 
+## Available Options for the Site Metadata
+
+
+- `title` (**required**): Defines the title of the website.
+- `description` (**required**): Defines the description of the website.
+- `betaLink` (_optional_): Configures the link for _beta button_.
+- `globalNotification` (_optional_, object): Activates a global banner at the top of every page within the website. It contains two configuration options:
+  `notificationType` (String, either **info** or **warning**) defines the type and color of the banner. `content` (String) defines the text within the banner.
+
+  ```js
+  siteMetadata: {
+    title: 'CHANGE TITLE',
+    description: 'CHANGE DESCRIPTION',
+    betaLink: '',
+    globalNotification: {
+      notificationType: 'info',
+      content:
+        'This is a global notification. You can _write_ **markdown** here!',
+    },
+  },
+  ```
+
 # Site path prefix
 
 All commercetools documentation websites are served under `docs.commercetools.com`. To make this work, all documentation websites must be bundled for production using a `pathPrefix`. This value determines the URL path where the website is served from.


### PR DESCRIPTION
closes #1274

This pull request moves the global notification configuration to the `siteMetadata` and adds documentation for the `siteMetadata` configuration options.