### PR TITLE
Provide component shadowing for the avatar component

### DIFF
--- a/.changeset/neat-kiwis-dance.md
+++ b/.changeset/neat-kiwis-dance.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': minor
+---
+
+Adds support for component shadowing for the avatar component. Now it can be overritten and displayed in the top bar next to the top menu button.

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
@@ -13,7 +13,7 @@ import {
   Icons,
 } from '@commercetools-docs/ui-kit';
 import { SearchDialog, SearchInput, Overlay } from '../../components';
-import Avatar from '../../overrides/avatar';
+import PlaceholderAvatarArea from '../../overrides/avatar';
 
 const SearchIcon = createStyledIcon(Icons.SearchSvgIcon);
 
@@ -235,7 +235,7 @@ const LayoutHeader = forwardRef((props, ref) => {
           </DocumentationSwitcherButton>
         </Inline>
         <Inline>
-          <Avatar />
+          <PlaceholderAvatarArea />
         </Inline>
       </TopMenuContainer>
       <SearchBoxContainer ref={ref}>

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
@@ -13,6 +13,7 @@ import {
   Icons,
 } from '@commercetools-docs/ui-kit';
 import { SearchDialog, SearchInput, Overlay } from '../../components';
+import Avatar from '../../overrides/avatar';
 
 const SearchIcon = createStyledIcon(Icons.SearchSvgIcon);
 
@@ -232,6 +233,9 @@ const LayoutHeader = forwardRef((props, ref) => {
               )}
             </SpacingsInline>
           </DocumentationSwitcherButton>
+        </Inline>
+        <Inline>
+          <Avatar />
         </Inline>
       </TopMenuContainer>
       <SearchBoxContainer ref={ref}>

--- a/packages/gatsby-theme-docs/src/overrides/avatar.js
+++ b/packages/gatsby-theme-docs/src/overrides/avatar.js
@@ -1,0 +1,2 @@
+// A React component to be rendered in the top bar next to the top menu toggle button
+export default () => null;


### PR DESCRIPTION
This pull request implements the new overridable avatar component. This is needed in order to override the component in the learning-tech websites to display the avatar (or not, if the user is not logged in yet).