### PR TITLE
More robust MDX error handling

### DIFF
--- a/.changeset/rare-shoes-run.md
+++ b/.changeset/rare-shoes-run.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/gatsby-theme-docs": patch
+---
+
+More robust MDX syntax error handling. Still requires restart but the humane error page is back. 


### PR DESCRIPTION
resolves #1221 (better than before)

We broke the existing error handling while adding the time to read feature.

This makes it more generic and applicable to multiple dynamically resolved fields with varying types. 

The fundamental limitation to have to restart remains because of the behavior of the MDX plugin. 