### PR TITLE
Improve `closeIcon` size and spacing in `search input`

### DIFF
--- a/.changeset/brave-spiders-hide.md
+++ b/.changeset/brave-spiders-hide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+The closing icon inside of the docs search input was improved to have the correct size and spacing.

--- a/packages/gatsby-theme-docs/src/components/search-input.js
+++ b/packages/gatsby-theme-docs/src/components/search-input.js
@@ -126,7 +126,8 @@ const SearchInput = React.forwardRef((props, ref) => {
           <SecondaryIconButton
             label="Close search dialog"
             onClick={props.onClose}
-            icon={<CloseIcon size="medium" />}
+            size="medium"
+            icon={<CloseIcon />}
           />
         </SearchInputIcon>
       )}


### PR DESCRIPTION

<img width="728" alt="Bildschirmfoto 2023-05-09 um 12 31 02" src="https://github.com/commercetools/commercetools-docs-kit/assets/31767369/e79cb2dc-f1e4-499d-9bff-2259c8408abc">
