### PR TITLE
fix: use only subdomain for kit website

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 This repository is a monorepository that contains packages to develop documentation websites for commercetools. It includes things like Gatsby themes, Gatsby plugins, UI components, etc. Please look at the individual packages in [`packages` folder](./packages) for functional documentation.
 
-See the [documentation](https://commercetools-docs-kit.vercel.app) of this kit for all further reading.
+See the [documentation](https://docs-kit.commercetools.vercel.app) of this kit for all further reading.
 
 ## Contributing
 

--- a/algolia-crawler.js
+++ b/algolia-crawler.js
@@ -44,7 +44,7 @@ new Crawler({
               // https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/how-to/indexing-long-documents/
 
               // To test visually, paste this into the chrome inspector DOM search feature on
-              // https://commercetools-docs-kit.vercel.app/docs-smoke-test/views/markdown#tables
+              // https://docs-kit.commercetools.vercel.app/docs-smoke-test/views/markdown#tables
               // navigate through the results and check for omissions or double matches
               // test other smoke test pages, too (e.g. cards, API docs)
 

--- a/packages/gatsby-theme-api-docs/README.md
+++ b/packages/gatsby-theme-api-docs/README.md
@@ -1,3 +1,3 @@
 # Gatsby Theme Add-On for API docs
 
-See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-api-docs).
+See [documentation](https://docs-kit.commercetools.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-api-docs).

--- a/packages/gatsby-theme-api-docs/package.json
+++ b/packages/gatsby-theme-api-docs/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-theme-api-docs"
   },
-  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-api-docs",
+  "homepage": "https://docs-kit.commercetools.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-api-docs",
   "keywords": [
     "gatsby",
     "gatsby-plugin",

--- a/packages/gatsby-theme-code-examples/README.md
+++ b/packages/gatsby-theme-code-examples/README.md
@@ -1,3 +1,3 @@
 # Gatsby Theme Add-On for Code Examples
 
-See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-code-examples).
+See [documentation](https://docs-kit.commercetools.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-code-examples).

--- a/packages/gatsby-theme-code-examples/package.json
+++ b/packages/gatsby-theme-code-examples/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-theme-code-examples"
   },
-  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-code-examples",
+  "homepage": "https://docs-kit.commercetools.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-code-examples",
   "keywords": ["gatsby", "gatsby-plugin", "gatsby-theme", "code", "examples"],
   "dependencies": {
     "@commercetools-docs/ui-kit": "21.1.0",

--- a/packages/gatsby-theme-constants/README.md
+++ b/packages/gatsby-theme-constants/README.md
@@ -1,3 +1,3 @@
 # Gatsby Theme Add-On for Constants
 
-See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-constants).
+See [documentation](https://docs-kit.commercetools.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-constants).

--- a/packages/gatsby-theme-constants/package.json
+++ b/packages/gatsby-theme-constants/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-theme-constants"
   },
-  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-constants",
+  "homepage": "https://docs-kit.commercetools.vercel.app/documentation/configuration/extensions#gatsby-theme-add-on-for-constants",
   "keywords": ["gatsby", "gatsby-plugin", "gatsby-theme", "yaml", "constants"],
   "dependencies": {
     "@commercetools-docs/ui-kit": "21.1.0",

--- a/packages/gatsby-theme-docs/README.md
+++ b/packages/gatsby-theme-docs/README.md
@@ -1,3 +1,3 @@
 # Gatsby Theme Docs
 
-See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/theme).
+See [documentation](https://docs-kit.commercetools.vercel.app/documentation/configuration/theme).

--- a/packages/gatsby-theme-docs/package.json
+++ b/packages/gatsby-theme-docs/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-theme-docs"
   },
-  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/theme",
+  "homepage": "https://docs-kit.commercetools.vercel.app/documentation/configuration/theme",
   "bin": {
     "create-docs-release-note": "bin/create-release-note.js"
   },

--- a/packages/gatsby-transformer-mdx-introspection/README.md
+++ b/packages/gatsby-transformer-mdx-introspection/README.md
@@ -1,3 +1,3 @@
 # Gatsby Transformer MDX Introspection
 
-See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/plugins#gatsby-transformer-mdx-introspection).
+See [documentation](https://docs-kit.commercetools.vercel.app/documentation/configuration/plugins#gatsby-transformer-mdx-introspection).

--- a/packages/gatsby-transformer-mdx-introspection/package.json
+++ b/packages/gatsby-transformer-mdx-introspection/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-transformer-mdx-introspection"
   },
-  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/plugins#gatsby-transformer-mdx-introspection",
+  "homepage": "https://docs-kit.commercetools.vercel.app/documentation/configuration/plugins#gatsby-transformer-mdx-introspection",
   "keywords": ["gatsby", "gatsby-plugin", "mdx"],
   "dependencies": {
     "@babel/parser": "^7.20.15",

--- a/packages/gatsby-transformer-raml/README.md
+++ b/packages/gatsby-transformer-raml/README.md
@@ -1,3 +1,3 @@
 # Gatsby Transformer RAML
 
-See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/plugins#gatsby-transformer-raml).
+See [documentation](https://docs-kit.commercetools.vercel.app/documentation/configuration/plugins#gatsby-transformer-raml).

--- a/packages/gatsby-transformer-raml/package.json
+++ b/packages/gatsby-transformer-raml/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/gatsby-transformer-raml"
   },
-  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/plugins#gatsby-transformer-raml",
+  "homepage": "https://docs-kit.commercetools.vercel.app/documentation/configuration/plugins#gatsby-transformer-raml",
   "keywords": ["gatsby", "gatsby-plugin", "gatsby-transformer", "raml"],
   "dependencies": {
     "firstline": "^2.0.2",

--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -1,6 +1,6 @@
 # Docs UI Components Library
 
-See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/packages#ui-components-library).
+See [documentation](https://docs-kit.commercetools.vercel.app/documentation/configuration/packages#ui-components-library).
 
 Source code is under the MIT License (see the [LICENSE](LICENSE) file)
 

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/ui-kit"
   },
-  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/packages#ui-components-library",
+  "homepage": "https://docs-kit.commercetools.vercel.app/documentation/configuration/packages#ui-components-library",
   "main": "dist/commercetools-docs-ui-kit.cjs.js",
   "module": "dist/commercetools-docs-ui-kit.esm.js",
   "files": ["dist", "package.json", "LICENSE", "README.md"],

--- a/packages/writing-style/README.md
+++ b/packages/writing-style/README.md
@@ -2,4 +2,4 @@
 
 This is a packaged redistribution of the [vale style linter](https://vale.sh/).
 
-See [documentation](https://commercetools-docs-kit.vercel.app/documentation/configuration/packages#commercetools-writing-style-linter).
+See [documentation](https://docs-kit.commercetools.vercel.app/documentation/configuration/packages#commercetools-writing-style-linter).

--- a/packages/writing-style/package.json
+++ b/packages/writing-style/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/commercetools/commercetools-docs-kit.git",
     "directory": "packages/writing-style"
   },
-  "homepage": "https://commercetools-docs-kit.vercel.app/documentation/configuration/packages#commercetools-writing-style-linter",
+  "homepage": "https://docs-kit.commercetools.vercel.app/documentation/configuration/packages#commercetools-writing-style-linter",
   "bin": {
     "commercetools-vale": "./bin/commercetools-vale.js",
     "commercetools-vale-bin": "./bin/commercetools-vale-bin.js"


### PR DESCRIPTION
This makes it consistent with all other URLs we use and the sentry and other
tooling configuration work by using only  *.commercetools.vercel.app