### PR TITLE
Search result improvements

### DIFF
--- a/.changeset/silly-rivers-swim.md
+++ b/.changeset/silly-rivers-swim.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': minor
+---
+
+Uptate for the search inside the documentation: Show the product name together with the website name on the first level of every search result.

--- a/algolia-crawler.js
+++ b/algolia-crawler.js
@@ -29,9 +29,10 @@ new Crawler({
           // FYI selector documentation: https://github.com/cheeriojs/cheerio#selectors
           recordProps: {
             lvl0: {
-              selectors: $(
-                'meta[name=commercetools:title-for-onsite-search]'
-              ).attr('content'),
+              selectors:
+                $('meta[name=commercetools:title-for-onsite-search]').attr(
+                  'content'
+                ) || '#site-title',
               defaultValue: 'General Topics',
             },
             lvl1: 'article h1',

--- a/algolia-crawler.js
+++ b/algolia-crawler.js
@@ -29,7 +29,9 @@ new Crawler({
           // FYI selector documentation: https://github.com/cheeriojs/cheerio#selectors
           recordProps: {
             lvl0: {
-              selectors: '#site-title',
+              selectors: $(
+                'meta[name=commercetools:title-for-onsite-search]'
+              ).attr('content'),
               defaultValue: 'General Topics',
             },
             lvl1: 'article h1',

--- a/packages/gatsby-theme-docs/src/components/seo.js
+++ b/packages/gatsby-theme-docs/src/components/seo.js
@@ -61,6 +61,10 @@ const SEO = (props) => {
       name: 'twitter:description',
       content: metaDescription,
     },
+    {
+      name: 'commercetools:title-for-onsite-search',
+      content: `${siteContextTitle} > ${siteData.siteMetadata.title}`,
+    },
     excludeFromSearchIndex && {
       name: 'robots',
       content: 'noindex',

--- a/packages/gatsby-theme-docs/src/components/seo.js
+++ b/packages/gatsby-theme-docs/src/components/seo.js
@@ -63,7 +63,9 @@ const SEO = (props) => {
     },
     {
       name: 'commercetools:title-for-onsite-search',
-      content: `${siteContextTitle} > ${siteData.siteMetadata.title}`,
+      content: siteContextTitle
+        ? `${siteContextTitle} > ${siteData.siteMetadata.title}`
+        : siteData.siteMetadata.title,
     },
     excludeFromSearchIndex && {
       name: 'robots',

--- a/packages/gatsby-theme-docs/src/components/seo.js
+++ b/packages/gatsby-theme-docs/src/components/seo.js
@@ -70,7 +70,7 @@ const SEO = (props) => {
   return (
     <Helmet
       titleTemplate={`%s | ${siteData.siteMetadata.title} | ${
-        siteContextTitle || 'commercetools'
+        siteContextTitle ? `commercetools ${siteContextTitle}` : `commercetools`
       }`}
     >
       <meta charSet="utf-8" />


### PR DESCRIPTION
closes #1444 

This pull request changes the site-context implementation in `layout-header` to have an element that Algolia can use to read the full site context as it appears in the header.

If we split the information into two elements, the crawler is not able to read out one element to get a clean string.