### PR TITLE
refactor: use gtag.js and support multiple IDs

### DIFF
--- a/.changeset/proud-adults-think.md
+++ b/.changeset/proud-adults-think.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-docs/gatsby-theme-docs': minor
+---
+
+Allow multiple GA tracking IDs by using gtag.js
+
+To migrate, rename the `gaTrackingId` theme configuration to `gaTrackingIds` and pass an array of strings.
+The previous configuration is still supported for compatibility.
+Find the new IDs for commercetools docs in the docs-kit documentation including the new GA4 id.

--- a/packages/gatsby-theme-docs/gatsby-config.js
+++ b/packages/gatsby-theme-docs/gatsby-config.js
@@ -24,6 +24,12 @@ const productionHostname = 'docs.commercetools.com';
 
 module.exports = (themeOptions = {}) => {
   const pluginOptions = { ...defaultOptions, ...themeOptions };
+  // backwards compat to single value GA configuration
+  if (
+    pluginOptions.gaTrackingId &&
+    typeof pluginOptions.gaTrackingId === 'string'
+  )
+    pluginOptions.gaTrackingIds = [pluginOptions.gaTrackingId];
   validateThemeOptions(pluginOptions);
 
   return {
@@ -209,20 +215,28 @@ module.exports = (themeOptions = {}) => {
           include_favicon: false,
         },
       },
-      pluginOptions.gaTrackingId && {
-        resolve: 'gatsby-plugin-google-analytics',
+      pluginOptions.gaTrackingIds && {
+        resolve: `gatsby-plugin-google-gtag`,
         options: {
-          trackingId: pluginOptions.gaTrackingId,
-          head: false,
-          anonymize: true,
-          respectDNT: false,
-          exclude: [],
+          trackingIds: pluginOptions.gaTrackingIds,
+          gtagConfig: {
+            anonymize_ip: true,
+            cookie_expires: 0,
+          },
+          pluginConfig: {
+            head: false,
+            respectDNT: false,
+            exclude: [],
+            delayOnRouteUpdate: 0,
+          },
         },
       },
       pluginOptions.hubspotTrackingCode && {
         resolve: 'gatsby-plugin-hubspot',
         options: {
           trackingCode: pluginOptions.hubspotTrackingCode,
+          respectDNT: false,
+          productionOnly: true,
         },
       },
       {

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -45,7 +45,7 @@
     "gatsby-core-utils": "3.24.0",
     "gatsby-plugin-emotion": "7.24.0",
     "gatsby-plugin-feed": "4.24.0",
-    "gatsby-plugin-google-analytics": "4.24.0",
+    "gatsby-plugin-google-gtag": "5.3.0",
     "gatsby-plugin-hubspot": "2.0.0",
     "gatsby-plugin-image": "2.24.0",
     "gatsby-plugin-manifest": "4.24.0",

--- a/packages/gatsby-theme-docs/src/components/link.js
+++ b/packages/gatsby-theme-docs/src/components/link.js
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { Location } from '@reach/router';
 import { Link as GatsbyLink, withPrefix } from 'gatsby';
 import styled from '@emotion/styled';
-import { OutboundLink } from 'gatsby-plugin-google-analytics';
+import { OutboundLink } from 'gatsby-plugin-google-gtag';
 import { ExternalLinkIcon } from '@commercetools-uikit/icons';
 import { Link as StyledLink, designSystem } from '@commercetools-docs/ui-kit';
 import getEnv from '../utils/get-env';
@@ -46,11 +46,7 @@ const InlineLink = styled.span`
 `;
 
 export const ExternalSiteLink = (props) => (
-  <StyledExternalSiteLink
-    {...props}
-    target="_blank"
-    rel="noopener noreferrer"
-  />
+  <StyledExternalSiteLink {...props} target="_blank" rel="noopener" />
 );
 
 /**

--- a/packages/gatsby-theme-docs/utils/default-options.js
+++ b/packages/gatsby-theme-docs/utils/default-options.js
@@ -3,7 +3,7 @@ const colorPresets = require('../color-presets');
 const defaultOptions = {
   websiteKey: '',
   colorPreset: colorPresets.base.key,
-  gaTrackingId: undefined,
+  gaTrackingIds: undefined,
   createNodeSlug: undefined,
   additionalPrismLanguages: [],
   overrideDefaultConfigurationData: [],

--- a/websites/documentation/src/content/configuration/theme.mdx
+++ b/websites/documentation/src/content/configuration/theme.mdx
@@ -11,7 +11,8 @@ The Docs-Kit theme also receives its plugin configuration through this standard 
 
 - `colorPreset` (_optional_): pick the "look and feel" of the website by choosing one of the available [Color Presets](./extensions#using-theme-color-presets). **Default: `base`**
 
-- `gaTrackingId` (_optional_): this is the Google Analytics tracking ID. For all sites hosted on the `docs.commercetools.com` domain the ID must be: `UA-38285631-3`.
+- `gaTrackingIds` (_optional_, Array): List of tracking IDs to be passed to `gtag.js`.
+  For all sites hosted on the `docs.commercetools.com` domain the IDs must be `["G-XGR7PSLVB2", "UA-38285631-3"]` to fill both UA and GA4 concurrently for the time being.
 
   > For test websites the gaTrackingId field should not be set.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,7 +2112,7 @@ __metadata:
     gatsby-core-utils: 3.24.0
     gatsby-plugin-emotion: 7.24.0
     gatsby-plugin-feed: 4.24.0
-    gatsby-plugin-google-analytics: 4.24.0
+    gatsby-plugin-google-gtag: 5.3.0
     gatsby-plugin-hubspot: 2.0.0
     gatsby-plugin-image: 2.24.0
     gatsby-plugin-manifest: 4.24.0
@@ -14502,18 +14502,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-plugin-google-analytics@npm:4.24.0":
-  version: 4.24.0
-  resolution: "gatsby-plugin-google-analytics@npm:4.24.0"
+"gatsby-plugin-google-gtag@npm:5.3.0":
+  version: 5.3.0
+  resolution: "gatsby-plugin-google-gtag@npm:5.3.0"
   dependencies:
     "@babel/runtime": ^7.15.4
-    minimatch: 3.0.4
-    web-vitals: ^1.1.2
+    minimatch: ^3.1.2
   peerDependencies:
-    gatsby: ^4.0.0-next
-    react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^0.0.0
-    react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^0.0.0
-  checksum: 390fe9d54a2241d208953472f3e58f6e6273b71872104c1fc757dd2a37fa74c52e06876d8f5de0e6fd150d8cfecbf1f21ffd4ed559bfe1b295587ae626e2741d
+    gatsby: ^5.0.0-next
+    react: ^18.0.0 || ^0.0.0
+    react-dom: ^18.0.0 || ^0.0.0
+  checksum: d8b01aa1f4c9c4ee4be29c7b76e5d530ff4c0646effd2701f98aed2a134ad3114987d723af5905d815ac2b4312ebcc300a62b2f89ce5fb54e6de70a4ed963041
   languageName: node
   linkType: hard
 
@@ -27083,13 +27082,6 @@ __metadata:
   version: 1.1.4
   resolution: "web-namespaces@npm:1.1.4"
   checksum: 5149842ccbfbc56fe4f8758957b3f8c8616a281874a5bb84aa1b305e4436a9bad853d21c629a7b8f174902449e1489c7a6c724fccf60965077c5636bd8aed42b
-  languageName: node
-  linkType: hard
-
-"web-vitals@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "web-vitals@npm:1.1.2"
-  checksum: 92071029089277166e11141b735831d9011e85737d32c1360034676db898ab0ca95f19041ee01904f2189ad6e711b9da6b17567e4831290a429a586c98bc573f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #1469 

includes two small changes of related scope: pass identical config to hubspot tracker and do not block passing the referrer to external links so our own other sites can see what traffic comes from the docs. 
