### PR TITLE
chore: fix renovate grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,18 +12,18 @@
   "separateMajorMinor": true,
   "packageRules": [
     {
-      "matchSourceUrlPrefixes": ["https://github.com/commercetools/ui-kit"],
-      "groupName": "all ui-kit packages"
-    },
-    {
-      "matchSourceUrlPrefixes": ["https://github.com/gregberge/svgr"],
-      "groupName": "all svgr packages"
-    },
-    {
-      "packagePatterns": ["*"],
+      "matchPackagePatterns": ["*"],
       "updateTypes": ["minor", "patch"],
       "groupName": "all dependencies",
       "groupSlug": "all"
+    },
+    {
+      "matchPackagePatterns": ["^@commercetools-uikit"],
+      "groupName": "all ui-kit packages"
+    },
+    {
+      "matchPackagePatterns": ["^@svgr"],
+      "groupName": "all svgr packages"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Following what described in this [issue](https://github.com/renovatebot/config-help/issues/339), I'm trying to re-sort the priority of the rules and match package names instead or URLs