### PR TITLE
Proof of Concept: replace GraphQL facade layer with fields on mdx nodes

### DIFF
--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -261,28 +261,34 @@ module.exports = (themeOptions = {}) => {
           feeds: [
             {
               serialize: ({ query: { site, allReleaseNotePage } }) => {
-                return allReleaseNotePage.nodes.map((node) => {
+                return allReleaseNotePage.nodes.map(({ fields }) => {
                   return {
-                    ...node,
-                    url: `${site.siteMetadata.siteUrl}${node.slug}`,
-                    guid: `${site.siteMetadata.siteUrl}${node.slug}`,
+                    ...fields,
+                    url: `${site.siteMetadata.siteUrl}${fields.slug}`,
+                    guid: `${site.siteMetadata.siteUrl}${fields.slug}`,
                   };
                 });
               },
               query: `
               {
-                allReleaseNotePage(
-                  limit: 10, sort: { order: DESC, fields: date },
+                allReleaseNotePage: allMdx(
+                  sort: {order: DESC, fields: fields___date}
+                  limit: 10
+                  filter: {fields: {pageType: {eq: "ReleaseNote"}}}
                 ) {
-                    nodes {
+                  nodes {
+                    id
+                    fields {
                       description
                       slug
                       title
                       date
                       categories: topics
                     }
+                  }
                 }
               }
+
             `,
               output: '/releases/feed.xml',
               title: 'commercetools Release Notes',

--- a/packages/gatsby-theme-docs/src/hooks/use-release-notes-topics.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-release-notes-topics.js
@@ -3,10 +3,11 @@ import { useStaticQuery, graphql } from 'gatsby';
 const useReleaseNotesTopics = (selectedTopics = []) => {
   const data = useStaticQuery(graphql`
     query GetAllReleaseNotesTopics {
-      allReleaseNoteTopics: allReleaseNotePage(
-        sort: { fields: topics, order: ASC }
+      allReleaseNoteTopics: allMdx(
+        sort: { fields: fields___topics, order: ASC }
+        filter: { fields: { pageType: { eq: "ReleaseNote" } } }
       ) {
-        group(field: topics) {
+        group(field: fields___topics) {
           fieldValue
         }
       }

--- a/packages/gatsby-theme-docs/src/templates/release-notes-detail.js
+++ b/packages/gatsby-theme-docs/src/templates/release-notes-detail.js
@@ -19,29 +19,33 @@ const releaseNoteMarkdownComponents = {
   h4: Markdown.withAnchorLink(Markdown.H6),
 };
 
-const ReleaseNotesDetailTemplate = (props) => (
-  <IntlProvider locale="en">
-    <ThemeProvider>
-      <LayoutReleaseNotesDetail pageData={props.data.releaseNotePage}>
-        <MDXProvider components={releaseNoteMarkdownComponents}>
-          <Markdown.TypographyPage>
-            <SEO
-              title={props.data.releaseNotePage.title}
-              excludeFromSearchIndex={
-                props.data.releaseNotePage.excludeFromSearchIndex
-              }
-            />
-            <div>
-              <LayoutReleaseNoteBody {...props.data.releaseNotePage}>
-                <MDXRenderer>{props.data.releaseNotePage.body}</MDXRenderer>
-              </LayoutReleaseNoteBody>
-            </div>
-          </Markdown.TypographyPage>
-        </MDXProvider>
-      </LayoutReleaseNotesDetail>
-    </ThemeProvider>
-  </IntlProvider>
-);
+const ReleaseNotesDetailTemplate = (props) => {
+  const releaseNotePage = {
+    body: props.data.releaseNotePage.body,
+    ...props.data.releaseNotePage.fields,
+  };
+  return (
+    <IntlProvider locale="en">
+      <ThemeProvider>
+        <LayoutReleaseNotesDetail pageData={releaseNotePage}>
+          <MDXProvider components={releaseNoteMarkdownComponents}>
+            <Markdown.TypographyPage>
+              <SEO
+                title={releaseNotePage.title}
+                excludeFromSearchIndex={releaseNotePage.excludeFromSearchIndex}
+              />
+              <div>
+                <LayoutReleaseNoteBody {...releaseNotePage}>
+                  <MDXRenderer>{releaseNotePage.body}</MDXRenderer>
+                </LayoutReleaseNoteBody>
+              </div>
+            </Markdown.TypographyPage>
+          </MDXProvider>
+        </LayoutReleaseNotesDetail>
+      </ThemeProvider>
+    </IntlProvider>
+  );
+};
 
 ReleaseNotesDetailTemplate.propTypes = {
   pageContext: PropTypes.shape({
@@ -49,9 +53,11 @@ ReleaseNotesDetailTemplate.propTypes = {
   }).isRequired,
   data: PropTypes.shape({
     releaseNotePage: PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      websitePrimaryColor: PropTypes.string.isRequired,
-      excludeFromSearchIndex: PropTypes.bool.isRequired,
+      fields: PropTypes.shape({
+        title: PropTypes.string.isRequired,
+        websitePrimaryColor: PropTypes.string.isRequired,
+        excludeFromSearchIndex: PropTypes.bool.isRequired,
+      }),
       body: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
@@ -61,14 +67,18 @@ export default ReleaseNotesDetailTemplate;
 
 export const query = graphql`
   query QueryReleaseDetailPage($slug: String!) {
-    releaseNotePage(slug: { eq: $slug }) {
-      title
-      websitePrimaryColor
-      excludeFromSearchIndex
-      date(formatString: "D MMMM YYYY")
-      description
-      type
-      topics
+    releaseNotePage: mdx(
+      fields: { slug: { eq: $slug }, pageType: { eq: "ReleaseNote" } }
+    ) {
+      fields {
+        title
+        websitePrimaryColor
+        excludeFromSearchIndex
+        date(formatString: "D MMMM YYYY")
+        description
+        type
+        topics
+      }
       body
     }
   }

--- a/packages/gatsby-theme-docs/src/templates/release-notes-list.js
+++ b/packages/gatsby-theme-docs/src/templates/release-notes-list.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, { node } from 'prop-types';
 import { IntlProvider } from 'react-intl';
 import { graphql } from 'gatsby';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
@@ -14,9 +14,10 @@ import useFilteredReleaseNotes from '../hooks/use-filtered-release-notes';
 import GatsbyLink from '../components/link';
 
 const ReleaseNotesListTemplate = (props) => {
-  const filteredReleaseNotes = useFilteredReleaseNotes(
-    props.data.allReleaseNotePage.nodes
-  );
+  const releaseNotes = props.data.allReleaseNotePage.nodes.map((node) => ({
+    ...node.fields,
+  }));
+  const filteredReleaseNotes = useFilteredReleaseNotes(releaseNotes);
 
   return (
     <IntlProvider locale="en">
@@ -75,14 +76,16 @@ ReleaseNotesListTemplate.propTypes = {
     allReleaseNotePage: PropTypes.shape({
       nodes: PropTypes.arrayOf(
         PropTypes.shape({
-          slug: PropTypes.string.isRequired,
-          title: PropTypes.string.isRequired,
-          date: PropTypes.string.isRequired,
-          description: PropTypes.string.isRequired,
-          type: PropTypes.string.isRequired,
-          topics: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-          body: PropTypes.string.isRequired,
-          hasMore: PropTypes.bool.isRequired,
+          fields: PropTypes.shape({
+            slug: PropTypes.string.isRequired,
+            title: PropTypes.string.isRequired,
+            date: PropTypes.string.isRequired,
+            description: PropTypes.string.isRequired,
+            type: PropTypes.string.isRequired,
+            topics: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+            body: PropTypes.string.isRequired,
+            hasMore: PropTypes.bool.isRequired,
+          }),
         })
       ).isRequired,
     }),
@@ -100,17 +103,22 @@ export const query = graphql`
       excludeFromSearchIndex
       body
     }
-    allReleaseNotePage(sort: { order: DESC, fields: date }) {
+    allReleaseNotePage: allMdx(
+      sort: { order: DESC, fields: fields___date }
+      filter: { fields: { pageType: { eq: "ReleaseNote" } } }
+    ) {
       nodes {
-        slug
-        title
-        date(formatString: "D MMMM YYYY")
-        isoDate: date
-        description
-        type
-        topics
-        body: rawExcerpt
-        hasMore
+        fields {
+          slug
+          title
+          date(formatString: "D MMMM YYYY")
+          isoDate: date
+          description
+          type
+          topics
+          body: rawExcerpt
+          hasMore
+        }
       }
     }
   }


### PR DESCRIPTION
**final finding**:  It does not get any better overall - the facade has significant advantages in queryability and sorting. Also, error handling does not get better by directly addressing the MDX node because that node is disappearing on mdx errors anyways. 

Superseded by improving the error handling again: https://github.com/commercetools/commercetools-docs-kit/pull/1301  

----

**Status**: Works in dev mode but the build fails, sort and filter statements on fields work in dev mode but not in the build. 

An ugly workaround to filtering would be the glob for "fileAbsolutePath" `{fileAbsolutePath: {glob: "**/src/releases/**"}}` in all the queries but it's sort of really ugly and does not solve sorting the release notes e.g. for the RSS feed. 

If it's really not possible to filter for fields in the build we could keep the facade API but try to not dynamically resolve the MDX body but rather query it from the node parent in the page queries. Maybe this makes the errors easier to catch and the schema definition could be simpler to understand if it does not have the dynamic resolution. 

----

addresses #539, maybe addresses build performance, reduces architectural complexity for easier onboarding and maintenance. 

We struggle with the dynamic resolution of the MDX body in our custom graphQL facade for long - the error behavior is hard to control and we still live with the suspicion that something in the setup causes every MDX compilation to happen twice.  @timonrey  and me decided to gradually reduce the architectural and code design complexity to more straightforward / OOTB gatsby features even if it incurs some "ugliness" or repetition.     

This PoC checks whether it's feasible to remove our custom graphQL facades on the example of the release notes (they are more complex than the content pages)

It creates the cleaned fields with defaults as before but sets them as nodeFields on the mdx node directly instead of creating another layer of data nodes. 

The intended effect has happened: the dev server is not completely crashing any more on MDX syntax errors! It's not really good error behavior yet (no useful output) but a much better starting point because the dev server is recovering cleanly at all.  (but the build fails, see above)

Also proves it's possible with relatively overseeable code mod because graphql has aliases that made the data structure only deviate in the nesting into "fields". 