### PR TITLE
Webpack experimental lazy compilation in low_mem mode

### DIFF
--- a/.changeset/forty-books-begin.md
+++ b/.changeset/forty-books-begin.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-docs/gatsby-theme-docs': minor
+---
+
+LOW_MEM=true flag also activates experimental webpack lazy compilation in development server.
+This makes the development server throw errors that require reloading it but the effect on startup time and memory is extremely high.
+Purpose is to allow testing MDX v2 plugin based work.

--- a/packages/gatsby-theme-docs/gatsby-node.js
+++ b/packages/gatsby-theme-docs/gatsby-node.js
@@ -642,7 +642,7 @@ exports.onCreateWebpackConfig = (
     config.cache = {
       ...config.cache,
       ...{
-        // compression: 'brotli', // only impacts the filesystem representation
+        // compression: 'brotli', // only impacts the filesystem representation, no effect here
         // the following combination at least leads to the dev server freeing some of the memory again once navigating the preview.
         idleTimeout: 100, // defaults to 60000 millis
         idleTimeoutAfterLargeChanges: 100, // defaults to 1000 millis
@@ -650,8 +650,24 @@ exports.onCreateWebpackConfig = (
         maxMemoryGenerations: 0, // see docs https://webpack.js.org/configuration/cache/#cachemaxmemorygenerations
       },
     };
+
     // run uncached if we have memory issues
     if (lowMemMode) config.cache = false;
+  }
+
+  // run lazy compilation if we have memory issues (makes the dev server throw errors but startup gets very fast)
+  // https://github.com/gatsbyjs/gatsby/discussions/36852
+  // https://github.com/gatsbyjs/gatsby/pull/37040  -> will become obsolete if this feature is published
+  if (stage === 'develop' && lowMemMode) {
+    config.experiments = {
+      ...config.experiments,
+      ...{
+        lazyCompilation: {
+          imports: true,
+          entries: true,
+        },
+      },
+    };
   }
 
   config.resolve = {


### PR DESCRIPTION
This brings the development server down to very low memory and startup time but at the cost of dev server robustness. 
That's why it's hidden behind our LOW_MEM flag which has other negative effects too (no information about where an error is, uncached builds)