### PR TITLE
refactor: load CSS variables via global import instead of using `<ThemeProvider>`

### DIFF
--- a/.changeset/forty-sloths-fail.md
+++ b/.changeset/forty-sloths-fail.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+'@commercetools-docs/ui-kit': patch
+---
+
+Load CSS variables via global import instead of using UI Kit's `<ThemeProvider>` (does not support SSR).

--- a/packages/gatsby-theme-docs/gatsby-browser.js
+++ b/packages/gatsby-theme-docs/gatsby-browser.js
@@ -11,6 +11,7 @@ import '@fontsource/roboto/latin-700.css';
 import '@fontsource/roboto-mono/latin-400.css';
 import '@fontsource/roboto-mono/latin-500.css';
 import '@fontsource/roboto-mono/latin-700.css';
+import './globals.css';
 import React from 'react';
 import Prism from 'prism-react-renderer/prism';
 import { CacheProvider } from '@emotion/react';

--- a/packages/gatsby-theme-docs/globals.css
+++ b/packages/gatsby-theme-docs/globals.css
@@ -1,0 +1,6 @@
+@import '@commercetools-uikit/design-system/materials/custom-properties.css';
+
+:root {
+  --font-family-default: 'Roboto', sans-serif;
+  --font-family-body: 'Roboto Mono', monospace;
+}

--- a/packages/gatsby-theme-docs/src/components/theme-provider.js
+++ b/packages/gatsby-theme-docs/src/components/theme-provider.js
@@ -37,13 +37,14 @@ const ThemeProvider = (props) => {
     <ErrorBoundary>
       <SiteDataContext.Provider value={siteData}>
         <Reset />
-        <Globals />
+        <Globals websitePrimaryColor={props.websitePrimaryColor} />
         {props.children}
       </SiteDataContext.Provider>
     </ErrorBoundary>
   );
 };
 ThemeProvider.propTypes = {
+  websitePrimaryColor: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
 };
 

--- a/packages/gatsby-theme-docs/src/layouts/content-homepage.js
+++ b/packages/gatsby-theme-docs/src/layouts/content-homepage.js
@@ -24,7 +24,6 @@ const LayoutContentHomepage = (props) => {
 
   return (
     <LayoutApplication
-      websitePrimaryColor={props.pageData.websitePrimaryColor}
       globalNotification={siteData.siteMetadata.globalNotification}
     >
       <LayoutSidebar

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -35,7 +35,6 @@ const LayoutContent = (props) => {
 
   return (
     <LayoutApplication
-      websitePrimaryColor={props.pageData.websitePrimaryColor}
       globalNotification={siteData.siteMetadata.globalNotification}
     >
       <LayoutSidebar

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { ThemeProvider as UiKitThemeProvider } from '@commercetools-uikit/design-system';
 import { designSystem } from '@commercetools-docs/ui-kit';
 
 /* NOTE: `overflow` shorthand is only supported is Chrome and FF */
@@ -44,13 +43,6 @@ const Container = styled.div`
 
 const LayoutApplication = (props) => (
   <>
-    <UiKitThemeProvider
-      themeOverrides={{
-        fontFamilyDefault: designSystem.typography.fontFamilies.primary,
-        fontFamilyBody: designSystem.typography.fontFamilies.primary,
-        websitePrimaryColor: props.websitePrimaryColor,
-      }}
-    />
     <Root
       role="application"
       id="application"
@@ -62,7 +54,6 @@ const LayoutApplication = (props) => (
   </>
 );
 LayoutApplication.propTypes = {
-  websitePrimaryColor: PropTypes.string.isRequired,
   globalNotification: PropTypes.shape({
     notificationType: PropTypes.oneOf(['info', 'warning']).isRequired,
     content: PropTypes.string.isRequired,

--- a/packages/gatsby-theme-docs/src/layouts/release-notes-detail.js
+++ b/packages/gatsby-theme-docs/src/layouts/release-notes-detail.js
@@ -30,7 +30,7 @@ const LayoutReleaseNotesDetail = (props) => {
     siteData.siteMetadata.excludeFromSearchIndex;
 
   return (
-    <LayoutApplication websitePrimaryColor={props.pageData.websitePrimaryColor}>
+    <LayoutApplication>
       <LayoutSidebar
         {...layoutState.sidebar}
         {...layoutState.searchDialog}

--- a/packages/gatsby-theme-docs/src/layouts/release-notes-list.js
+++ b/packages/gatsby-theme-docs/src/layouts/release-notes-list.js
@@ -28,7 +28,7 @@ const LayoutReleaseNotesList = (props) => {
     siteData.siteMetadata.excludeFromSearchIndex;
 
   return (
-    <LayoutApplication websitePrimaryColor={props.pageData.websitePrimaryColor}>
+    <LayoutApplication>
       <LayoutSidebar
         {...layoutState.sidebar}
         {...layoutState.searchDialog}

--- a/packages/gatsby-theme-docs/src/templates/homepage.js
+++ b/packages/gatsby-theme-docs/src/templates/homepage.js
@@ -12,7 +12,9 @@ import markdownComponents from '../markdown-components';
 
 const HomepageTemplate = (props) => (
   <IntlProvider locale="en">
-    <ThemeProvider>
+    <ThemeProvider
+      websitePrimaryColor={props.data.contentPage.websitePrimaryColor}
+    >
       <PageDataContext.Provider value={props.data.contentPage}>
         <LayoutContentHomepage
           pageContext={props.pageContext}

--- a/packages/gatsby-theme-docs/src/templates/page-content.js
+++ b/packages/gatsby-theme-docs/src/templates/page-content.js
@@ -17,7 +17,9 @@ const ContentCards = (props) => (
 
 const PageContentTemplate = (props) => (
   <IntlProvider locale="en">
-    <ThemeProvider>
+    <ThemeProvider
+      websitePrimaryColor={props.data.contentPage.websitePrimaryColor}
+    >
       <PageDataContext.Provider value={props.data.contentPage}>
         <LayoutContent
           pageContext={props.pageContext}

--- a/packages/gatsby-theme-docs/src/templates/release-notes-detail.js
+++ b/packages/gatsby-theme-docs/src/templates/release-notes-detail.js
@@ -21,7 +21,9 @@ const releaseNoteMarkdownComponents = {
 
 const ReleaseNotesDetailTemplate = (props) => (
   <IntlProvider locale="en">
-    <ThemeProvider>
+    <ThemeProvider
+      websitePrimaryColor={props.data.releaseNotePage.websitePrimaryColor}
+    >
       <LayoutReleaseNotesDetail pageData={props.data.releaseNotePage}>
         <MDXProvider components={releaseNoteMarkdownComponents}>
           <Markdown.TypographyPage>

--- a/packages/gatsby-theme-docs/src/templates/release-notes-list.js
+++ b/packages/gatsby-theme-docs/src/templates/release-notes-list.js
@@ -20,7 +20,9 @@ const ReleaseNotesListTemplate = (props) => {
 
   return (
     <IntlProvider locale="en">
-      <ThemeProvider>
+      <ThemeProvider
+        websitePrimaryColor={props.data.contentPage.websitePrimaryColor}
+      >
         <LayoutReleaseNotesList
           pageContext={props.pageContext}
           pageData={props.data.contentPage}

--- a/packages/ui-kit/src/components/globals.tsx
+++ b/packages/ui-kit/src/components/globals.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { css, Global } from '@emotion/react';
 import { colors, dimensions, typography, tokens } from '../design-system';
 
-// eslint-disable-next-line react/display-name
-const Globals = () => (
+type TGlobalsProps = {
+  websitePrimaryColor: string;
+};
+
+const Globals = (props: TGlobalsProps) => (
   <Global
     styles={css`
+      :root {
+        --website-primary-color: ${props.websitePrimaryColor};
+      }
+
       html,
       body {
         padding: 0;
@@ -100,4 +107,5 @@ const Globals = () => (
     `}
   />
 );
+
 export default Globals;


### PR DESCRIPTION
Temporary workaround for #1410 