### PR TITLE
Allow newer changeset GH action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1.2.0
+        uses: changesets/action@v1
         with:
           commit: 'ci(changesets): version packages'
           publish: yarn changeset publish


### PR DESCRIPTION
following their documentation, this unlocks minor
versions of the changesets action.
The 1.2 we hardwired uses the deprecated way
to set outputs and would at some point fail

