### PR TITLE
Adds additional terms to Vale writing style checker

### DIFF
--- a/.changeset/modern-pets-type.md
+++ b/.changeset/modern-pets-type.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/writing-style': minor
+---
+
+adds words to word suggestion list

--- a/packages/writing-style/styles/commercetools/WordList-Suggestions.yml
+++ b/packages/writing-style/styles/commercetools/WordList-Suggestions.yml
@@ -6,3 +6,6 @@ action:
   name: replace
 swap:
   Extension: API Extension
+  once: after
+  Once: After
+  via: using|through|by|with


### PR DESCRIPTION
**Info:** The words 'via' and 'once' must be avoided in documentation as per the [Google's word list](https://developers.google.com/style/word-list). Hence, this PR adds the suggestions to _commercetools/WordList-Suggestions.yml_ file.