### PR TITLE
Replace `date-filter` ui-kit component with new custom component as release note filter

### DIFF
--- a/.changeset/thin-pumpkins-kiss.md
+++ b/.changeset/thin-pumpkins-kiss.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Fix regression on the date filter for release notes. The release note date filter is now visible and functional on all viewports.

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -20,7 +20,6 @@
     "@commercetools-docs/ui-kit": "19.7.0",
     "@commercetools-uikit/card": "^15.3.0",
     "@commercetools-uikit/checkbox-input": "^15.3.0",
-    "@commercetools-uikit/date-input": "^15.3.0",
     "@commercetools-uikit/design-system": "^15.3.0",
     "@commercetools-uikit/icon-button": "^15.3.0",
     "@commercetools-uikit/icons": "^15.3.0",

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -99,6 +99,8 @@ const ReleaseNotesFilterDates = () => {
     });
     setFromFilterDate(undefined);
     setToFilterDate(undefined);
+    document.getElementById('from-filter-date').value = '';
+    document.getElementById('to-filter-date').value = '';
     scrollToTop();
   }
 

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
-import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
+import { designSystem } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import useReleaseNotesFilterParams from '../hooks/use-release-notes-filter-params';
@@ -48,11 +48,19 @@ const ClearAll = styled.button`
   }
 `;
 
+/**
+ * Return the date in yyyy-mm-dd format
+ */
+const isoYMD = (inDate) => {
+  const date = inDate || new Date();
+  return date.toISOString().substring(0, 10);
+};
+
 const ReleaseNotesFilterDates = () => {
   const [filterParams, setFilterParams] = useReleaseNotesFilterParams();
-  const [fromDate, setFromFilterDate] = useState();
-  const [toDate, setToFilterDate] = useState();
-  const maximumDate = IsoDateFormat.format(new Date());
+  const [fromDate, setFromFilterDate] = useState('');
+  const [toDate, setToFilterDate] = useState('');
+  const maximumDate = isoYMD();
 
   useEffect(() => {
     if (filterParams.fromFilterDate) {
@@ -116,29 +124,25 @@ const ReleaseNotesFilterDates = () => {
   function handleOnFromFilterDateChange(e) {
     let date;
     try {
-      date = IsoDateFormat.format(new Date(e.target.value));
+      date = isoYMD(new Date(e.target.value));
     } catch (err) {
-      return;
+      if (fromDate) {
+        setFromFilterDate('');
+      }
     }
-    if (date.length === 10) {
-      setFromFilterDate(date);
-    } else if (date.length !== 10 && fromDate) {
-      setFromFilterDate(undefined);
-    }
+    setFromFilterDate(date);
   }
 
   function handleOnToFilterDateChange(e) {
     let date;
     try {
-      date = IsoDateFormat.format(new Date(e.target.value));
+      date = isoYMD(new Date(e.target.value));
     } catch (err) {
-      return;
+      if (toDate) {
+        setToFilterDate('');
+      }
     }
-    if (date.length === 10) {
-      setToFilterDate(date);
-    } else if (date.length !== 10 && fromDate) {
-      setToFilterDate(undefined);
-    }
+    setToFilterDate(date);
   }
 
   function handleOnBlur(event, field) {

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -34,7 +34,7 @@ const DateInputField = styled.input`
 `;
 
 const ReleaseNotesFilterDates = () => {
-  const [filterParams, setFilterParams] = useReleaseNotesFilterParams();
+  const [, setFilterParams] = useReleaseNotesFilterParams();
   const maximumDate = IsoDateFormat.format(new Date());
 
   return (
@@ -48,8 +48,6 @@ const ReleaseNotesFilterDates = () => {
             type="date"
             id="from-filter-date"
             max={maximumDate}
-            value={filterParams.fromFilterDate || ''}
-            onClick={handleClick}
             onChange={handleOnFromFilterDateChange}
           />
         </div>
@@ -62,7 +60,6 @@ const ReleaseNotesFilterDates = () => {
             type="date"
             id="to-filter-date"
             max={maximumDate}
-            value={filterParams.toFilterDate || ''}
             onChange={handleOnToFilterDateChange}
           />
         </div>
@@ -70,20 +67,20 @@ const ReleaseNotesFilterDates = () => {
     </SpacingsStack>
   );
 
-  function handleClick(e) {
-    if ('showPicker' in HTMLInputElement.prototype) {
-      document.getElementById(e.target.id).showPicker();
+  function handleOnFromFilterDateChange(e) {
+    const date = IsoDateFormat.format(new Date(e.target.value));
+    if (date.length === 10) {
+      setFilterParams({ fromFilterDate: e.target.value || undefined });
+      scrollToTop();
     }
   }
 
-  function handleOnFromFilterDateChange(e) {
-    setFilterParams({ fromFilterDate: e.target.value || undefined });
-    scrollToTop();
-  }
-
   function handleOnToFilterDateChange(e) {
-    setFilterParams({ toFilterDate: e.target.value || undefined });
-    scrollToTop();
+    const date = IsoDateFormat.format(new Date(e.target.value));
+    if (date.length === 10) {
+      setFilterParams({ toFilterDate: e.target.value || undefined });
+      scrollToTop();
+    }
   }
 };
 

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -111,7 +111,6 @@ const ReleaseNotesFilterDates = () => {
     });
     setFromFilterDate('');
     setToFilterDate('');
-    setFilterParams({ fromFilterDate: undefined, toFilterDate: undefined });
   }
 
   function handleOnFromFilterDateChange(e) {

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -107,10 +107,8 @@ const ReleaseNotesFilterDates = () => {
       toFilterDate: undefined,
       filterTopics: [],
     });
-    setFromFilterDate(undefined);
-    setToFilterDate(undefined);
-    document.getElementById('from-filter-date').value = '';
-    document.getElementById('to-filter-date').value = '';
+    setFromFilterDate('');
+    setToFilterDate('');
     scrollToTop();
   }
 

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
+import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import useReleaseNotesFilterParams from '../hooks/use-release-notes-filter-params';
 import scrollToTop from '../utils/scroll-to-top';
 
@@ -33,13 +34,32 @@ const DateInputField = styled.input`
   }
 `;
 
+const ClearAll = styled.button`
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: ${designSystem.colors.light.link};
+  font-size: ${designSystem.typography.fontSizes.extraSmall};
+  text-decoration: none;
+  background-color: transparent;
+
+  :hover {
+    color: ${designSystem.colors.light.linkHover};
+  }
+`;
+
 const ReleaseNotesFilterDates = () => {
   const [, setFilterParams] = useReleaseNotesFilterParams();
   const maximumDate = IsoDateFormat.format(new Date());
 
   return (
     <SpacingsStack scale="s">
-      <FilterTitle>Filter by date</FilterTitle>
+      <SpacingsInline alignItems="center" justifyContent="space-between">
+        <FilterTitle>Filter by date</FilterTitle>
+        <ClearAll onClick={handleOnClearAll} aria-label="Clear all">
+          Clear all
+        </ClearAll>
+      </SpacingsInline>
 
       <SpacingsStack scale="xs">
         <DateLabel htmlFor="from-filter-date">From</DateLabel>
@@ -66,6 +86,15 @@ const ReleaseNotesFilterDates = () => {
       </SpacingsStack>
     </SpacingsStack>
   );
+
+  function handleOnClearAll() {
+    setFilterParams({
+      fromFilterDate: undefined,
+      toFilterDate: undefined,
+      filterTopics: [],
+    });
+    scrollToTop();
+  }
 
   function handleOnFromFilterDateChange(e) {
     const date = IsoDateFormat.format(new Date(e.target.value));

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
@@ -49,10 +49,20 @@ const ClearAll = styled.button`
 `;
 
 const ReleaseNotesFilterDates = () => {
-  const [, setFilterParams] = useReleaseNotesFilterParams();
+  const [filterParams, setFilterParams] = useReleaseNotesFilterParams();
   const [fromDate, setFromFilterDate] = useState();
   const [toDate, setToFilterDate] = useState();
   const maximumDate = IsoDateFormat.format(new Date());
+
+  useEffect(() => {
+    if (filterParams.fromFilterDate) {
+      setFromFilterDate(filterParams.fromFilterDate);
+    }
+    if (filterParams.toFilterDate) {
+      setToFilterDate(filterParams.toFilterDate);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <SpacingsStack scale="s">
@@ -105,20 +115,34 @@ const ReleaseNotesFilterDates = () => {
   }
 
   function handleOnFromFilterDateChange(e) {
-    const date = IsoDateFormat.format(new Date(e.target.value));
+    let date;
+    try {
+      date = IsoDateFormat.format(new Date(e.target.value));
+    } catch (err) {
+      return;
+    }
     if (date.length === 10) {
       setFromFilterDate(date);
       setFilterParams({ fromFilterDate: e.target.value || undefined });
       scrollToTop();
+    } else if (date.length !== 10 && fromDate) {
+      setFromFilterDate(undefined);
     }
   }
 
   function handleOnToFilterDateChange(e) {
-    const date = IsoDateFormat.format(new Date(e.target.value));
+    let date;
+    try {
+      date = IsoDateFormat.format(new Date(e.target.value));
+    } catch (err) {
+      return;
+    }
     if (date.length === 10) {
       setToFilterDate(date);
       setFilterParams({ toFilterDate: e.target.value || undefined });
       scrollToTop();
+    } else if (date.length !== 10 && toDate) {
+      setToFilterDate(undefined);
     }
   }
 };

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
+import { designSystem } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
-import DateInput from '@commercetools-uikit/date-input';
 import useReleaseNotesFilterParams from '../hooks/use-release-notes-filter-params';
 import scrollToTop from '../utils/scroll-to-top';
 
@@ -17,9 +16,25 @@ const DateLabel = styled.label`
   line-height: ${designSystem.typography.lineHeights.small};
 `;
 
+const DateInputField = styled.input`
+  color: ${designSystem.colors.light.textPrimary};
+  border: 1px solid ${designSystem.colors.light.borderInput};
+  border-radius: ${designSystem.tokens.borderRadiusForSearchDialog};
+  font-size: ${designSystem.typography.fontSizes.body};
+  height: ${designSystem.dimensions.heights.inputSearchPrimary};
+  padding: 0 ${designSystem.dimensions.spacings.s};
+  box-sizing: border-box;
+  font-family: inherit;
+  outline: none;
+  width: 100%;
+
+  &:focus {
+    border-color: ${designSystem.colors.light.borderHighlight};
+  }
+`;
+
 const ReleaseNotesFilterDates = () => {
   const [filterParams, setFilterParams] = useReleaseNotesFilterParams();
-  const maximumDate = IsoDateFormat.format(new Date());
 
   return (
     <SpacingsStack scale="s">
@@ -28,11 +43,11 @@ const ReleaseNotesFilterDates = () => {
       <SpacingsStack scale="xs">
         <DateLabel htmlFor="from-filter-date">From</DateLabel>
         <div>
-          <DateInput
+          <DateInputField
+            type="date"
             id="from-filter-date"
             value={filterParams.fromFilterDate || ''}
             onChange={handleOnFromFilterDateChange}
-            maxValue={maximumDate}
           />
         </div>
       </SpacingsStack>
@@ -40,11 +55,11 @@ const ReleaseNotesFilterDates = () => {
       <SpacingsStack scale="xs">
         <DateLabel htmlFor="to-filter-date">To</DateLabel>
         <div>
-          <DateInput
+          <DateInputField
+            type="date"
             id="to-filter-date"
             value={filterParams.toFilterDate || ''}
             onChange={handleOnToFilterDateChange}
-            maxValue={maximumDate}
           />
         </div>
       </SpacingsStack>

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { designSystem } from '@commercetools-docs/ui-kit';
+import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import useReleaseNotesFilterParams from '../hooks/use-release-notes-filter-params';
 import scrollToTop from '../utils/scroll-to-top';
@@ -35,6 +35,7 @@ const DateInputField = styled.input`
 
 const ReleaseNotesFilterDates = () => {
   const [filterParams, setFilterParams] = useReleaseNotesFilterParams();
+  const maximumDate = IsoDateFormat.format(new Date());
 
   return (
     <SpacingsStack scale="s">
@@ -46,6 +47,7 @@ const ReleaseNotesFilterDates = () => {
           <DateInputField
             type="date"
             id="from-filter-date"
+            max={maximumDate}
             value={filterParams.fromFilterDate || ''}
             onChange={handleOnFromFilterDateChange}
           />
@@ -58,6 +60,7 @@ const ReleaseNotesFilterDates = () => {
           <DateInputField
             type="date"
             id="to-filter-date"
+            max={maximumDate}
             value={filterParams.toFilterDate || ''}
             onChange={handleOnToFilterDateChange}
           />

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import styled from '@emotion/styled';
 import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
@@ -50,16 +50,16 @@ const ClearAll = styled.button`
 
 const ReleaseNotesFilterDates = () => {
   const [filterParams, setFilterParams] = useReleaseNotesFilterParams();
-  const [fromDate, setFromFilterDate] = useState();
-  const [toDate, setToFilterDate] = useState();
   const maximumDate = IsoDateFormat.format(new Date());
 
   useEffect(() => {
     if (filterParams.fromFilterDate) {
-      setFromFilterDate(filterParams.fromFilterDate);
+      document.getElementById('from-filter-date').value =
+        filterParams.fromFilterDate;
     }
     if (filterParams.toFilterDate) {
-      setToFilterDate(filterParams.toFilterDate);
+      document.getElementById('to-filter-date').value =
+        filterParams.fromFilterDate;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -80,7 +80,6 @@ const ReleaseNotesFilterDates = () => {
             type="date"
             id="from-filter-date"
             max={maximumDate}
-            value={fromDate}
             onChange={handleOnFromFilterDateChange}
           />
         </div>
@@ -93,7 +92,6 @@ const ReleaseNotesFilterDates = () => {
             type="date"
             id="to-filter-date"
             max={maximumDate}
-            value={toDate}
             onChange={handleOnToFilterDateChange}
           />
         </div>
@@ -107,8 +105,8 @@ const ReleaseNotesFilterDates = () => {
       toFilterDate: undefined,
       filterTopics: [],
     });
-    setFromFilterDate('');
-    setToFilterDate('');
+    document.getElementById('from-filter-date').value = '';
+    document.getElementById('to-filter-date').value = '';
     scrollToTop();
   }
 
@@ -120,11 +118,8 @@ const ReleaseNotesFilterDates = () => {
       return;
     }
     if (date.length === 10) {
-      setFromFilterDate(date);
       setFilterParams({ fromFilterDate: e.target.value || undefined });
       scrollToTop();
-    } else if (date.length !== 10 && fromDate) {
-      setFromFilterDate(undefined);
     }
   }
 
@@ -136,11 +131,8 @@ const ReleaseNotesFilterDates = () => {
       return;
     }
     if (date.length === 10) {
-      setToFilterDate(date);
       setFilterParams({ toFilterDate: e.target.value || undefined });
       scrollToTop();
-    } else if (date.length !== 10 && toDate) {
-      setToFilterDate(undefined);
     }
   }
 };

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
@@ -50,16 +50,16 @@ const ClearAll = styled.button`
 
 const ReleaseNotesFilterDates = () => {
   const [filterParams, setFilterParams] = useReleaseNotesFilterParams();
+  const [fromDate, setFromFilterDate] = useState();
+  const [toDate, setToFilterDate] = useState();
   const maximumDate = IsoDateFormat.format(new Date());
 
   useEffect(() => {
     if (filterParams.fromFilterDate) {
-      document.getElementById('from-filter-date').value =
-        filterParams.fromFilterDate;
+      setFromFilterDate(filterParams.fromFilterDate);
     }
     if (filterParams.toFilterDate) {
-      document.getElementById('to-filter-date').value =
-        filterParams.fromFilterDate;
+      setToFilterDate(filterParams.toFilterDate);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -80,7 +80,9 @@ const ReleaseNotesFilterDates = () => {
             type="date"
             id="from-filter-date"
             max={maximumDate}
+            value={fromDate}
             onChange={handleOnFromFilterDateChange}
+            onBlur={(e) => handleOnBlur(e, 'from')}
           />
         </div>
       </SpacingsStack>
@@ -92,7 +94,9 @@ const ReleaseNotesFilterDates = () => {
             type="date"
             id="to-filter-date"
             max={maximumDate}
+            value={toDate}
             onChange={handleOnToFilterDateChange}
+            onBlur={(e) => handleOnBlur(e, 'to')}
           />
         </div>
       </SpacingsStack>
@@ -105,9 +109,9 @@ const ReleaseNotesFilterDates = () => {
       toFilterDate: undefined,
       filterTopics: [],
     });
-    document.getElementById('from-filter-date').value = '';
-    document.getElementById('to-filter-date').value = '';
-    scrollToTop();
+    setFromFilterDate('');
+    setToFilterDate('');
+    setFilterParams({ fromFilterDate: undefined, toFilterDate: undefined });
   }
 
   function handleOnFromFilterDateChange(e) {
@@ -118,8 +122,9 @@ const ReleaseNotesFilterDates = () => {
       return;
     }
     if (date.length === 10) {
-      setFilterParams({ fromFilterDate: e.target.value || undefined });
-      scrollToTop();
+      setFromFilterDate(date);
+    } else if (date.length !== 10 && fromDate) {
+      setFromFilterDate(undefined);
     }
   }
 
@@ -131,9 +136,20 @@ const ReleaseNotesFilterDates = () => {
       return;
     }
     if (date.length === 10) {
-      setFilterParams({ toFilterDate: e.target.value || undefined });
-      scrollToTop();
+      setToFilterDate(date);
+    } else if (date.length !== 10 && fromDate) {
+      setToFilterDate(undefined);
     }
+  }
+
+  function handleOnBlur(event, field) {
+    event.stopPropagation();
+    if (field === 'from') {
+      setFilterParams({ fromFilterDate: fromDate || undefined });
+    } else {
+      setFilterParams({ toFilterDate: toDate || undefined });
+    }
+    scrollToTop();
   }
 };
 

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -66,12 +66,12 @@ const ReleaseNotesFilterDates = () => {
 
   return (
     <SpacingsStack scale="s">
-      <SpacingsInline alignItems="center" justifyContent="space-between">
-        <FilterTitle>Filter by date</FilterTitle>
+      <SpacingsInline alignItems="center">
         <ClearAll onClick={handleOnClearAll} aria-label="Clear all">
           Clear all
         </ClearAll>
       </SpacingsInline>
+      <FilterTitle>Filter by date</FilterTitle>
 
       <SpacingsStack scale="xs">
         <DateLabel htmlFor="from-filter-date">From</DateLabel>

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -49,6 +49,7 @@ const ReleaseNotesFilterDates = () => {
             id="from-filter-date"
             max={maximumDate}
             value={filterParams.fromFilterDate || ''}
+            onClick={handleClick}
             onChange={handleOnFromFilterDateChange}
           />
         </div>
@@ -68,6 +69,12 @@ const ReleaseNotesFilterDates = () => {
       </SpacingsStack>
     </SpacingsStack>
   );
+
+  function handleClick(e) {
+    if ('showPicker' in HTMLInputElement.prototype) {
+      document.getElementById(e.target.id).showPicker();
+    }
+  }
 
   function handleOnFromFilterDateChange(e) {
     setFilterParams({ fromFilterDate: e.target.value || undefined });

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-dates.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { designSystem, IsoDateFormat } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
@@ -50,6 +50,8 @@ const ClearAll = styled.button`
 
 const ReleaseNotesFilterDates = () => {
   const [, setFilterParams] = useReleaseNotesFilterParams();
+  const [fromDate, setFromFilterDate] = useState();
+  const [toDate, setToFilterDate] = useState();
   const maximumDate = IsoDateFormat.format(new Date());
 
   return (
@@ -68,6 +70,7 @@ const ReleaseNotesFilterDates = () => {
             type="date"
             id="from-filter-date"
             max={maximumDate}
+            value={fromDate}
             onChange={handleOnFromFilterDateChange}
           />
         </div>
@@ -80,6 +83,7 @@ const ReleaseNotesFilterDates = () => {
             type="date"
             id="to-filter-date"
             max={maximumDate}
+            value={toDate}
             onChange={handleOnToFilterDateChange}
           />
         </div>
@@ -93,12 +97,15 @@ const ReleaseNotesFilterDates = () => {
       toFilterDate: undefined,
       filterTopics: [],
     });
+    setFromFilterDate(undefined);
+    setToFilterDate(undefined);
     scrollToTop();
   }
 
   function handleOnFromFilterDateChange(e) {
     const date = IsoDateFormat.format(new Date(e.target.value));
     if (date.length === 10) {
+      setFromFilterDate(date);
       setFilterParams({ fromFilterDate: e.target.value || undefined });
       scrollToTop();
     }
@@ -107,6 +114,7 @@ const ReleaseNotesFilterDates = () => {
   function handleOnToFilterDateChange(e) {
     const date = IsoDateFormat.format(new Date(e.target.value));
     if (date.length === 10) {
+      setToFilterDate(date);
       setFilterParams({ toFilterDate: e.target.value || undefined });
       scrollToTop();
     }

--- a/packages/gatsby-theme-docs/src/components/release-notes-filter-topics.js
+++ b/packages/gatsby-theme-docs/src/components/release-notes-filter-topics.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
-import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import CheckboxInput from '@commercetools-uikit/checkbox-input';
 import { designSystem } from '@commercetools-docs/ui-kit';
 import useReleaseNotesFilterParams from '../hooks/use-release-notes-filter-params';
@@ -13,19 +12,6 @@ const Container = styled.div`
   border-top: 1px solid ${designSystem.colors.light.borderInput};
   padding: ${designSystem.dimensions.spacings.m} 0;
 `;
-const ClearAll = styled.button`
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  color: ${designSystem.colors.light.link};
-  font-size: ${designSystem.typography.fontSizes.extraSmall};
-  text-decoration: none;
-  background-color: transparent;
-
-  :hover {
-    color: ${designSystem.colors.light.linkHover};
-  }
-`;
 
 const ReleaseNotesFilterTopics = () => {
   const [filterParams, setFilterParams] = useReleaseNotesFilterParams();
@@ -36,12 +22,7 @@ const ReleaseNotesFilterTopics = () => {
   return (
     <Container>
       <SpacingsStack>
-        <SpacingsInline alignItems="center" justifyContent="space-between">
-          <FilterTitle>Filter by topics</FilterTitle>
-          <ClearAll onClick={handleOnClearAll} aria-label="Clear all">
-            Clear all
-          </ClearAll>
-        </SpacingsInline>
+        <FilterTitle>Filter by topics</FilterTitle>
         <SpacingsStack scale="s">
           {allTopics.map((topic) => (
             <div key={topic.name}>
@@ -58,11 +39,6 @@ const ReleaseNotesFilterTopics = () => {
       </SpacingsStack>
     </Container>
   );
-
-  function handleOnClearAll() {
-    setFilterParams({ filterTopics: [] });
-    scrollToTop();
-  }
 
   function handleOnTopicChange(e) {
     const isChecked = e.target.checked;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,7 +2085,6 @@ __metadata:
     "@commercetools-docs/ui-kit": 19.7.0
     "@commercetools-uikit/card": ^15.3.0
     "@commercetools-uikit/checkbox-input": ^15.3.0
-    "@commercetools-uikit/date-input": ^15.3.0
     "@commercetools-uikit/design-system": ^15.3.0
     "@commercetools-uikit/icon-button": ^15.3.0
     "@commercetools-uikit/icons": ^15.3.0
@@ -2415,47 +2414,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@commercetools-uikit/calendar-time-utils@npm:15.3.0":
-  version: 15.3.0
-  resolution: "@commercetools-uikit/calendar-time-utils@npm:15.3.0"
-  dependencies:
-    "@babel/runtime": ^7.19.0
-    "@babel/runtime-corejs3": ^7.19.1
-    "@commercetools-uikit/utils": 15.3.0
-  peerDependencies:
-    moment-timezone: 0.5.x
-  checksum: 65694cec81464f30a41e6b8130d0bb1f469d246a436105cd074366d3b41eef27a11935dc7f6ff3c4434095f602348bfb422e9adad03514b03e5e9653170bdd07
-  languageName: node
-  linkType: hard
-
-"@commercetools-uikit/calendar-utils@npm:15.3.0":
-  version: 15.3.0
-  resolution: "@commercetools-uikit/calendar-utils@npm:15.3.0"
-  dependencies:
-    "@babel/runtime": ^7.19.0
-    "@babel/runtime-corejs3": ^7.19.1
-    "@commercetools-uikit/accessible-button": 15.3.0
-    "@commercetools-uikit/design-system": 15.3.0
-    "@commercetools-uikit/hooks": 15.3.0
-    "@commercetools-uikit/icons": 15.3.0
-    "@commercetools-uikit/input-utils": 15.3.0
-    "@commercetools-uikit/secondary-icon-button": 15.3.0
-    "@commercetools-uikit/spacings-inline": 15.3.0
-    "@commercetools-uikit/text": 15.3.0
-    "@commercetools-uikit/tooltip": 15.3.0
-    "@commercetools-uikit/utils": 15.3.0
-    "@emotion/react": ^11.4.0
-    "@emotion/styled": ^11.3.0
-    prop-types: 15.8.1
-    react-select: 5.4.0
-  peerDependencies:
-    moment: 2.x
-    react: 17.x
-    react-intl: 5.x
-  checksum: 5b19e70f59f2369b8eda43a128863d0f25d86b414c96347ee4e4740b1be78810c350a4a8d69252ecd00319ec44e8c372aeab0009ee6c1c9669880e4c0e4bdfff
-  languageName: node
-  linkType: hard
-
 "@commercetools-uikit/card@npm:^15.3.0":
   version: 15.3.0
   resolution: "@commercetools-uikit/card@npm:15.3.0"
@@ -2510,39 +2468,6 @@ __metadata:
   peerDependencies:
     react: 17.x
   checksum: fe086a951e49c8eda8e64fe1814f0e3a1e08a6ce24315d732c8db3ac29859927d4c6ddc73e2a10b8147ac7c9a21df8b9bdde87eb5657b74326303b4af2fc5de4
-  languageName: node
-  linkType: hard
-
-"@commercetools-uikit/date-input@npm:^15.3.0":
-  version: 15.3.0
-  resolution: "@commercetools-uikit/date-input@npm:15.3.0"
-  dependencies:
-    "@babel/runtime": ^7.19.0
-    "@babel/runtime-corejs3": ^7.19.1
-    "@commercetools-uikit/accessible-button": 15.3.0
-    "@commercetools-uikit/calendar-time-utils": 15.3.0
-    "@commercetools-uikit/calendar-utils": 15.3.0
-    "@commercetools-uikit/constraints": 15.3.0
-    "@commercetools-uikit/design-system": 15.3.0
-    "@commercetools-uikit/hooks": 15.3.0
-    "@commercetools-uikit/icons": 15.3.0
-    "@commercetools-uikit/secondary-icon-button": 15.3.0
-    "@commercetools-uikit/select-utils": 15.3.0
-    "@commercetools-uikit/spacings-inline": 15.3.0
-    "@commercetools-uikit/text": 15.3.0
-    "@commercetools-uikit/tooltip": 15.3.0
-    "@commercetools-uikit/utils": 15.3.0
-    "@emotion/react": ^11.4.0
-    "@emotion/styled": ^11.3.0
-    downshift: 6.1.11
-    prop-types: 15.8.1
-    react-is: 17.0.2
-    warning: 4.0.3
-  peerDependencies:
-    moment: 2.x
-    react: 17.x
-    react-intl: 5.x
-  checksum: ccbe11045d9584bb38d1aa62af4b258a0c9f5b7e23d703aa1f0b9b9c45e53a88551c2c927e1f26802c528358567046692bf1333b30fb403c1d0231391e3e2b77
   languageName: node
   linkType: hard
 
@@ -2763,7 +2688,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@commercetools-uikit/secondary-icon-button@npm:15.3.0, @commercetools-uikit/secondary-icon-button@npm:^15.3.0":
+"@commercetools-uikit/secondary-icon-button@npm:^15.3.0":
   version: 15.3.0
   resolution: "@commercetools-uikit/secondary-icon-button@npm:15.3.0"
   dependencies:
@@ -2923,7 +2848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@commercetools-uikit/tooltip@npm:15.3.0, @commercetools-uikit/tooltip@npm:^15.3.0":
+"@commercetools-uikit/tooltip@npm:^15.3.0":
   version: 15.3.0
   resolution: "@commercetools-uikit/tooltip@npm:15.3.0"
   dependencies:
@@ -12240,21 +12165,6 @@ __metadata:
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 38e902c80b0666ab59e9310a3d24ed237029a7ce34d976796349765ac96b8d769f6df19090f1f471b77a25ca391971efde8a1ea63bb83111bd8bec8e5cc9b2cd
-  languageName: node
-  linkType: hard
-
-"downshift@npm:6.1.11":
-  version: 6.1.11
-  resolution: "downshift@npm:6.1.11"
-  dependencies:
-    "@babel/runtime": ^7.14.8
-    compute-scroll-into-view: ^1.0.17
-    prop-types: ^15.7.2
-    react-is: ^17.0.2
-    tslib: ^2.3.0
-  peerDependencies:
-    react: ">=16.12.0"
-  checksum: 96d58ddcaf19cf41bb11e8d6f8e78db9eca1eca6e4dd2c6a43204283d4f442f37f445769443869698ad4d45db3926987ff39a95dbe785283f236088f53c08592
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow up from the discussion here:
https://github.com/commercetools/commercetools-docs-kit/pull/1423

will close #1382 

This pull request replaces the date-input filter from the ui-kit with a new custom native html date picker.

Preview deeplink:  https://docskit-pr-1446.commercetools.vercel.app/docs-smoke-test/releases