### PR TITLE
[Design adjustments] Reduce spacing between sections in the content page

### DIFF
--- a/.changeset/tough-walls-laugh.md
+++ b/.changeset/tough-walls-laugh.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/ui-kit': patch
+---
+
+Adjust spacing between sections in the page content.

--- a/packages/ui-kit/src/components/markdown.tsx
+++ b/packages/ui-kit/src/components/markdown.tsx
@@ -304,22 +304,22 @@ const TypographyPage = styled.div`
   }
 
   section > ${H2} {
-    margin: ${dimensions.spacings.huge} 0 ${dimensions.spacings.m};
+    margin: ${dimensions.spacings.large} 0 ${dimensions.spacings.m};
   }
   section > ${H3} {
-    margin: ${dimensions.spacings.big} 0 0;
+    margin: ${dimensions.spacings.s} 0 0;
   }
   section > ${H4} {
-    margin: ${dimensions.spacings.xl} 0 0;
+    margin: ${dimensions.spacings.s} 0 0;
   }
   section > ${H5} {
-    margin: ${dimensions.spacings.xl} 0 0;
+    margin: ${dimensions.spacings.s} 0 0;
   }
   section > ${H6} {
-    margin: ${dimensions.spacings.m} 0 ${dimensions.spacings.s};
+    margin: ${dimensions.spacings.s} 0 ${dimensions.spacings.s};
   }
   section > ${Blockquote} {
-    margin: ${dimensions.spacings.l} ${dimensions.spacings.xxl};
+    margin: ${dimensions.spacings.s} ${dimensions.spacings.xxl};
   }
   section > ${Ul}, section > ${Ol}, section > ${Dl} {
     margin-top: ${dimensions.spacings.s};

--- a/packages/ui-kit/src/components/markdown.tsx
+++ b/packages/ui-kit/src/components/markdown.tsx
@@ -307,19 +307,19 @@ const TypographyPage = styled.div`
     margin: ${dimensions.spacings.large} 0 ${dimensions.spacings.m};
   }
   section > ${H3} {
-    margin: ${dimensions.spacings.s} 0 0;
+    margin: ${dimensions.spacings.l} 0 0;
   }
   section > ${H4} {
-    margin: ${dimensions.spacings.s} 0 0;
+    margin: ${dimensions.spacings.m} 0 0;
   }
   section > ${H5} {
-    margin: ${dimensions.spacings.s} 0 0;
+    margin: ${dimensions.spacings.m} 0 0;
   }
   section > ${H6} {
-    margin: ${dimensions.spacings.s} 0 ${dimensions.spacings.s};
+    margin: ${dimensions.spacings.m} 0 ${dimensions.spacings.s};
   }
   section > ${Blockquote} {
-    margin: ${dimensions.spacings.s} ${dimensions.spacings.xxl};
+    margin: ${dimensions.spacings.l} ${dimensions.spacings.xxl};
   }
   section > ${Ul}, section > ${Ol}, section > ${Dl} {
     margin-top: ${dimensions.spacings.s};


### PR DESCRIPTION
closes #1748 

Hi @zbalek 
This is how the content page looks like if we reduce the spacing between the sections to 8px as suggested in the Figma board. I personally think that it looks a bit too squeezed now. Maybe 16px between the h3 sections would be better, but that's just my opinion :)