### PR TITLE
refactor: remove React imports due to new jsx transform

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+process.env.ENABLE_NEW_JSX_TRANSFORM = 'true';
+
 const path = require('path');
 
 module.exports = {

--- a/packages/gatsby-theme-api-docs/src/components/description.js
+++ b/packages/gatsby-theme-api-docs/src/components/description.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import {

--- a/packages/gatsby-theme-api-docs/src/components/resource-method.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource-method.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useReadResourceByResourcePath } from '../hooks/use-read-resource-by-resource-path';
 import reportError from '../utils/report-error';

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import {

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/request-response-examples.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/request-response-examples.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import { MultiCodeBlock, CodeBlock } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { designSystem } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/url.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/url.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';

--- a/packages/gatsby-theme-api-docs/src/components/resource/resource-by-api-key.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/resource-by-api-key.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useReadResourceByResourcePath } from '../../hooks/use-read-resource-by-resource-path';
 import Resource from './resource';

--- a/packages/gatsby-theme-api-docs/src/components/resource/resource.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/resource.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import { FullWidthContainer } from '@commercetools-docs/gatsby-theme-docs';

--- a/packages/gatsby-theme-api-docs/src/components/type/enum.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/enum.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Markdown } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
@@ -31,7 +31,7 @@ const Enum = ({
                 enumDescriptions.find((enumDesc) => enumDesc.name === value);
 
               return (
-                <React.Fragment key={value}>
+                <Fragment key={value}>
                   <Markdown.Dt>
                     <Markdown.InlineCode>{value}</Markdown.InlineCode>
                   </Markdown.Dt>
@@ -42,7 +42,7 @@ const Enum = ({
                       />
                     </Markdown.Dd>
                   )}
-                </React.Fragment>
+                </Fragment>
               );
             })}
         </Markdown.Dl>{' '}

--- a/packages/gatsby-theme-api-docs/src/components/type/examples.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/examples.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import { MultiCodeBlock, CodeBlock } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-api-docs/src/components/type/properties/properties.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/properties/properties.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Table from '../../table';
 import Rows from './rows/rows';

--- a/packages/gatsby-theme-api-docs/src/components/type/properties/regex-properties.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/properties/regex-properties.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Markdown, designSystem } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-api-docs/src/components/type/properties/rows/description.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/properties/rows/description.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Markdown, useISO310NumberFormatter } from '@commercetools-docs/ui-kit';
@@ -142,7 +142,7 @@ const Description = (props) => {
             Can be{' '}
             {props.property.enumeration.map((currentEnum, index) => {
               return index === props.property.enumeration.length - 1 ? (
-                <React.Fragment key={currentEnum}>
+                <Fragment key={currentEnum}>
                   or{' '}
                   <Markdown.InlineCode css={customCodeStyle}>
                     {generateAppropriatePrimitiveText(
@@ -150,9 +150,9 @@ const Description = (props) => {
                       currentEnum
                     )}
                   </Markdown.InlineCode>
-                </React.Fragment>
+                </Fragment>
               ) : (
-                <React.Fragment key={currentEnum}>
+                <Fragment key={currentEnum}>
                   <Markdown.InlineCode css={customCodeStyle}>
                     {generateAppropriatePrimitiveText(
                       props.property.type,
@@ -160,7 +160,7 @@ const Description = (props) => {
                     )}
                   </Markdown.InlineCode>
                   ,{' '}
-                </React.Fragment>
+                </Fragment>
               );
             })}
             {'\u200B' /* zero-width space for the search crawler */}

--- a/packages/gatsby-theme-api-docs/src/components/type/properties/rows/rows.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/properties/rows/rows.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import NameType from './name-type';
 import Description from './description';

--- a/packages/gatsby-theme-api-docs/src/components/type/type-by-api-key.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/type-by-api-key.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import ApiType from './type';
 import { useApiTypes } from '../../hooks/use-api-types';
 

--- a/packages/gatsby-theme-api-docs/src/components/type/type.js
+++ b/packages/gatsby-theme-api-docs/src/components/type/type.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
   FullWidthContainer,

--- a/packages/gatsby-theme-api-docs/src/utils/render-type-as-link.js
+++ b/packages/gatsby-theme-api-docs/src/utils/render-type-as-link.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from '@commercetools-docs/gatsby-theme-docs';
 import { locationForType } from '../hooks/use-type-locations';
 

--- a/packages/gatsby-theme-api-docs/src/utils/report-error.js
+++ b/packages/gatsby-theme-api-docs/src/utils/report-error.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ContentNotifications } from '@commercetools-docs/ui-kit';
 
 function reportError(errorMsg) {

--- a/packages/gatsby-theme-code-examples/src/code-example.js
+++ b/packages/gatsby-theme-code-examples/src/code-example.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
   MultiCodeBlock,

--- a/packages/gatsby-theme-code-examples/src/multi-code-example.js
+++ b/packages/gatsby-theme-code-examples/src/multi-code-example.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Children } from 'react';
 import PropTypes from 'prop-types';
 import {
   ContentNotifications,
@@ -13,7 +13,7 @@ function MultiCodeExample(props) {
   try {
     return (
       <MultiCodeBlock title={props.title} secondaryTheme={props.secondaryTheme}>
-        {React.Children.map(props.children, (child, index) => {
+        {Children.map(props.children, (child, index) => {
           if (!child.props || child.props.mdxType !== 'CodeExample') {
             throw new Error(
               `Children of <MultiLanguageCodeExamples> must be a <CodeExample> component and not "${

--- a/packages/gatsby-theme-constants/src/constant.js
+++ b/packages/gatsby-theme-constants/src/constant.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
   ContentNotifications,

--- a/packages/gatsby-theme-docs/gatsby-browser.js
+++ b/packages/gatsby-theme-docs/gatsby-browser.js
@@ -11,7 +11,7 @@ import '@fontsource/roboto/latin-700.css';
 import '@fontsource/roboto-mono/latin-400.css';
 import '@fontsource/roboto-mono/latin-500.css';
 import '@fontsource/roboto-mono/latin-700.css';
-import React from 'react';
+
 import Prism from 'prism-react-renderer/prism';
 import { CacheProvider } from '@emotion/react';
 import { docsCache } from './utils/create-emotion-cache';

--- a/packages/gatsby-theme-docs/gatsby-ssr.js
+++ b/packages/gatsby-theme-docs/gatsby-ssr.js
@@ -3,7 +3,7 @@
  *
  * See: https://www.gatsbyjs.org/docs/ssr-apis/
  */
-import React from 'react';
+
 import { renderToString } from 'react-dom/server';
 import { withPrefix } from 'gatsby';
 import { createContentDigest } from 'gatsby-core-utils';

--- a/packages/gatsby-theme-docs/src/components/algolia-search.js
+++ b/packages/gatsby-theme-docs/src/components/algolia-search.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { css, Global } from '@emotion/react';
 import { designSystem } from '@commercetools-docs/ui-kit';
@@ -223,12 +223,11 @@ const algoliaStyles = css`
   }
 `;
 
-const AlgoliaSearch = React.forwardRef((props, ref) => {
-  const [isSearchEnabled, setIsSearchEnabled] = React.useState(true);
-  const [hasErrorLoadingAlgolia, setHasErrorLoadingAlgolia] =
-    React.useState(false);
+const AlgoliaSearch = forwardRef((props, ref) => {
+  const [isSearchEnabled, setIsSearchEnabled] = useState(true);
+  const [hasErrorLoadingAlgolia, setHasErrorLoadingAlgolia] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // https://github.com/algolia/docsearch/issues/352
     const isClient = typeof window !== 'undefined';
     if (isClient) {

--- a/packages/gatsby-theme-docs/src/components/anchor.js
+++ b/packages/gatsby-theme-docs/src/components/anchor.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 /**

--- a/packages/gatsby-theme-docs/src/components/beta-flag.js
+++ b/packages/gatsby-theme-docs/src/components/beta-flag.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { designSystem } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-docs/src/components/burger-icon.js
+++ b/packages/gatsby-theme-docs/src/components/burger-icon.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const svgPaths = {

--- a/packages/gatsby-theme-docs/src/components/card.js
+++ b/packages/gatsby-theme-docs/src/components/card.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import {

--- a/packages/gatsby-theme-docs/src/components/cards.js
+++ b/packages/gatsby-theme-docs/src/components/cards.js
@@ -1,14 +1,13 @@
-import React from 'react';
+import { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
 import { ContentNotifications, cardElements } from '@commercetools-docs/ui-kit';
 
 const Cards = (props) => {
   try {
     return (
       <cardElements.CardsContainer {...props} data-search-key="cards-container">
-        {React.Children.map(props.children, (child) => {
-          if (!React.isValidElement(child)) {
+        {Children.map(props.children, (child) => {
+          if (!isValidElement(child)) {
             throwErrorMessage(child);
           } else if (
             child.type.displayName === 'MDXCreateElement' &&
@@ -18,7 +17,7 @@ const Cards = (props) => {
             throwErrorMessage(child.props.mdxType);
           }
 
-          return React.cloneElement(
+          return cloneElement(
             child,
             {
               clickable: props.clickable,

--- a/packages/gatsby-theme-docs/src/components/child-sections-nav.js
+++ b/packages/gatsby-theme-docs/src/components/child-sections-nav.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import {

--- a/packages/gatsby-theme-docs/src/components/content-pagination.js
+++ b/packages/gatsby-theme-docs/src/components/content-pagination.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql, Link } from 'gatsby';
 import styled from '@emotion/styled';

--- a/packages/gatsby-theme-docs/src/components/content-pagination.spec.js
+++ b/packages/gatsby-theme-docs/src/components/content-pagination.spec.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import { PurePagination } from './content-pagination';

--- a/packages/gatsby-theme-docs/src/components/error-boundary.js
+++ b/packages/gatsby-theme-docs/src/components/error-boundary.js
@@ -1,8 +1,9 @@
 /* eslint-disable react/prop-types,class-methods-use-this */
-import React from 'react';
+
+import { Component } from 'react';
 import reportErrorToSentry from '../utils/report-error-to-sentry';
 
-class ErrorBoundary extends React.Component {
+class ErrorBoundary extends Component {
   static getDerivedStateFromError(/* error */) {
     // Update state so the next render will show the fallback UI.
     return { hasError: true };

--- a/packages/gatsby-theme-docs/src/components/global-navigation-link.js
+++ b/packages/gatsby-theme-docs/src/components/global-navigation-link.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/react';
 import { designSystem } from '@commercetools-docs/ui-kit';
 import Link from './link';

--- a/packages/gatsby-theme-docs/src/components/global-notification.js
+++ b/packages/gatsby-theme-docs/src/components/global-notification.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';

--- a/packages/gatsby-theme-docs/src/components/link.js
+++ b/packages/gatsby-theme-docs/src/components/link.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Location } from '@reach/router';
@@ -136,11 +136,11 @@ const PureLink = (extendedProps) => {
       hrefObject.host
     )
   ) {
-    const linkWithIcon = React.isValidElement(props.children) ? (
+    const linkWithIcon = isValidElement(props.children) ? (
       // In case the children are a React element (e.g. <code>) we need to inject
       // the external link icon next to the actual text.
       // For this we assume that the React element's own child is plain text.
-      React.cloneElement(props.children, {
+      cloneElement(props.children, {
         children: (
           <InlineLink>
             <span css={getStylesFromProps({ noUnderline })}>

--- a/packages/gatsby-theme-docs/src/components/link.spec.js
+++ b/packages/gatsby-theme-docs/src/components/link.spec.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import {
   createMemorySource,

--- a/packages/gatsby-theme-docs/src/components/release-note-heading.js
+++ b/packages/gatsby-theme-docs/src/components/release-note-heading.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { designSystem } from '@commercetools-docs/ui-kit';
 

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-topics.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-topics.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';

--- a/packages/gatsby-theme-docs/src/components/release-notes-subscribe-links.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-subscribe-links.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { withPrefix } from 'gatsby';
 import { css } from '@emotion/react';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';

--- a/packages/gatsby-theme-docs/src/components/search-dialog.js
+++ b/packages/gatsby-theme-docs/src/components/search-dialog.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import { lazy, Suspense, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css, keyframes } from '@emotion/react';
 import { designSystem } from '@commercetools-docs/ui-kit';
 import SearchInput from './search-input';
 
-const AlgoliaSearch = React.lazy(() => import('./algolia-search'));
+const AlgoliaSearch = lazy(() => import('./algolia-search'));
 
 const searchInputId = 'search-bar';
 
@@ -122,9 +122,9 @@ const InputPlaceholder = () => (
 );
 
 const SearchDialog = (props) => {
-  const ref = React.useRef();
+  const ref = useRef();
   const { onClose } = props;
-  React.useEffect(() => {
+  useEffect(() => {
     const onKeyPress = (event) => {
       // Listen to "escape" key events to close the dialog
       if (event.key.toLowerCase() === 'escape') {
@@ -148,7 +148,7 @@ const SearchDialog = (props) => {
               event.stopPropagation();
             }}
           >
-            <React.Suspense fallback={<InputPlaceholder />}>
+            <Suspense fallback={<InputPlaceholder />}>
               <AlgoliaSearch searchInputId={searchInputId} ref={ref}>
                 <SearchInput
                   ref={ref}
@@ -157,7 +157,7 @@ const SearchDialog = (props) => {
                   onClose={props.onClose}
                 />
               </AlgoliaSearch>
-            </React.Suspense>
+            </Suspense>
           </Content>
         </Center>
       </div>

--- a/packages/gatsby-theme-docs/src/components/search-dialog.spec.js
+++ b/packages/gatsby-theme-docs/src/components/search-dialog.spec.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, waitFor, fireEvent } from '@testing-library/react';
 import SearchDialog from './search-dialog';
 

--- a/packages/gatsby-theme-docs/src/components/search-input.js
+++ b/packages/gatsby-theme-docs/src/components/search-input.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import SecondaryIconButton from '@commercetools-uikit/secondary-icon-button';
@@ -67,10 +67,10 @@ const SearchInputIcon = styled.span`
   ${(props) => `${props.position}: ${designSystem.dimensions.spacings.xs};`}
 `;
 
-const SearchInput = React.forwardRef((props, ref) => {
+const SearchInput = forwardRef((props, ref) => {
   const { onFocus } = props;
-  const [isActive, setIsActive] = React.useState(false);
-  const [isLoading, setIsLoading] = React.useState(true);
+  const [isActive, setIsActive] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   const handleFocus = (event) => {
     if (props.isDisabled) return;
@@ -82,7 +82,7 @@ const SearchInput = React.forwardRef((props, ref) => {
     setIsActive(false);
     props.onClose();
   };
-  React.useEffect(() => {
+  useEffect(() => {
     if (isLoading) {
       setIsLoading(false);
     }

--- a/packages/gatsby-theme-docs/src/components/seo.js
+++ b/packages/gatsby-theme-docs/src/components/seo.js
@@ -5,7 +5,6 @@
  * See: https://www.gatsbyjs.org/docs/use-static-query/
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { useSiteData } from '../hooks/use-site-data';

--- a/packages/gatsby-theme-docs/src/components/side-by-side.js
+++ b/packages/gatsby-theme-docs/src/components/side-by-side.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';

--- a/packages/gatsby-theme-docs/src/components/theme-provider.js
+++ b/packages/gatsby-theme-docs/src/components/theme-provider.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql } from 'gatsby';
 import { Reset, Globals } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-docs/src/components/top-menu.js
+++ b/packages/gatsby-theme-docs/src/components/top-menu.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Children } from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql } from 'gatsby';
 import styled from '@emotion/styled';
@@ -118,7 +118,7 @@ const Columns = styled.div`
   grid-gap: ${designSystem.dimensions.spacings.xl};
   grid-auto-columns: 1fr;
   grid-template-columns: repeat(
-    ${(props) => React.Children.count(props.children)},
+    ${(props) => Children.count(props.children)},
     1fr
   );
 

--- a/packages/gatsby-theme-docs/src/components/user-research-banner.js
+++ b/packages/gatsby-theme-docs/src/components/user-research-banner.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { designSystem, Icons } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-docs/src/hooks/use-active-section.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-active-section.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useCallback, useState } from 'react';
 import { designSystem } from '@commercetools-docs/ui-kit';
 import useScrollSpy from './use-scroll-spy';
 
@@ -16,8 +16,8 @@ const getSectionElements = () =>
 const offset = calculateOffset();
 
 const useActiveSelection = () => {
-  const [activeSection, setActiveSection] = React.useState();
-  const onScroll = React.useCallback(() => {
+  const [activeSection, setActiveSection] = useState();
+  const onScroll = useCallback(() => {
     const sectionElements = getSectionElements();
     let nextActiveSection;
     sectionElements.forEach((section) => {

--- a/packages/gatsby-theme-docs/src/hooks/use-layout-state.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-layout-state.js
@@ -1,32 +1,32 @@
-import React from 'react';
+import { useCallback, useState } from 'react';
 
 const useLayoutState = () => {
   // State for the sidebar menu
-  const [isSidebarMenuOpen, setSidebarMenuOpen] = React.useState(false);
-  const toggleSidebarMenu = React.useCallback(() => {
+  const [isSidebarMenuOpen, setSidebarMenuOpen] = useState(false);
+  const toggleSidebarMenu = useCallback(() => {
     setSidebarMenuOpen((prev) => !prev);
   }, [setSidebarMenuOpen]);
-  const closeSidebarMenu = React.useCallback(() => {
+  const closeSidebarMenu = useCallback(() => {
     setSidebarMenuOpen(false);
   }, [setSidebarMenuOpen]);
 
   // State for the top menu
-  const [isTopMenuOpen, setIsTopMenuOpen] = React.useState(false);
-  const toggleTopMenu = React.useCallback(() => {
+  const [isTopMenuOpen, setIsTopMenuOpen] = useState(false);
+  const toggleTopMenu = useCallback(() => {
     setIsTopMenuOpen((prev) => !prev);
   }, [setIsTopMenuOpen]);
-  const closeTopMenu = React.useCallback(() => {
+  const closeTopMenu = useCallback(() => {
     setIsTopMenuOpen(false);
   }, [setIsTopMenuOpen]);
 
   // State for the search dialog
-  const [isSearchDialogOpen, setIsSearchDialogOpen] = React.useState(false);
-  const openSearchDialog = React.useCallback(() => {
+  const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
+  const openSearchDialog = useCallback(() => {
     setIsSearchDialogOpen(true);
     // Additionally make sure to close the top menu
     closeTopMenu();
   }, [setIsSearchDialogOpen, closeTopMenu]);
-  const closeSearchDialog = React.useCallback(() => {
+  const closeSearchDialog = useCallback(() => {
     setIsSearchDialogOpen(false);
   }, [setIsSearchDialogOpen]);
 

--- a/packages/gatsby-theme-docs/src/hooks/use-page-data.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-page-data.js
@@ -1,6 +1,5 @@
-/* eslint-disable react/prop-types */
-import React from 'react';
+import { createContext, useContext } from 'react';
 
-export const PageDataContext = React.createContext({});
+export const PageDataContext = createContext({});
 
-export const usePageData = () => React.useContext(PageDataContext);
+export const usePageData = () => useContext(PageDataContext);

--- a/packages/gatsby-theme-docs/src/hooks/use-page-toc.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-page-toc.js
@@ -1,6 +1,5 @@
-/* eslint-disable react/prop-types */
-import React from 'react';
+import { createContext, useContext } from 'react';
 
-export const PageTocContext = React.createContext({});
+export const PageTocContext = createContext({});
 
-export const usePageToc = () => React.useContext(PageTocContext);
+export const usePageToc = () => useContext(PageTocContext);

--- a/packages/gatsby-theme-docs/src/hooks/use-release-notes-filter-params.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-release-notes-filter-params.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import { useCallback } from 'react';
 import { useLocation, navigate } from '@reach/router';
 import { encode, decode } from 'qss';
 
 const useReleaseNotesFilterParams = () => {
   const location = useLocation();
 
-  const setFilterParams = React.useCallback(
+  const setFilterParams = useCallback(
     (params) => {
       const currentQueryParams = decode(location.search.substring(1));
       const newQueryString = encode({

--- a/packages/gatsby-theme-docs/src/hooks/use-scroll-position.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-scroll-position.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { useCallback, useState } from 'react';
 import useScrollSpy from './use-scroll-spy';
 
 const useScrollPosition = (containerId) => {
-  const [position, setPosition] = React.useState(0);
-  const onScroll = React.useCallback((element) => {
+  const [position, setPosition] = useState(0);
+  const onScroll = useCallback((element) => {
     setPosition(element.scrollTop);
   }, []);
   useScrollSpy(`#${containerId}`, onScroll);

--- a/packages/gatsby-theme-docs/src/hooks/use-scroll-spy.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-scroll-spy.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useCallback, useEffect } from 'react';
 import throttle from 'lodash.throttle';
 
 const getElement = (selector) => document.querySelector(selector);
@@ -6,7 +6,7 @@ const getElement = (selector) => document.querySelector(selector);
 const throttleMs = 100;
 
 const useScrollSpy = (selector, callback) => {
-  const onScroll = React.useCallback(
+  const onScroll = useCallback(
     throttle(() => {
       const element = getElement(selector);
       callback(element);
@@ -14,7 +14,7 @@ const useScrollSpy = (selector, callback) => {
     [callback]
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const element = getElement(selector);
     element.addEventListener('scroll', onScroll);
     return () => {

--- a/packages/gatsby-theme-docs/src/hooks/use-site-data.js
+++ b/packages/gatsby-theme-docs/src/hooks/use-site-data.js
@@ -1,6 +1,5 @@
-/* eslint-disable react/prop-types */
-import React from 'react';
+import { createContext, useContext } from 'react';
 
-export const SiteDataContext = React.createContext({});
+export const SiteDataContext = createContext({});
 
-export const useSiteData = () => React.useContext(SiteDataContext);
+export const useSiteData = () => useContext(SiteDataContext);

--- a/packages/gatsby-theme-docs/src/layouts/content-homepage.js
+++ b/packages/gatsby-theme-docs/src/layouts/content-homepage.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useInView } from 'react-intersection-observer';
 import useLayoutState from '../hooks/use-layout-state';

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Markdown } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';

--- a/packages/gatsby-theme-docs/src/layouts/internals/footer.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/footer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Children } from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 import styled from '@emotion/styled';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
@@ -43,7 +43,7 @@ const Columns = styled.div`
   grid-gap: ${designSystem.dimensions.spacings.xl};
   grid-auto-columns: 1fr;
   grid-template-columns: repeat(
-    ${(props) => React.Children.count(props.children)},
+    ${(props) => Children.count(props.children)},
     1fr
   );
 

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { ThemeProvider as UiKitThemeProvider } from '@emotion/react';

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-footer.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-footer.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { designSystem } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-header-logo.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-header-logo.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { designSystem, LogoButton } from '@commercetools-docs/ui-kit';
 

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-header.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-main.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-navigation.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { keyframes, css } from '@emotion/react';
@@ -145,9 +145,9 @@ const Blank = styled.div`
 `;
 
 const LayoutPageNavigation = (props) => {
-  const [isMenuOpen, setMenuOpen] = React.useState(false);
-  const [modalPortalNode, setModalPortalNode] = React.useState();
-  React.useEffect(() => {
+  const [isMenuOpen, setMenuOpen] = useState(false);
+  const [modalPortalNode, setModalPortalNode] = useState();
+  useEffect(() => {
     setModalPortalNode(document.getElementById('modal-portal'));
   }, []);
 

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-release-notes-filters.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { keyframes, css } from '@emotion/react';
@@ -141,9 +141,9 @@ const Blank = styled.div`
 `;
 
 const LayoutPageReleaseNotesFilters = (props) => {
-  const [isMenuOpen, setMenuOpen] = React.useState(false);
-  const [modalPortalNode, setModalPortalNode] = React.useState();
-  React.useEffect(() => {
+  const [isMenuOpen, setMenuOpen] = useState(false);
+  const [modalPortalNode, setModalPortalNode] = useState();
+  useEffect(() => {
     setModalPortalNode(document.getElementById('modal-portal'));
   }, []);
 

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-page-with-hero.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-page-with-hero.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { designSystem, Markdown } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note-body.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note-body.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { ThemeProvider as UiKitThemeProvider } from '@emotion/react';

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-sidebar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { css, keyframes } from '@emotion/react';
@@ -66,9 +66,9 @@ const MenuButton = styled.button`
 `;
 
 const LayoutSidebar = (props) => {
-  const [menuButtonNode, setMenuButtonNode] = React.useState();
-  const [modalPortalNode, setModalPortalNode] = React.useState();
-  React.useEffect(() => {
+  const [menuButtonNode, setMenuButtonNode] = useState();
+  const [modalPortalNode, setModalPortalNode] = useState();
+  useEffect(() => {
     setMenuButtonNode(document.getElementById('sidebar-menu-toggle'));
     setModalPortalNode(document.getElementById('modal-portal'));
   }, []);

--- a/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
@@ -146,7 +146,7 @@ const LevelGroup = (props) => {
                 <Indented level={props.level}>{item.title}</Indented>
               </Link>
               {props.children &&
-                React.cloneElement(props.children, {
+                cloneElement(props.children, {
                   items: item.items,
                   level: props.level + 1,
                   activeSection: props.activeSection,
@@ -166,7 +166,7 @@ const LevelGroup = (props) => {
               </Indented>
             )}
             {props.children &&
-              React.cloneElement(props.children, {
+              cloneElement(props.children, {
                 items: item.items,
                 level: props.level + 1,
                 activeSection: props.activeSection,
@@ -224,7 +224,7 @@ const Container = (props) => (
             <Indented level={1}>{item.title}</Indented>
           </Link>
           {props.children &&
-            React.cloneElement(props.children, {
+            cloneElement(props.children, {
               items: item.items,
               activeSection: props.activeSection,
               level: 2,

--- a/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.spec.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/page-navigation.spec.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import styled from '@emotion/styled';
 import PageNavigation from './page-navigation';

--- a/packages/gatsby-theme-docs/src/layouts/internals/page-read-time-estimation.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/page-read-time-estimation.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { designSystem } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Location } from '@reach/router';
 import { useStaticQuery, graphql, Link, withPrefix } from 'gatsby';
@@ -7,11 +7,14 @@ import styled from '@emotion/styled';
 import { BackIcon } from '@commercetools-uikit/icons';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
-import { designSystem, createStyledIcon } from '@commercetools-docs/ui-kit';
+import {
+  designSystem,
+  createStyledIcon,
+  Icons,
+} from '@commercetools-docs/ui-kit';
 import SiteIcon from '../../overrides/site-icon';
 import useScrollPosition from '../../hooks/use-scroll-position';
 import { BetaFlag } from '../../components';
-import { Icons } from '@commercetools-docs/ui-kit';
 import LayoutHeaderLogo from './layout-header-logo';
 
 const ReleaseNotesIcon = createStyledIcon(Icons.ReleaseNotesSvgIcon);
@@ -22,7 +25,7 @@ const ReleaseNotesIcon = createStyledIcon(Icons.ReleaseNotesSvgIcon);
 // `connect` to perform sync updates to a ref to save the latest props after
 // a render is actually committed to the DOM.
 const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 const trimTrailingSlash = (url) => url.replace(/(\/?)$/, '');
 
@@ -172,9 +175,9 @@ const SidebarLinkWrapper = (props) => {
   const cachedScrollPosition = (location.state || {}).sidebarScrollPosition;
   const locationPath = trimTrailingSlash(location.pathname);
 
-  const linkRef = React.useRef();
+  const linkRef = useRef();
 
-  const restoreScrollPosition = React.useCallback(() => {
+  const restoreScrollPosition = useCallback(() => {
     document
       .getElementById(scrollContainerId)
       .scrollBy(0, cachedScrollPosition);
@@ -230,7 +233,7 @@ SidebarLinkWrapper.propTypes = {
 
 const SidebarChapter = (props) => {
   const elemId = `sidebar-chapter-${props.index}`;
-  const getChapterDOMElement = React.useCallback(
+  const getChapterDOMElement = useCallback(
     () => document.getElementById(elemId),
     [elemId]
   );

--- a/packages/gatsby-theme-docs/src/layouts/release-notes-detail.js
+++ b/packages/gatsby-theme-docs/src/layouts/release-notes-detail.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { designSystem } from '@commercetools-docs/ui-kit';

--- a/packages/gatsby-theme-docs/src/layouts/release-notes-list.js
+++ b/packages/gatsby-theme-docs/src/layouts/release-notes-list.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Markdown } from '@commercetools-docs/ui-kit';
 import { useInView } from 'react-intersection-observer';

--- a/packages/gatsby-theme-docs/src/overrides/page-header-banner-area.js
+++ b/packages/gatsby-theme-docs/src/overrides/page-header-banner-area.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import UserResearchBanner from '../components/user-research-banner';
 
 // A banner to be rendered in the top-right corner of a content page

--- a/packages/gatsby-theme-docs/src/overrides/site-icon.js
+++ b/packages/gatsby-theme-docs/src/overrides/site-icon.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Icons } from '@commercetools-docs/ui-kit';
 
 // A React component to be rendered next to the microsite title

--- a/packages/gatsby-theme-docs/src/overrides/top-menu-banner-area.js
+++ b/packages/gatsby-theme-docs/src/overrides/top-menu-banner-area.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import UserResearchBanner from '../components/user-research-banner';
 
 // A React component to be rendered on the right side of the top-menu

--- a/packages/gatsby-theme-docs/src/templates/homepage.js
+++ b/packages/gatsby-theme-docs/src/templates/homepage.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
 import { graphql } from 'gatsby';

--- a/packages/gatsby-theme-docs/src/templates/page-content.js
+++ b/packages/gatsby-theme-docs/src/templates/page-content.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
 import { graphql } from 'gatsby';

--- a/packages/gatsby-theme-docs/src/templates/release-notes-detail.js
+++ b/packages/gatsby-theme-docs/src/templates/release-notes-detail.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
 import { graphql } from 'gatsby';

--- a/packages/gatsby-theme-docs/src/templates/release-notes-list.js
+++ b/packages/gatsby-theme-docs/src/templates/release-notes-list.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
 import { graphql } from 'gatsby';

--- a/packages/ui-kit/src/components/card-elements.tsx
+++ b/packages/ui-kit/src/components/card-elements.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import * as designSystem from '../design-system';
 import { css } from '@emotion/react';

--- a/packages/ui-kit/src/components/code-block.tsx
+++ b/packages/ui-kit/src/components/code-block.tsx
@@ -1,9 +1,7 @@
-import type { Theme } from '@emotion/react';
-
-import React from 'react';
+import { useState } from 'react';
 import ReactDOM from 'react-dom';
 import styled from '@emotion/styled';
-import { css, ThemeProvider, useTheme } from '@emotion/react';
+import { css, ThemeProvider, useTheme, type Theme } from '@emotion/react';
 import Tooltip from '@commercetools-uikit/tooltip';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import { ClipboardIcon } from '@commercetools-uikit/icons';
@@ -205,7 +203,7 @@ const CodeBlock = (props: CodeBlockProps) => {
   const isCommandLine = ['terminal', 'console'].includes(languageCode);
 
   // Copy to clipboard logic
-  const [isCopiedToClipboard, setIsCopiedToClipboard] = React.useState(false);
+  const [isCopiedToClipboard, setIsCopiedToClipboard] = useState(false);
   const handleCopyToClipboardClick = () => {
     copyToClipboard(props.content);
 

--- a/packages/ui-kit/src/components/content-notifications.tsx
+++ b/packages/ui-kit/src/components/content-notifications.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import styled from '@emotion/styled';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import {

--- a/packages/ui-kit/src/components/globals.tsx
+++ b/packages/ui-kit/src/components/globals.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css, Global } from '@emotion/react';
 import { colors, dimensions, typography, tokens } from '../design-system';
 

--- a/packages/ui-kit/src/components/logo-button.tsx
+++ b/packages/ui-kit/src/components/logo-button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import { dimensions, colors, typography } from '../design-system';

--- a/packages/ui-kit/src/components/markdown.tsx
+++ b/packages/ui-kit/src/components/markdown.tsx
@@ -1,4 +1,9 @@
-import React from 'react';
+import {
+  Children,
+  useState,
+  type ComponentType,
+  type SyntheticEvent,
+} from 'react';
 import reactIs from 'react-is';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -157,7 +162,7 @@ const Table = styled.table`
       left: -9999px;
     }
     ${(props) => {
-      const tableHeaders = React.Children.toArray(props.children).find(
+      const tableHeaders = Children.toArray(props.children).find(
         (elem) =>
           reactIs.isElement(elem) &&
           (elem.type === 'thead' || elem.props.mdxType === 'thead')
@@ -168,7 +173,7 @@ const Table = styled.table`
       const rowHeadersChildren = Array.isArray(rowHeaders)
         ? rowHeaders
         : rowHeaders.props.children;
-      return React.Children.toArray(rowHeadersChildren).reduce(
+      return Children.toArray(rowHeadersChildren).reduce(
         (styles, elem, index) => `
         ${styles}
         td:nth-of-type(${index + 1})::before { content: "${
@@ -316,9 +321,9 @@ const TooltipBodyComponent = styled.div`
 /* eslint-disable react/display-name */
 const withCopyToClipboard =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (Component: React.ComponentType) => (props: any) => {
-    const [isCopiedToClipboard, setIsCopiedToClipboard] = React.useState(false);
-    const handleCopyToClipboardClick = (event: React.SyntheticEvent) => {
+  (Component: ComponentType) => (props: any) => {
+    const [isCopiedToClipboard, setIsCopiedToClipboard] = useState(false);
+    const handleCopyToClipboardClick = (event: SyntheticEvent) => {
       event.preventDefault();
       const sectionUrl = `${window.location.href.split('#')[0]}#${props.id}`;
       copyToClipboard(sectionUrl);

--- a/packages/ui-kit/src/components/mermaid-client-side.tsx
+++ b/packages/ui-kit/src/components/mermaid-client-side.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import mermaid from 'mermaid';
 import { colors, typography, tokens, dimensions } from '../design-system';

--- a/packages/ui-kit/src/components/mermaid.tsx
+++ b/packages/ui-kit/src/components/mermaid.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { lazy, Suspense } from 'react';
 import LoadingSpinner from '@commercetools-uikit/loading-spinner';
 
 // This is a client-side only implementation of mermaid, which is its primary development target.
@@ -10,7 +10,7 @@ import LoadingSpinner from '@commercetools-uikit/loading-spinner';
 // server side rendering also has the disadvantage that clickable elements cannot
 // work because this requires attaching event handlers.
 
-const MermaidLazy = React.lazy(() => import('./mermaid-client-side'));
+const MermaidLazy = lazy(() => import('./mermaid-client-side'));
 
 type MermaidProps = {
   graph: string;
@@ -21,11 +21,11 @@ const Mermaid = (props: MermaidProps) => {
   return (
     <>
       {isClientSide && (
-        <React.Suspense
+        <Suspense
           fallback={<LoadingSpinner scale="l" maxDelayDuration={500} />}
         >
           <MermaidLazy graph={props.graph} />
-        </React.Suspense>
+        </Suspense>
       )}
     </>
   );

--- a/packages/ui-kit/src/components/multi-code-block.tsx
+++ b/packages/ui-kit/src/components/multi-code-block.tsx
@@ -1,4 +1,10 @@
-import React from 'react';
+import {
+  cloneElement,
+  useCallback,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import reactIs from 'react-is';
 import styled from '@emotion/styled';
 import { ThemeProvider } from '@emotion/react';
@@ -104,8 +110,8 @@ function extractLanguages(children: OneOrManyChildren): string[] {
 function MultiCodeBlock(props: MultiCodeBlockProps) {
   const langs = extractLanguages(props.children);
 
-  const [selected, setSelected] = React.useState(langs[0]);
-  const handleOnLanguageChange = React.useCallback((event) => {
+  const [selected, setSelected] = useState(langs[0]);
+  const handleOnLanguageChange = useCallback((event) => {
     setSelected(event.target.value);
   }, []);
 
@@ -114,7 +120,7 @@ function MultiCodeBlock(props: MultiCodeBlockProps) {
       colors.light.codeBlocks[props.secondaryTheme ? 'secondary' : 'primary'],
   };
 
-  let selectedElement: React.ReactElement | undefined;
+  let selectedElement: ReactElement | undefined;
   if (Array.isArray(props.children)) {
     selectedElement =
       props.children.find((child) => child.props.language === selected) ||
@@ -164,7 +170,7 @@ function MultiCodeBlock(props: MultiCodeBlockProps) {
         ) : null}
 
         {selectedElement &&
-          React.cloneElement(selectedElement, {
+          cloneElement(selectedElement, {
             secondaryTheme: props.secondaryTheme,
           })}
       </Container>
@@ -172,7 +178,7 @@ function MultiCodeBlock(props: MultiCodeBlockProps) {
   );
 }
 
-type OneOrManyChildren = React.ReactElement | React.ReactElement[];
+type OneOrManyChildren = ReactElement | ReactElement[];
 type MultiCodeBlockProps = {
   secondaryTheme?: boolean;
   title?: string;
@@ -183,9 +189,7 @@ export default MultiCodeBlock;
 
 /* eslint-disable react/display-name */
 // Maps the props coming from MDX to the underlying <CodeBlock> component.
-export const CodeBlockMarkdownWrapper = (props: {
-  children?: React.ReactNode;
-}) => {
+export const CodeBlockMarkdownWrapper = (props: { children?: ReactNode }) => {
   const childElement = reactIs.isElement(props.children)
     ? props.children
     : null;

--- a/packages/ui-kit/src/components/reset.tsx
+++ b/packages/ui-kit/src/components/reset.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Global, css } from '@emotion/react';
 
 /**

--- a/packages/ui-kit/src/components/rss/rss-feed-table.tsx
+++ b/packages/ui-kit/src/components/rss/rss-feed-table.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { DocsDateFormat } from '../../utils/dates';

--- a/packages/ui-kit/src/components/rss/rss-feeds.tsx
+++ b/packages/ui-kit/src/components/rss/rss-feeds.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import useSWR from 'swr';
 import LoadingSpinner from '@commercetools-uikit/loading-spinner';
 import ContentNotifications from './../content-notifications';

--- a/packages/ui-kit/src/hooks/use-iso310-number-formatter.spec.tsx
+++ b/packages/ui-kit/src/hooks/use-iso310-number-formatter.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { render, screen } from '@testing-library/react';
 import useISO310NumberFormatter from './use-iso310-number-formatter';

--- a/packages/ui-kit/src/utils/create-styled-icon.ts
+++ b/packages/ui-kit/src/utils/create-styled-icon.ts
@@ -2,7 +2,6 @@ import invariant from 'tiny-invariant';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '../design-system';
-import React from 'react';
 
 export type IconSize = 'small' | 'medium' | 'big' | 'scale';
 export type StyledComponentProps = {

--- a/packages/ui-kit/src/utils/markdown-fragment-to-react.js
+++ b/packages/ui-kit/src/utils/markdown-fragment-to-react.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement, Fragment } from 'react';
 import styled from '@emotion/styled';
 import unified from 'unified';
 import filter from 'unist-util-filter';
@@ -61,8 +61,8 @@ const markdownFragmentToReact = (
     .use(safeCustomPlugin)
     .use(remarkRehype)
     .use(rehypeReact, {
-      createElement: React.createElement,
-      Fragment: React.Fragment,
+      createElement,
+      Fragment,
       components: {
         p: Markdown.Paragraph,
         a: Link,

--- a/websites/api-docs-smoke-test/src/@commercetools-docs/gatsby-theme-docs/overrides/page-header-side.js
+++ b/websites/api-docs-smoke-test/src/@commercetools-docs/gatsby-theme-docs/overrides/page-header-side.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import GithubSvgIcon from '../../../icons/github.svg';
 
 // A React component to be rendered in the top-right corner of a content page

--- a/websites/api-docs-smoke-test/src/@commercetools-docs/gatsby-theme-docs/overrides/site-icon.js
+++ b/websites/api-docs-smoke-test/src/@commercetools-docs/gatsby-theme-docs/overrides/site-icon.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Icons } from '@commercetools-docs/ui-kit';
 
 // A React component to be rendered next to the microsite title


### PR DESCRIPTION
Cleanup work to remove the `React` import as it's not required when using the new JSX transform (Gatsby already supports this).