### PR TITLE
[Improvement idea] Add navigation to other microsites

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean": "yarn workspaces foreach -p --include '@commercetools-website/*' run clean",
-    "start": "yarn workspace @commercetools-website/docs-smoke-test start",
+    "start": "yarn workspace @commercetools-website/documentation start",
     "build-packages": "preconstruct build",
     "build": "./scripts/build.sh",
     "vercel-build": "echo \"you're welcome - nothing to build\"",

--- a/websites/api-docs-smoke-test/src/content/index.mdx
+++ b/websites/api-docs-smoke-test/src/content/index.mdx
@@ -8,3 +8,23 @@ beta: true
 This is a smoke test website for types and endpoints.
 
 </Subtitle>
+
+# Other smoke tests and docs websites
+
+<Cards narrow>
+  <Card>
+
+  [Documentation](/../documentation)
+
+  </Card>
+  <Card>
+
+  [Docs kit smoke test](/../docs-smoke-test)
+
+  </Card>
+  <Card>
+
+  [Site Template](/../site-template)
+
+  </Card>
+</Cards>

--- a/websites/docs-smoke-test/src/content/index.mdx
+++ b/websites/docs-smoke-test/src/content/index.mdx
@@ -2,22 +2,17 @@
 title: Explore how to build a documentation website for commercetools
 ---
 
-# Smoke test and docs websites
+# Other smoke tests and docs websites
 
 <Cards narrow>
   <Card>
 
-  [Docs kit smoke test (this)](/../docs-smoke-test)
+  [Documentation](/../documentation)
 
   </Card>
   <Card>
 
   [Api docs smoke test](/../api-docs-smoke-test)
-
-  </Card>
-  <Card>
-
-  Documentation (tbd)
 
   </Card>
   <Card>

--- a/websites/documentation/src/content/index.mdx
+++ b/websites/documentation/src/content/index.mdx
@@ -41,3 +41,23 @@ The commercetools Docs-Kit implementation is developed and maintained under the 
 All artwork, visual design and other creative or visual content elements remain under full copyright of commercetools GmbH.
 
 </Info>
+
+# Other smoke tests and docs websites
+
+<Cards narrow>
+  <Card>
+
+  [Docs kit smoke test](/../docs-smoke-test)
+
+  </Card>
+  <Card>
+
+  [Api docs smoke test](/../api-docs-smoke-test)
+
+  </Card>
+  <Card>
+
+  [Site Template](/../site-template)
+
+  </Card>
+</Cards>

--- a/websites/site-template/src/content/index.mdx
+++ b/websites/site-template/src/content/index.mdx
@@ -4,3 +4,23 @@ beta: false
 ---
 
 To be changed: Write content.
+
+# Other smoke tests and docs websites
+
+<Cards narrow>
+  <Card>
+
+  [Documentation](/../documentation)
+
+  </Card>
+  <Card>
+
+  [Docs kit smoke test](/../docs-smoke-test)
+
+  </Card>
+  <Card>
+
+  [Api docs smoke test (this)](/../api-docs-smoke-test)
+
+  </Card>
+</Cards>


### PR DESCRIPTION
At the moment the docs-smoke-test has cards on the index page that contain links to the other microsites which is useful for the deployed website since you can quickly navigate to the smoke test or documentation you need. I suggest to add these cards to all microsites (especially to the new documentation website) so that you can use the link in the index page to get to the smoke test instead of changing the URL.