### PR TITLE
fix: card border being cut off

### DIFF
--- a/.changeset/giant-cougars-live.md
+++ b/.changeset/giant-cougars-live.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Fix issue with the clickable cards being cut off in certaion situations.

--- a/packages/gatsby-theme-docs/src/layouts/internals/page-content-inset.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/page-content-inset.js
@@ -22,9 +22,6 @@ import { designSystem, Markdown } from '@commercetools-docs/ui-kit';
 const PageContentInset = styled.div`
   max-width: ${(props) =>
     props.maxWidth || designSystem.dimensions.widths.pageContentWide};
-  section {
-    overflow: clip;
-  }
   section > * {
     max-width: ${(props) =>
       props.maxWidth || designSystem.dimensions.widths.pageContent};


### PR DESCRIPTION
The issue was introduced with this change that was made for the sticky example feature:
https://github.com/commercetools/commercetools-docs-kit/commit/86feac81f1127d2b5c9645147463a8d77bef33c3#diff-f1996a28d6f3f74e10c2bd9bac8c7e46a2a566b5549b06065d9f39d4e00ec1b0L19

I checked the sticky behaviour..it is still working as expected.
Please also have a look into the snapshots. They will show that not only the card borders are fixed but also all bottom-borders that we use inside of the sections.
closes #1442 