### PR TITLE
[feats] Enhancements for the request body

### DIFF
--- a/.changeset/new-apricots-sip.md
+++ b/.changeset/new-apricots-sip.md
@@ -3,4 +3,4 @@
 '@commercetools-docs/gatsby-transformer-raml': minor
 ---
 
-Enhancements for the request and response bodies: the content type is now displayed next to the request "body" title, request and response bodies were adjusted to support images, and descriptions inside of the response body are now displayed next to the response code.
+Enhancements for the request and response bodies: the content type is now displayed in the request and response body, the two bodies were adjusted to support images, and descriptions inside of the response body are now displayed next to the response code.

--- a/.changeset/new-apricots-sip.md
+++ b/.changeset/new-apricots-sip.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-api-docs': minor
+'@commercetools-docs/gatsby-transformer-raml': minor
+---
+
+Enhancements for the request and response bodies: the content type is now displayed next to the request "body" title, request and response bodies were adjusted to support images, and descriptions inside of the response body are now displayed next to the response code.

--- a/api-specs/test/api.raml
+++ b/api-specs/test/api.raml
@@ -443,6 +443,38 @@ uses:
               example: !include examples/product-example.json
               type: any
 
+    /namespace-action:
+      uriParameters:
+        namespace:
+          displayName: Namespace
+          type: string
+          description: Namespace
+        action:
+          displayName: Action
+          type: string
+          description: Action
+      get:
+        description: Use the GET method to allow the frontend to fetch data asynchronously.
+        responses:
+          200:
+            description: We recommend to use standard HTTP response codes and `application/json` encoded content.
+      post:
+        description: Use the POST method to write data to a backend system.
+        responses:
+          200:
+            description: We recommend to use standard HTTP response codes and `application/json` encoded content.
+
+    /namespace-action-with-example:
+      get:
+        description: Use the GET method to allow the frontend to fetch data asynchronously. The example fetches a cart.
+        responses:
+          200:
+            description: We recommend to use standard HTTP response codes and `application/json` encoded content. The response will look like the response you have declared in your action. As an example we will fetch the cart.
+            body:
+              application/json:
+                type: object
+                example: !include examples/action-success.json
+
 
 #   /resourceWithHeaders:
 #    description: Tests use of specific headers.

--- a/api-specs/test/api.raml
+++ b/api-specs/test/api.raml
@@ -411,5 +411,38 @@ uses:
             description: Should display 5th (7th in RAML)
             example: true
 
+    /images:
+      post:
+        displayName: Upload a product image
+        queryParameters:
+          filename?:
+            type: string
+          variant?:
+            type: number
+            format: int64
+          sku?:
+            type: string
+          staged?:
+            type: boolean
+        description: |
+          Uploads a binary image file to a given product variant. The supported image formats are JPEG, PNG and GIF.
+        securedBy: [oauth_2_0: { scopes: ['manage_products:{projectKey}'] }]
+        body:
+          image/jpeg:
+            type: file
+          image/png:
+            type: file
+          image/gif:
+            type: file
+        headers:
+          Content-Type:
+            enum: ['image/jpeg', 'image/png', 'image/gif']
+        responses:
+          200:
+            body:
+              example: !include examples/product-example.json
+              type: any
+
+
 #   /resourceWithHeaders:
 #    description: Tests use of specific headers.

--- a/api-specs/test/examples/action-success.json
+++ b/api-specs/test/examples/action-success.json
@@ -1,0 +1,81 @@
+{
+  "cartId": "534a5f86-ea14-4b54-b2da-62a0672707e1",
+  "cartVersion": "15",
+  "lineItems": [
+    {
+      "lineItemId": "d41690bc-ea20-4254-b10b-8dxeac87c1b0",
+      "productId": "6bgggaf4-c2b8-4ba7-945e-95e2a113a41f",
+      "name": "Casual jacket",
+      "type": "variant",
+      "count": 1,
+      "price": {
+        "fractionDigits": 2,
+        "centAmount": 39900,
+        "currencyCode": "EUR"
+      },
+      "discountTexts": [],
+      "discounts": [],
+      "totalPrice": {
+        "fractionDigits": 2,
+        "centAmount": 39900,
+        "currencyCode": "EUR"
+      },
+      "variant": {
+        "id": "1",
+        "sku": "M0E200KJ1200DSDJ",
+        "images": ["https://your-storage.com/images/casual_jacket.jpg"],
+        "groupId": "78d95",
+        "attributes": {
+          "articleNumberManufacturer": "621840423 V0065",
+          "articleNumberMax": "78665",
+          "matrixId": "M0E200KJ1200DSDJ",
+          "baseId": "78665",
+          "designer": {
+            "key": "casual",
+            "label": "casual"
+          },
+          "madeInItaly": {
+            "key": "no",
+            "label": "no"
+          },
+          "commonSize": {
+            "key": "xxs",
+            "label": "XXS"
+          },
+          "size": "XXS",
+          "color": {
+            "key": "black",
+            "label": "Black"
+          },
+          "colorFreeDefinition": "black",
+          "style": {
+            "key": "sporty",
+            "label": "sporty"
+          },
+          "gender": {
+            "key": "men",
+            "label": "Men"
+          },
+          "season": "S15"
+        },
+        "price": {
+          "fractionDigits": 2,
+          "centAmount": 39900,
+          "currencyCode": "EUR"
+        },
+        "isOnStock": true
+      },
+      "isGift": false,
+      "_url": "/slug/p/M0E200KJ1200DSDJ"
+    }
+  ],
+  "sum": {
+    "fractionDigits": 2,
+    "centAmount": 39900,
+    "currencyCode": "EUR"
+  },
+  "shippingAddress": {},
+  "billingAddress": {},
+  "payments": [],
+  "discountCodes": []
+}

--- a/api-specs/test/examples/product-example.json
+++ b/api-specs/test/examples/product-example.json
@@ -1,0 +1,106 @@
+{
+  "id": "e7ba4c75-b1bb-483d-94d8-2c4a10f78472",
+  "version": 2,
+  "masterData": {
+    "current": {
+      "categories": [
+        {
+          "id": "cf6d790a-f027-4f46-9a2b-4bc9a31066fb",
+          "typeId": "category"
+        }
+      ],
+      "description": {
+        "en": "Sample description"
+      },
+      "masterVariant": {
+        "attributes": [],
+        "id": 1,
+        "images": [
+          {
+            "dimensions": {
+              "h": 1400,
+              "w": 1400
+            },
+            "url": "https://commercetools.com/cli/data/253245821_1.jpg"
+          }
+        ],
+        "prices": [
+          {
+            "value": {
+              "type": "centPrecision",
+              "fractionDigits": 2,
+              "centAmount": 10000,
+              "currencyCode": "EUR"
+            },
+            "id": "753472a3-ddff-4e0f-a93b-2eb29c90ba54"
+          }
+        ],
+        "sku": "sku_MB_PREMIUM_TECH_T_variant1_1369226795424"
+      },
+      "name": {
+        "en": "MB PREMIUM TECH T"
+      },
+      "slug": {
+        "en": "mb-premium-tech-t1369226795424"
+      },
+      "variants": [],
+      "searchKeywords": {}
+    },
+    "hasStagedChanges": false,
+    "published": true,
+    "staged": {
+      "categories": [
+        {
+          "id": "cf6d790a-f027-4f46-9a2b-4bc9a31066fb",
+          "typeId": "category"
+        }
+      ],
+      "description": {
+        "en": "Sample description"
+      },
+      "masterVariant": {
+        "attributes": [],
+        "id": 1,
+        "images": [
+          {
+            "dimensions": {
+              "h": 1400,
+              "w": 1400
+            },
+            "url": "https://commercetools.com/cli/data/253245821_1.jpg"
+          }
+        ],
+        "prices": [
+          {
+            "value": {
+              "type": "centPrecision",
+              "fractionDigits": 2,
+              "centAmount": 10000,
+              "currencyCode": "EUR"
+            },
+            "id": "753472a3-ddff-4e0f-a93b-2eb29c90ba54"
+          }
+        ],
+        "sku": "sku_MB_PREMIUM_TECH_T_variant1_1369226795424"
+      },
+      "name": {
+        "en": "MB PREMIUM TECH T"
+      },
+      "slug": {
+        "en": "mb-premium-tech-t1369226795424"
+      },
+      "variants": [],
+      "searchKeywords": {}
+    }
+  },
+  "productType": {
+    "id": "24f510c3-f334-4099-94e2-d6224a8eb919",
+    "typeId": "product-type"
+  },
+  "taxCategory": {
+    "id": "f1e10e3a-45eb-49d8-ad0b-fdf984202f59",
+    "typeId": "tax-category"
+  },
+  "createdAt": "1970-01-01T00:00:00.001Z",
+  "lastModifiedAt": "1970-01-01T00:00:00.001Z"
+}

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/highlights.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/highlights.js
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+import { designSystem } from '@commercetools-docs/ui-kit';
+
+export default styled.code`
+  display: inline-block;
+  color: ${designSystem.colors.light.textCode};
+  white-space: nowrap;
+`;

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
@@ -33,6 +33,23 @@ const Container = styled.div`
 
 const TitleWithAnchor = Markdown.withCopyToClipboard(Title);
 
+function convertContentType(type) {
+  switch (type) {
+    case 'applicationjson':
+      return 'application/json';
+    case 'applicationxwwwformurlencoded':
+      return 'application/x-www-form-urlencoded';
+    case 'imagejpeg':
+      return 'image/jpeg';
+    case 'imagepng':
+      return 'image/png';
+    case 'imagegif':
+      return 'image/gif';
+    default:
+      return '';
+  }
+}
+
 const Method = ({
   apiKey,
   uris,
@@ -49,6 +66,26 @@ const Method = ({
   if (method.uriParameters) {
     allUriParameters = allUriParameters.concat(method.uriParameters);
   }
+
+  let contentType;
+  if (method.body) {
+    const findOutContentTypes = Object.keys(method.body).reduce(
+      (list, value) => {
+        return method.body[value] !== null ? [...list, value] : [...list];
+      },
+      []
+    );
+    findOutContentTypes.forEach((type) => {
+      if (!contentType) {
+        contentType = convertContentType(type);
+      } else {
+        contentType = `${contentType} ${convertContentType(type)}`;
+      }
+    });
+  }
+
+  const isImage = contentType ? contentType.includes('image') : false;
+
   const methodColor = computeMethodColor(methodType.toLowerCase());
 
   const id = generateEndpointURN({
@@ -108,18 +145,22 @@ const Method = ({
                     method.body.applicationjson?.type ||
                     method.body.applicationxwwwformurlencoded?.type
                   }
+                  isImage={isImage}
+                  contentType={contentType}
                 />
               )}
 
-              {method.responses && (
+              {!isImage && method.responses && (
                 <Responses apiKey={apiKey} responses={method.responses} />
               )}
             </SpacingsStack>
-            <RequestResponseExamples
-              apiKey={apiKey}
-              requestCodeExamples={method.codeExamples}
-              responses={method.responses}
-            />
+            {!isImage && (
+              <RequestResponseExamples
+                apiKey={apiKey}
+                requestCodeExamples={method.codeExamples}
+                responses={method.responses}
+              />
+            )}
           </SideBySide>
         </Container>
       </SpacingsStack>

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
@@ -79,7 +79,7 @@ const Method = ({
       if (!contentType) {
         contentType = convertContentType(type);
       } else {
-        contentType = `${contentType} ${convertContentType(type)}`;
+        contentType = `${contentType} or ${convertContentType(type)}`;
       }
     });
   }

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
@@ -149,7 +149,11 @@ const Method = ({
               )}
 
               {(!method.body || isStructuredDataType) && method.responses && (
-                <Responses apiKey={apiKey} responses={method.responses} />
+                <Responses
+                  apiKey={apiKey}
+                  responses={method.responses}
+                  contentType={contentType}
+                />
               )}
             </SpacingsStack>
             {(!method.body || isStructuredDataType) && (

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
@@ -67,7 +67,7 @@ const Method = ({
     allUriParameters = allUriParameters.concat(method.uriParameters);
   }
 
-  let contentType;
+  const contentType = [];
   if (method.body) {
     const findOutContentTypes = Object.keys(method.body).reduce(
       (list, value) => {
@@ -76,17 +76,13 @@ const Method = ({
       []
     );
     findOutContentTypes.forEach((type) => {
-      if (!contentType) {
-        contentType = convertContentType(type);
-      } else {
-        contentType = `${contentType} or ${convertContentType(type)}`;
-      }
+      contentType.push(convertContentType(type));
     });
   }
 
-  const isStructuredDataType = contentType
-    ? contentType.includes('application')
-    : false;
+  const isStructuredDataType =
+    contentType.includes('application/json') ||
+    contentType.includes('application/x-www-form-urlencoded');
 
   const methodColor = computeMethodColor(methodType.toLowerCase());
 

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
@@ -84,7 +84,9 @@ const Method = ({
     });
   }
 
-  const isImage = contentType ? contentType.includes('image') : false;
+  const isStructuredDataType = contentType
+    ? contentType.includes('application')
+    : false;
 
   const methodColor = computeMethodColor(methodType.toLowerCase());
 
@@ -145,16 +147,16 @@ const Method = ({
                     method.body.applicationjson?.type ||
                     method.body.applicationxwwwformurlencoded?.type
                   }
-                  isImage={isImage}
+                  isStructuredDataType={isStructuredDataType}
                   contentType={contentType}
                 />
               )}
 
-              {!isImage && method.responses && (
+              {isStructuredDataType && method.responses && (
                 <Responses apiKey={apiKey} responses={method.responses} />
               )}
             </SpacingsStack>
-            {!isImage && (
+            {isStructuredDataType && (
               <RequestResponseExamples
                 apiKey={apiKey}
                 requestCodeExamples={method.codeExamples}

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/method.js
@@ -152,11 +152,11 @@ const Method = ({
                 />
               )}
 
-              {isStructuredDataType && method.responses && (
+              {(!method.body || isStructuredDataType) && method.responses && (
                 <Responses apiKey={apiKey} responses={method.responses} />
               )}
             </SpacingsStack>
-            {isStructuredDataType && (
+            {(!method.body || isStructuredDataType) && (
               <RequestResponseExamples
                 apiKey={apiKey}
                 requestCodeExamples={method.codeExamples}

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
+import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import {
   useTypeLocations,
   locationForType,
@@ -8,6 +9,7 @@ import {
 import renderTypeAsLink from '../../../utils/render-type-as-link';
 import ApiTypeByKey from '../../type/type-by-api-key';
 import Title from './title';
+import ContentType from './highlights';
 
 const RequestRepresentation = (props) => {
   const typeLocations = useTypeLocations();
@@ -19,8 +21,13 @@ const RequestRepresentation = (props) => {
 
   return (
     <SpacingsStack scale="xs">
-      <Title>Request Body:</Title>
-      {requestRepresentationLocation ? (
+      <SpacingsInline scale="xs">
+        <Title>Request Body:</Title>
+        <ContentType>{props.contentType}</ContentType>
+      </SpacingsInline>
+      {props.isImage ? (
+        <Title>The file to upload</Title>
+      ) : requestRepresentationLocation ? (
         renderTypeAsLink(props.apiKey, props.apiType, typeLocations)
       ) : (
         <ApiTypeByKey
@@ -35,7 +42,9 @@ const RequestRepresentation = (props) => {
 
 RequestRepresentation.propTypes = {
   apiKey: PropTypes.string.isRequired,
-  apiType: PropTypes.string.isRequired,
+  apiType: PropTypes.string,
+  isImage: PropTypes.bool.isRequired,
+  contentType: PropTypes.string.isRequired,
 };
 
 export default RequestRepresentation;

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
@@ -1,15 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
-import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import {
   useTypeLocations,
   locationForType,
 } from '../../../hooks/use-type-locations';
+import { dimensions } from '../../../design-system';
 import renderTypeAsLink from '../../../utils/render-type-as-link';
 import ApiTypeByKey from '../../type/type-by-api-key';
 import Title from './title';
 import ContentType from './highlights';
+
+const BodyTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  span:first-of-type {
+    padding-right: ${dimensions.spacings.l};
+  }
+`;
 
 const RequestRepresentation = (props) => {
   const typeLocations = useTypeLocations();
@@ -21,10 +30,10 @@ const RequestRepresentation = (props) => {
 
   return (
     <SpacingsStack scale="xs">
-      <SpacingsInline scale="xs">
+      <BodyTitleContainer>
         <Title>Request Body:</Title>
         <ContentType>{props.contentType}</ContentType>
-      </SpacingsInline>
+      </BodyTitleContainer>
       {props.isImage ? (
         <Title>The file to upload</Title>
       ) : requestRepresentationLocation ? (

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
+import { designSystem } from '@commercetools-docs/ui-kit';
 import {
   useTypeLocations,
   locationForType,
@@ -25,7 +26,7 @@ const RequestRepresentation = (props) => {
     align-items: center;
     flex-direction: row;
     span {
-      margin-right: 8px;
+      margin-right: ${designSystem.dimensions.spacings.s};
     }
   `;
 

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
@@ -34,7 +34,7 @@ const RequestRepresentation = (props) => {
         <Title>Request Body:</Title>
         <ContentType>{props.contentType}</ContentType>
       </BodyTitleContainer>
-      {props.isImage ? (
+      {!props.isStructuredDataType ? (
         <Title>The file to upload</Title>
       ) : requestRepresentationLocation ? (
         renderTypeAsLink(props.apiKey, props.apiType, typeLocations)
@@ -52,7 +52,7 @@ const RequestRepresentation = (props) => {
 RequestRepresentation.propTypes = {
   apiKey: PropTypes.string.isRequired,
   apiType: PropTypes.string,
-  isImage: PropTypes.bool.isRequired,
+  isStructuredDataType: PropTypes.bool.isRequired,
   contentType: PropTypes.string.isRequired,
 };
 

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
-import SpacingsInlie from '@commercetools-uikit/spacings-inline';
+import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import {
   useTypeLocations,
   locationForType,
@@ -23,7 +23,7 @@ const RequestRepresentation = (props) => {
     <SpacingsStack scale="xs">
       <Title>Request Body:</Title>
       {!props.isStructuredDataType ? (
-        <SpacingsInlie>
+        <SpacingsInline alignItems="center">
           {props.contentType.map((type, index) => {
             if (index === 0) {
               return <ContentType key={index}>{type}</ContentType>;
@@ -36,13 +36,13 @@ const RequestRepresentation = (props) => {
             );
           })}
           <span>The file to upload.</span>
-        </SpacingsInlie>
+        </SpacingsInline>
       ) : requestRepresentationLocation ? (
-        <SpacingsInlie>
+        <SpacingsInline alignItems="center">
           {renderTypeAsLink(props.apiKey, props.apiType, typeLocations)}
           <span>as</span>
           <ContentType>{props.contentType}</ContentType>
-        </SpacingsInlie>
+        </SpacingsInline>
       ) : (
         <SpacingsStack>
           <ContentType>{props.contentType}</ContentType>

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import {
@@ -19,23 +20,30 @@ const RequestRepresentation = (props) => {
     typeLocations
   );
 
+  const ContentTypeRow = styled.div`
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    span {
+      margin-right: 8px;
+    }
+  `;
+
   return (
     <SpacingsStack scale="xs">
       <Title>Request Body:</Title>
       {!props.isStructuredDataType ? (
         <SpacingsInline alignItems="center">
           {props.contentType.map((type, index) => {
-            if (index === 0) {
-              return <ContentType key={index}>{type}</ContentType>;
-            }
             return (
-              <>
-                <span>or</span>
-                <ContentType key={index}>{type}</ContentType>
-              </>
+              <ContentTypeRow key={index}>
+                {index !== 0 && <span>or</span>}
+                <ContentType>{type}</ContentType>
+                {index === props.contentType.length - 1 && <p>.</p>}
+              </ContentTypeRow>
             );
           })}
-          <span>The file to upload.</span>
+          <span>The file to upload</span>
         </SpacingsInline>
       ) : requestRepresentationLocation ? (
         <SpacingsInline alignItems="center">

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/request-representation.js
@@ -1,24 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
+import SpacingsInlie from '@commercetools-uikit/spacings-inline';
 import {
   useTypeLocations,
   locationForType,
 } from '../../../hooks/use-type-locations';
-import { dimensions } from '../../../design-system';
 import renderTypeAsLink from '../../../utils/render-type-as-link';
 import ApiTypeByKey from '../../type/type-by-api-key';
 import Title from './title';
 import ContentType from './highlights';
-
-const BodyTitleContainer = styled.div`
-  display: flex;
-  align-items: center;
-  span:first-of-type {
-    padding-right: ${dimensions.spacings.l};
-  }
-`;
 
 const RequestRepresentation = (props) => {
   const typeLocations = useTypeLocations();
@@ -30,20 +21,37 @@ const RequestRepresentation = (props) => {
 
   return (
     <SpacingsStack scale="xs">
-      <BodyTitleContainer>
-        <Title>Request Body:</Title>
-        <ContentType>{props.contentType}</ContentType>
-      </BodyTitleContainer>
+      <Title>Request Body:</Title>
       {!props.isStructuredDataType ? (
-        <Title>The file to upload</Title>
+        <SpacingsInlie>
+          {props.contentType.map((type, index) => {
+            if (index === 0) {
+              return <ContentType key={index}>{type}</ContentType>;
+            }
+            return (
+              <>
+                <span>or</span>
+                <ContentType key={index}>{type}</ContentType>
+              </>
+            );
+          })}
+          <span>The file to upload.</span>
+        </SpacingsInlie>
       ) : requestRepresentationLocation ? (
-        renderTypeAsLink(props.apiKey, props.apiType, typeLocations)
+        <SpacingsInlie>
+          {renderTypeAsLink(props.apiKey, props.apiType, typeLocations)}
+          <span>as</span>
+          <ContentType>{props.contentType}</ContentType>
+        </SpacingsInlie>
       ) : (
-        <ApiTypeByKey
-          apiKey={props.apiKey}
-          type={props.apiType}
-          doNotRenderExamples
-        />
+        <SpacingsStack>
+          <ContentType>{props.contentType}</ContentType>
+          <ApiTypeByKey
+            apiKey={props.apiKey}
+            type={props.apiType}
+            doNotRenderExamples
+          />
+        </SpacingsStack>
       )}
     </SpacingsStack>
   );
@@ -53,7 +61,7 @@ RequestRepresentation.propTypes = {
   apiKey: PropTypes.string.isRequired,
   apiType: PropTypes.string,
   isStructuredDataType: PropTypes.bool.isRequired,
-  contentType: PropTypes.string.isRequired,
+  contentType: PropTypes.array.isRequired,
 };
 
 export default RequestRepresentation;

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
@@ -42,9 +42,10 @@ const Responses = ({ apiKey, responses }) => {
                   ? renderTypeAsLink(
                       apiKey,
                       response.body.applicationjson.type,
-                      typeLocations
+                      typeLocations,
+                      response.description
                     )
-                  : 'No body is returned.'}
+                  : response.description || 'No body is returned.'}
               </LinkContainer>
             </p>
           );

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
@@ -36,7 +36,7 @@ const Responses = ({ apiKey, responses, contentType }) => {
       <SpacingsStack scale="s">
         {responses.map((response) => {
           return (
-            <SpacingsInline key={response.code}>
+            <SpacingsInline alignItems="center" key={response.code}>
               <ResponseCode
                 css={computeStatusCodeBackgroundColor(response.code)}
               >

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
@@ -4,9 +4,11 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { designSystem } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
+import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import { tokens, dimensions, typography } from '../../../design-system';
 import { useTypeLocations } from '../../../hooks/use-type-locations';
 import renderTypeAsLink from '../../../utils/render-type-as-link';
+import ContentType from './highlights';
 import Title from './title';
 
 const ResponseCode = styled.span`
@@ -22,7 +24,7 @@ const LinkContainer = styled.span`
   line-height: ${typography.lineHeights.responseBodyType};
 `;
 
-const Responses = ({ apiKey, responses }) => {
+const Responses = ({ apiKey, responses, contentType }) => {
   const typeLocations = useTypeLocations();
 
   return (
@@ -31,23 +33,33 @@ const Responses = ({ apiKey, responses }) => {
       <SpacingsStack scale="s">
         {responses.map((response) => {
           return (
-            <p key={response.code}>
+            <SpacingsInline key={response.code}>
               <ResponseCode
                 css={computeStatusCodeBackgroundColor(response.code)}
               >
                 {response.code}
               </ResponseCode>
               <LinkContainer>
-                {response.body
-                  ? renderTypeAsLink(
+                {response.body ? (
+                  <SpacingsInline alignItems="center">
+                    {renderTypeAsLink(
                       apiKey,
                       response.body.applicationjson.type,
                       typeLocations,
                       response.description
-                    )
-                  : response.description || 'No body is returned.'}
+                    )}
+                    {contentType.length > 0 && (
+                      <>
+                        <span>as</span>
+                        <ContentType>{contentType}</ContentType>
+                      </>
+                    )}
+                  </SpacingsInline>
+                ) : (
+                  response.description || 'No body is returned.'
+                )}
               </LinkContainer>
-            </p>
+            </SpacingsInline>
           );
         })}
       </SpacingsStack>
@@ -83,6 +95,7 @@ Responses.propTypes = {
       body: PropTypes.object,
     })
   ).isRequired,
+  contentType: PropTypes.array.isRequired,
 };
 
 export default Responses;

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { designSystem } from '@commercetools-docs/ui-kit';
+import {
+  designSystem,
+  markdownFragmentToReact,
+} from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import { tokens, dimensions, typography } from '../../../design-system';
@@ -56,7 +59,8 @@ const Responses = ({ apiKey, responses, contentType }) => {
                     )}
                   </SpacingsInline>
                 ) : (
-                  response.description || 'No body is returned.'
+                  markdownFragmentToReact(response.description) ||
+                  'No body is returned.'
                 )}
               </LinkContainer>
             </SpacingsInline>

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/responses.js
@@ -17,6 +17,7 @@ import Title from './title';
 const ResponseCode = styled.span`
   font-size: ${designSystem.typography.fontSizes.extraSmall};
   color: ${designSystem.colors.light.surfacePrimary};
+  margin-top: ${dimensions.spacings.xxs};
   padding: ${dimensions.spacings.xxs} ${designSystem.dimensions.spacings.s};
   border-radius: ${tokens.borderRadiusForResponseCode};
   line-height: ${typography.lineHeights.responseCode};
@@ -36,7 +37,7 @@ const Responses = ({ apiKey, responses, contentType }) => {
       <SpacingsStack scale="s">
         {responses.map((response) => {
           return (
-            <SpacingsInline alignItems="center" key={response.code}>
+            <SpacingsInline key={response.code}>
               <ResponseCode
                 css={computeStatusCodeBackgroundColor(response.code)}
               >

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.js
@@ -1,15 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
-import { designSystem } from '@commercetools-docs/ui-kit';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
+import Scope from './highlights';
 import Title from './title';
-
-const Scope = styled.code`
-  display: inline-block;
-  color: ${designSystem.colors.light.textCode};
-  white-space: nowrap;
-`;
 
 const Scopes = (props) => {
   return (

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/title.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/title.js
@@ -1,11 +1,8 @@
 import styled from '@emotion/styled';
-import { typography, dimensions } from '../../../design-system';
+import { typography } from '../../../design-system';
 
 export default styled.span`
   font-size: ${typography.fontSizes.h5};
   font-weight: ${typography.fontWeights.regular};
   white-space: nowrap;
-  @media screen and (${dimensions.viewports.tablet}) {
-    min-width: 9rem;
-  }
 `;

--- a/packages/gatsby-theme-api-docs/src/hooks/use-api-resources.js
+++ b/packages/gatsby-theme-api-docs/src/hooks/use-api-resources.js
@@ -54,6 +54,18 @@ export const useApiResources = () => {
           type
           builtinType
         }
+        imagejpeg {
+          type
+          builtinType
+        }
+        imagepng {
+          type
+          builtinType
+        }
+        imagegif {
+          type
+          builtinType
+        }
       }
 
       fragment methodsWithBodies on RamlResourceMethodWithBody {

--- a/packages/gatsby-theme-api-docs/src/utils/render-type-as-link.js
+++ b/packages/gatsby-theme-api-docs/src/utils/render-type-as-link.js
@@ -2,13 +2,15 @@ import React from 'react';
 import { Link } from '@commercetools-docs/gatsby-theme-docs';
 import { locationForType } from '../hooks/use-type-locations';
 
-function renderTypeAsLink(apiKey, type, typeLocations) {
+function renderTypeAsLink(apiKey, type, typeLocations, description) {
   const typeLocation = locationForType(apiKey, type, typeLocations);
 
   const originalTypeLocation = typeLocation ? typeLocation.url : '';
 
   return originalTypeLocation ? (
     <Link href={originalTypeLocation}>{type}</Link>
+  ) : description ? (
+    description
   ) : (
     type
   );

--- a/packages/gatsby-theme-api-docs/src/utils/render-type-as-link.js
+++ b/packages/gatsby-theme-api-docs/src/utils/render-type-as-link.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from '@commercetools-docs/gatsby-theme-docs';
+import { markdownFragmentToReact } from '@commercetools-docs/ui-kit';
 import { locationForType } from '../hooks/use-type-locations';
 
 function renderTypeAsLink(apiKey, type, typeLocations, description) {
@@ -10,7 +11,7 @@ function renderTypeAsLink(apiKey, type, typeLocations, description) {
   return originalTypeLocation ? (
     <Link href={originalTypeLocation}>{type}</Link>
   ) : description ? (
-    description
+    markdownFragmentToReact(description)
   ) : (
     type
   );

--- a/packages/gatsby-transformer-raml/src/schema/define-raml-resource.js
+++ b/packages/gatsby-transformer-raml/src/schema/define-raml-resource.js
@@ -119,6 +119,9 @@ const defineRamlResource = ({ schema, createTypes }) => {
         applicationjson: 'RamlResourceMethodBodyApplicationJson',
         applicationxwwwformurlencoded:
           'RamlResourceMethodBodyApplicationxwwwformurlencoded',
+        imagejpeg: 'RamlResourceMethodBodyImageJpeg',
+        imagepng: 'RamlResourceMethodBodyImagePng',
+        imagegif: 'RamlResourceMethodBodyImageGif',
       },
     }),
 
@@ -137,6 +140,30 @@ const defineRamlResource = ({ schema, createTypes }) => {
         type: 'String!',
         builtinType: 'String!',
         examples: '[RamlExample!]',
+      },
+    }),
+
+    schema.buildObjectType({
+      name: 'RamlResourceMethodBodyImageJpeg',
+      fields: {
+        type: 'String!',
+        builtinType: 'String!',
+      },
+    }),
+
+    schema.buildObjectType({
+      name: 'RamlResourceMethodBodyImagePng',
+      fields: {
+        type: 'String!',
+        builtinType: 'String!',
+      },
+    }),
+
+    schema.buildObjectType({
+      name: 'RamlResourceMethodBodyImageGif',
+      fields: {
+        type: 'String!',
+        builtinType: 'String!',
       },
     }),
 

--- a/packages/gatsby-transformer-raml/src/utils/resource/do-recursion.js
+++ b/packages/gatsby-transformer-raml/src/utils/resource/do-recursion.js
@@ -6,6 +6,9 @@ const fieldsToClean = {
   '(builtinType)': true,
   'application/json': true,
   'application/x-www-form-urlencoded': true,
+  'image/jpeg': true,
+  'image/png': true,
+  'image/gif': true,
   '(codeExamples)': true,
 };
 

--- a/websites/api-docs-smoke-test/src/content/endpoints/endpoints-for-resource.mdx
+++ b/websites/api-docs-smoke-test/src/content/endpoints/endpoints-for-resource.mdx
@@ -20,3 +20,11 @@ import { ApiEndpointsForResource } from "/shortcodes"
 # /{projectKey}/resource/images
 
 <ApiEndpointsForResource apiKey="test" resource="/{projectKey}/resource/images" />
+
+# /{projectKey}/resource/namespace-action
+
+<ApiEndpointsForResource apiKey="test" resource="/{projectKey}/resource/namespace-action" />
+
+# /{projectKey}/resource/namespace-action-with-example
+
+<ApiEndpointsForResource apiKey="test" resource="/{projectKey}/resource/namespace-action-with-example" />

--- a/websites/api-docs-smoke-test/src/content/endpoints/endpoints-for-resource.mdx
+++ b/websites/api-docs-smoke-test/src/content/endpoints/endpoints-for-resource.mdx
@@ -2,6 +2,7 @@
 title: ApiEndpointsForResource Component
 description: Test endpoints
 ---
+
 import { ApiEndpointsForResource } from "/shortcodes"
 
 # /{projectKey}/resource
@@ -15,3 +16,7 @@ import { ApiEndpointsForResource } from "/shortcodes"
 # /{projectKey}/resource/product-projection-search
 
 <ApiEndpointsForResource apiKey="test" resource="/{projectKey}/resource/product-projection-search" />
+
+# /{projectKey}/resource/images
+
+<ApiEndpointsForResource apiKey="test" resource="/{projectKey}/resource/images" />


### PR DESCRIPTION
This pull request implements requested enhancements:
- the content type is now displayed next to `body`
- the request and response bodies are were adjusted to support images
- descriptions inside of the response body are now displayed next to the response code

closes #1426
closes #1430 
closes #1324 

Link to the examples:
https://docskit-pr-1462.commercetools.vercel.app/api-docs-smoke-test/endpoints/endpoints-for-resource

Design ideas:

<img width="613" alt="image" src="https://user-images.githubusercontent.com/31767369/212646190-f3010197-bfad-4b88-9c64-fe2f4192a67b.png">

<img width="658" alt="image (2)" src="https://user-images.githubusercontent.com/31767369/212646257-1be2563b-0d1b-40f1-b2d1-50ead8c8ca52.png">

<img width="613" alt="image (1)" src="https://user-images.githubusercontent.com/31767369/212646326-3cf106ec-46cf-469a-b34c-bda62e22189c.png">
