### PR TITLE
Remove open-source from banned words

### DIFF
--- a/packages/writing-style/styles/commercetools/WordList.yml
+++ b/packages/writing-style/styles/commercetools/WordList.yml
@@ -36,7 +36,6 @@ swap:
   l10n: localization
   long press: touch & hold
   open beta: public beta # acc. to our beta policy
-  open-source: open source
   private beta: closed beta # acc. to our beta policy
   regex: regular expression
   sign into: sign in to


### PR DESCRIPTION
When used as an adjective preceding a noun, open-source should be hyphenated. 

Sources:
- https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/o/open-source
- https://www.oxfordlearnersdictionaries.com/definition/english/open-source

I deleted the check entirely, instead of swapping them around since there can be cases when the non-hyphenated version should be used (see in Microsoft example above). 