### PR TITLE
Update writing style to match branding guidelines

### DIFF
--- a/packages/writing-style/styles/commercetools/Brand.yml
+++ b/packages/writing-style/styles/commercetools/Brand.yml
@@ -9,9 +9,10 @@ swap:
   Commercetools: commercetools
   commerceTools: commercetools
   CommerceTools: commercetools
-  CTP: the commercetools platform
+  CTP: commercetools Composable Commerce
   CT: commercetools
   ct: commercetools
-  SPHERE: the commercetools platform
-  SPHERE.IO: the commercetools platform
-  sphere.io: the commercetools platform
+  SPHERE: commercetools Composable Commerce
+  SPHERE.IO: commercetools Composable Commerce
+  sphere.io: commercetools Composable Commerce
+

--- a/packages/writing-style/styles/commercetools/PortfolioNaming.yml
+++ b/packages/writing-style/styles/commercetools/PortfolioNaming.yml
@@ -1,0 +1,9 @@
+extends: substitution
+message: "Use '%s' instead of '%s'. Visit https://wiki.commercetools.com/display/DOCS/Brand+guidelines+in+documentation for additional suggestions."
+level: warning
+ignorecase: true
+action:
+  name: replace
+swap:
+  Platform: Composable Commerce
+  Frontastic: commercetools Frontend


### PR DESCRIPTION
According to our new [Branding guidelines](https://wiki.commercetools.com/display/DOCS/Brand+guidelines+in+documentation), the word 'platform' should be avoided in documentation. However there are still a few instances (for example enums), where using synonyms or paraphrasing is not an option.

This PR extends the [Brand.yml](packages/writing-style/styles/commercetools/Brand.yml) file to no longer suggest using the word 'platform'. Additionally, a new file [PortfolioNaming.yaml](packages/writing-style/styles/commercetools/PortfolioNaming.yml) will provide warnings for using the word 'platform' or 'Frontastic'.