### PR TITLE
fix(raml transformer): hide fields with markDeprecated property from api generated docs

### DIFF
--- a/.changeset/rotten-tomatoes-divide.md
+++ b/.changeset/rotten-tomatoes-divide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-transformer-raml': minor
+---
+
+Fields marked as `markDeprecated` should not be rendered in the API docs as it happens with the `deprecated` flag.

--- a/.changeset/rotten-tomatoes-divide.md
+++ b/.changeset/rotten-tomatoes-divide.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools-docs/gatsby-transformer-raml': minor
+'@commercetools-docs/gatsby-transformer-raml': patch
 ---
 
 Fields marked as `markDeprecated` should not be rendered in the API docs as it happens with the `deprecated` flag.

--- a/packages/gatsby-transformer-raml/src/create-type-node.js
+++ b/packages/gatsby-transformer-raml/src/create-type-node.js
@@ -77,7 +77,7 @@ function processProperties({
   if (properties) {
     propertiesArray = propertiesToArrays(properties);
     propertiesArray = propertiesArray.filter(
-      (property) => !property.deprecated
+      (property) => !property.deprecated && !property.markDeprecated
     );
     propertiesArray = sortProperties({
       properties: propertiesArray,


### PR DESCRIPTION
Fixes: commercetools-docs#2051