### PR TITLE
Render cards without external link icon

### DIFF
--- a/.changeset/happy-dogs-peel.md
+++ b/.changeset/happy-dogs-peel.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': minor
+---
+
+Improves Cards with external links. The external link icon will now be rendered only for text links and not for the card itself.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Check local links including anchors
         if: ${{ env.DEPLOY_ENV == 'Preview' }}
         working-directory: public
-        run: npx --quiet start-server-and-test 'npx --quiet http-server --silent -p 9000' 9000 'docker run --network=host -v "$(pwd)/../:/repo/" tennox/linkcheck --skip-file /repo/linkcheck-local-skip-list :9000'
+        run: npx --quiet start-server-and-test 'npx --quiet http-server --silent -p 9000' 9000 'docker run --network=host -v "$(pwd)/../:/repo/" tennox/linkcheck2.0.20 --skip-file /repo/linkcheck-local-skip-list :9000'
 
   link-check:
     name: 'Check links'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,6 +115,8 @@ jobs:
         id: finish_deployment
         with:
           step: finish
+          override: false
+          auto_inactive: false
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           env: ${{ steps.start-deployment.outputs.env }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Check local links including anchors
         if: ${{ env.DEPLOY_ENV == 'Preview' }}
         working-directory: public
-        run: npx --quiet start-server-and-test 'npx --quiet http-server --silent -p 9000' 9000 'docker run --network=host -v "$(pwd)/../:/repo/" tennox/linkcheck2.0.20 --skip-file /repo/linkcheck-local-skip-list :9000'
+        run: npx --quiet start-server-and-test 'npx --quiet http-server --silent -p 9000' 9000 'docker run --network=host -v "$(pwd)/../:/repo/" tennox/linkcheck --skip-file /repo/linkcheck-local-skip-list :9000'
 
   link-check:
     name: 'Check links'

--- a/packages/gatsby-theme-docs/src/components/card.js
+++ b/packages/gatsby-theme-docs/src/components/card.js
@@ -52,7 +52,7 @@ const Card = (props) => (
     <WrapWith
       condition={Boolean(props.clickable && props.href)}
       wrapper={(children) => (
-        <GatsbyLink href={props.href} noUnderline>
+        <GatsbyLink href={props.href} noUnderline noAdditionalStyling>
           {children}
         </GatsbyLink>
       )}
@@ -86,13 +86,9 @@ const Card = (props) => (
               {props.href && props.textLink && (
                 <ReadMoreContainer>
                   <ReadMore>
-                    {props.clickable ? (
-                      props.textLink
-                    ) : (
-                      <GatsbyLink href={props.href} noUnderline>
-                        {props.textLink}
-                      </GatsbyLink>
-                    )}
+                    <GatsbyLink href={props.href} noUnderline>
+                      {props.textLink}
+                    </GatsbyLink>
                   </ReadMore>
                 </ReadMoreContainer>
               )}

--- a/packages/gatsby-theme-docs/src/components/card.js
+++ b/packages/gatsby-theme-docs/src/components/card.js
@@ -86,9 +86,13 @@ const Card = (props) => (
               {props.href && props.textLink && (
                 <ReadMoreContainer>
                   <ReadMore>
-                    <GatsbyLink href={props.href} noUnderline>
-                      {props.textLink}
-                    </GatsbyLink>
+                    {props.clickable ? (
+                      props.textLink
+                    ) : (
+                      <GatsbyLink href={props.href} noUnderline>
+                        {props.textLink}
+                      </GatsbyLink>
+                    )}
                   </ReadMore>
                 </ReadMoreContainer>
               )}

--- a/packages/gatsby-theme-docs/src/components/link.js
+++ b/packages/gatsby-theme-docs/src/components/link.js
@@ -156,6 +156,15 @@ const PureLink = (extendedProps) => {
         <ExternalLinkIcon size="small" />
       </InlineLink>
     );
+    if (props.noAdditionalStyling) {
+      return (
+        <ExternalSiteLink
+          {...props}
+          data-link-type="external-link"
+          css={getStylesFromProps({ noUnderline })}
+        ></ExternalSiteLink>
+      );
+    }
     return (
       <ExternalSiteLink
         {...props}
@@ -232,6 +241,7 @@ PureLink.propTypes = {
   target: PropTypes.string,
   className: PropTypes.string,
   noUnderline: PropTypes.bool,
+  noAdditionalStyling: PropTypes.bool,
   children: PropTypes.node,
   // from @react/router
   location: PropTypes.object.isRequired,

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -2,7 +2,7 @@
 title: Cards
 ---
 
-* The actual card content is markdown
+ * The actual card content is markdown
  * Card titles are not links
  * Card titles never become entries in the page index nav like section headings.
  * Card titles of both sizes are rendered as H6 to enhance accessibility while making sure they are always "inside" the actual headings

--- a/websites/docs-smoke-test/src/content/components/cards.mdx
+++ b/websites/docs-smoke-test/src/content/components/cards.mdx
@@ -2,7 +2,7 @@
 title: Cards
 ---
 
- * The actual card content is markdown
+* The actual card content is markdown
  * Card titles are not links
  * Card titles never become entries in the page index nav like section headings.
  * Card titles of both sizes are rendered as H6 to enhance accessibility while making sure they are always "inside" the actual headings
@@ -112,9 +112,21 @@ None of the properties are required but the body content should not be empty.
 ```jsx
 <Cards clickable>
   <Card
-    title="A regular heading"
+    title="Card with internal Link"
     href="/components/images"
-    textLink="Read more about images...">This is visually eleveated, has a link to the **images (bold)** page and the complete card is a clickable target.</Card>
+    textLink="Read more about images..."
+  >
+    This is visually eleveated, has a link to the **images (bold)** page and the
+    complete card is a clickable target.
+  </Card>
+  <Card
+    title="Card with external Link"
+    href="https://commercetools.com"
+    textLink="Read more about images..."
+  >
+    This is visually eleveated, has a link to an external page and the
+    complete card is a clickable target.
+  </Card>
 </Cards>
 ```
 
@@ -122,9 +134,14 @@ None of the properties are required but the body content should not be empty.
 
 <Cards clickable>
   <Card
-    title="A regular heading"
+    title="Card with internal Link"
     href="/components/images"
     textLink="Read more about images...">This is visually eleveated, has a link to the **images (bold)** page and the complete card is a clickable target.</Card>
+  <Card
+    title="Card with external Link"
+    href="https://commercetools.com"
+    textLink="Read more about images...">This is visually eleveated, has a link to an **external (bold)** page and the
+    complete card is a clickable target..</Card>
 </Cards>
 
 
@@ -449,6 +466,42 @@ Icons on **narrow** cards are aligned to the left of the card regardless of whet
     href="/components/images"
     image={<CardBannerOssIcon />}>
     Clickable card with an image
+  </Card>
+</Cards>
+
+## Clickable Card with an Image and an external Link
+
+```jsx
+<Cards clickable>
+  <Card
+    title="Clickable with Image and external link"
+    href="https://commercetools.com"
+    image={<CardBannerApiIcon />}
+  >
+    Clickable card with an image. The external link icon is not being rendered.
+  </Card>
+  <Card
+    title="Clickable with Image and external link"
+    href="https://commercetools.com"
+    image={<CardBannerDefaultIcon />}
+  >
+    Clickable card with an image. The external link icon is not being rendered.
+  </Card>
+</Cards>
+```
+
+<Cards clickable>
+  <Card
+    title="Clickable with Image and external link"
+    href="https://commercetools.com"
+    image={<CardBannerApiIcon />}>
+    Clickable card with an image. The external link icon is not being rendered.
+  </Card>
+  <Card
+    title="Clickable with Image and external link"
+    href="https://commercetools.com"
+    image={<CardBannerDefaultIcon />}>
+    Clickable card with an image. The external link icon is not being rendered.
   </Card>
 </Cards>
 


### PR DESCRIPTION
closes #1291 

Now cards with external links won't render the external link icon anymore. It appears only next to textlinks.