### PR TITLE
[Feat] support email links and render them as external links

### DIFF
--- a/.changeset/friendly-colts-approve.md
+++ b/.changeset/friendly-colts-approve.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': minor
+---
+
+Add support for email links. They are now being rendered as external links.

--- a/packages/gatsby-theme-docs/src/components/link.js
+++ b/packages/gatsby-theme-docs/src/components/link.js
@@ -129,7 +129,9 @@ const PureLink = (extendedProps) => {
 
   // Case 2: the link points to an external website.
   const isExternalLink =
-    /^https?/.test(props.href) || (props.target && props.target === '_blank');
+    /^https?/.test(props.href) ||
+    /^mailto?/.test(props.href) ||
+    (props.target && props.target === '_blank');
   if (
     isExternalLink &&
     ![siteData.siteMetadata.productionHostname, dummyHostname].includes(

--- a/websites/docs-smoke-test/src/content/views/links.mdx
+++ b/websites/docs-smoke-test/src/content/views/links.mdx
@@ -136,11 +136,21 @@ timeToRead: 5
 [Link](/html/hello.html)
 ```
 
-| Link     | Type          | Expected outcome                           |
-| -------- | ------------- | ------------------------------------------ |
-| [Link](/downloads/hello.txt) | `static-link` | It renders a normal HTML link pointing to the `hello.txt` page |
-| [Link](/downloads/hello.json) | `static-link` | It renders a normal HTML link pointing to the `hello.json` page |
-| [Link](/html/hello.html) | `static-link` | It renders a normal HTML link pointing to the `hello.html` page (HTML pages do not work in development mode) |
+| Link                          | Type          | Expected outcome                                                                                             |
+| ----------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
+| [Link](/downloads/hello.txt)  | `static-link` | It renders a normal HTML link pointing to the `hello.txt` page                                               |
+| [Link](/downloads/hello.json) | `static-link` | It renders a normal HTML link pointing to the `hello.json` page                                              |
+| [Link](/html/hello.html)      | `static-link` | It renders a normal HTML link pointing to the `hello.html` page (HTML pages do not work in development mode) |
+
+### Link to an email address
+
+```md
+[Link](mailto:documentation@commercetools.com)
+```
+
+| Link                                           | Type            | Expected outcome                                                               |
+| ---------------------------------------------- | --------------- | ------------------------------------------------------------------------------ |
+| [Link](mailto:documentation@commercetools.com) | `external-link` | It renders a link to open a new email with the given address as the recipient. |
 
 ## Last Heading
 


### PR DESCRIPTION
I've noticed during the frontend docs migration that the link component in the kit did not support email links yet. They were rendered by gatsby as internal links which led to a wrong url.

This PR implements `mailto` links as external links which will fix the issue and make it possible to support the email links in the frontend docs content.