### PR TITLE
fix: explicitly include api-specs/test package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:base", ":preserveSemverRanges"],
   "schedule": ["on the 1st and 3rd day instance on Wednesday after 3am"],
+  "includePaths": ["api-specs/test/**"],
   "separateMajorMinor": true,
   "packageRules": [
     {


### PR DESCRIPTION
Seems like the base configuration of renovate excludes directories named test:

https://github.com/renovatebot/renovate/blob/e5ccf2b85e290e45b20bbf36d5a529a5261d0c62/lib/config/presets/internal/default.ts#L42-L55

I try fixing it adding explicitly the path api-specs/test/** to the includePaths rule