### PR TITLE
feat: reduce mem in critical stage no sourcemaps

### DIFF
--- a/.changeset/long-crabs-watch.md
+++ b/.changeset/long-crabs-watch.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/gatsby-theme-docs": patch
+---
+
+Reduce memory usage in HTML build stage by not generating source maps in that stage

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -610,6 +610,11 @@ exports.onCreateWebpackConfig = (
       use: loaders.null(),
     });
   }
+  // improve build performance in the memory critical stage of our builds by not generating source maps
+  // (yes, this can make errors cryptic, we will have to revisit if it's firing back too much)
+  if (stage === 'build-html') {
+    config.devtool = false;
+  }
 
   config.resolve = {
     ...config.resolve,


### PR DESCRIPTION
Since we are fully replacing the webpack config the standard approaches to disable source maps don't work, it has to be directly in our gatsby-node.js

Also, the approaches we tried optimized the JS build stage but our problem is in the HTML build stage. 

To my nonscientific observation this reduces memory usage by ca. 50%  in the docs-smoke-test on main (MDX v2 based)