### PR TITLE
feat: email verification + company association

### DIFF
--- a/.changeset/light-plums-end.md
+++ b/.changeset/light-plums-end.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/gatsby-theme-docs": patch
+---
+
+feat: email verification + company association

--- a/cypress/e2e/self-learning-smoke-test/02-profile-modal.ts
+++ b/cypress/e2e/self-learning-smoke-test/02-profile-modal.ts
@@ -1,5 +1,5 @@
 import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
-import { ETestId } from './e2e.const';
+import { ETestId, TEST_USER_USERNAME } from './e2e.const';
 
 Then("The user can't submit the form", () => {
   cy.get(
@@ -34,5 +34,8 @@ When(
     cy.get(
       `[data-testid="${ETestId.profileModal}"] > div[name="main"] input[name="company"]`
     ).should('have.value', company);
+    cy.get(
+      `[data-testid="${ETestId.profileModal}"] > div[name="main"] input[name="email"]`
+    ).should('have.value', TEST_USER_USERNAME);
   }
 );

--- a/cypress/e2e/self-learning-smoke-test/02-profile-modal.ts
+++ b/cypress/e2e/self-learning-smoke-test/02-profile-modal.ts
@@ -3,7 +3,7 @@ import { ETestId } from './e2e.const';
 
 Then("The user can't submit the form", () => {
   cy.get(
-    `[data-testid="${ETestId.profileModal}"] > div[name="main"] button`
+    `[data-testid="${ETestId.profileModal}"] > div[name="main"] button[label="Save"]`
   ).should('not.be.enabled');
 });
 

--- a/cypress/support/step_definitions/common.steps.ts
+++ b/cypress/support/step_definitions/common.steps.ts
@@ -307,7 +307,7 @@ Given('The user sees a complete profile modal with empty fields', () => {
   cy.get(
     `[data-testid="${ETestId.profileModal}"] > div[name="main"] input[type="text"]`
   )
-    .should('have.length', 3)
+    .should('have.length', 4)
     .each(($input) => {
       cy.wrap($input).should('have.value', '');
     });

--- a/cypress/support/step_definitions/common.steps.ts
+++ b/cypress/support/step_definitions/common.steps.ts
@@ -304,15 +304,23 @@ Given('The user sees a complete profile modal with empty fields', () => {
   cy.get(`[data-testid="${ETestId.profileModal}"] div[name="main"]`).should(
     'be.visible'
   );
+  // then let's ensure the expected values are displayed
   cy.get(
-    `[data-testid="${ETestId.profileModal}"] > div[name="main"] input[type="text"]`
-  )
-    .should('have.length', 4)
-    .each(($input) => {
-      cy.wrap($input).should('have.value', '');
-    });
+    `[data-testid="${ETestId.profileModal}"] > div[name="main"] input[name="firstName"]`
+  ).should('have.value', '');
+
   cy.get(
-    `[data-testid="${ETestId.profileModal}"] > div[name="main"] button`
+    `[data-testid="${ETestId.profileModal}"] > div[name="main"] input[name="lastName"]`
+  ).should('have.value', '');
+
+  cy.get(
+    `[data-testid="${ETestId.profileModal}"] > div[name="main"] input[name="company"]`
+  ).should('have.value', '');
+  cy.get(
+    `[data-testid="${ETestId.profileModal}"] > div[name="main"] input[name="email"]`
+  ).should('have.value', TEST_USER_USERNAME);
+  cy.get(
+    `[data-testid="${ETestId.profileModal}"] > div[name="main"] button[label="Save"]`
   ).should('be.disabled');
 });
 

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
@@ -206,7 +206,7 @@ const ProfileModal = () => {
           <Label>
             <Link
               isExternal
-              to={`mailto:${mailToData.email}?subject=${mailToData.company_association_verify_request.subject}&body=${mailToData.company_association_verify_request.body}`}
+              to={`mailto:${mailToData.email}?subject=${mailToData.email_change_request.subject}&body=${mailToData.email_change_request.body}`}
             >
               Please contact us to change your email address.
             </Link>

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
@@ -229,7 +229,7 @@ const ProfileModal = () => {
           />
           {profile?.global_account_name ? (
             <Label>
-              Your company association is <b>{profile.global_account_name}</b>{' '}
+              Your verified company association is <b>{profile.global_account_name}</b>{' '}
               with id <b>{profile.global_account_id}</b> <br />
               <Link
                 isExternal

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
@@ -8,7 +8,7 @@ import { FormDialog, useModalState } from '@commercetools-docs/ui-kit';
 import { useContext, useEffect } from 'react';
 import { LearningContextApi, LearningContextState } from './learning-context';
 import { useUpdateUser } from '../hooks/use-update-user';
-import { VerifiedIcon, CheckInactiveIcon } from '@commercetools-uikit/icons';
+import { VerifiedIcon } from '@commercetools-uikit/icons';
 import SendVerificationEmailButton from './verify-email-button';
 import Stamp from '@commercetools-uikit/stamp';
 import FieldLabel from '@commercetools-uikit/field-label';
@@ -244,7 +244,8 @@ const ProfileModal = () => {
           </SpacingsStack>
         ) : (
           <Label>
-            Your company association is not verified.{' '}
+            Your company association is not verified.
+            <br />
             <Link
               isExternal
               to={`mailto:${mailToData.email}?subject=${mailToData.company_association_verify_request.subject}&body=${mailToData.company_association_verify_request.body}`}

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
@@ -11,6 +11,9 @@ import { useUpdateUser } from '../hooks/use-update-user';
 import { VerifiedIcon, CheckInactiveIcon } from '@commercetools-uikit/icons';
 import SendVerificationEmailButton from './verify-email-button';
 import Stamp from '@commercetools-uikit/stamp';
+import FieldLabel from '@commercetools-uikit/field-label';
+import Label from '@commercetools-uikit/label';
+import Link from '@commercetools-uikit/link';
 
 import ConfigContext, {
   EFeatureFlag,
@@ -24,7 +27,17 @@ export type TProfileFormValues = {
   email: string;
   global_account_name: string;
 };
-
+const mailToData = {
+  email: 'training@commercetools.com',
+  email_change_request: {
+    subject: 'commercetools ID: Data Change Request',
+    body: "Hi,%0A%0A I'm writing to change my email.%0A%0A Thanks%0A",
+  },
+  company_association_verify_request: {
+    subject: 'commercetools ID: Data Change Request',
+    body: "Hi,%0A%0A I'm writing to verify my company association.%0A%0A Thanks%0A",
+  },
+};
 const ProfileModal = () => {
   const { selfLearningFeatures } = useContext(ConfigContext);
   const { updateProfile, closeProfileModal } = useContext(LearningContextApi);
@@ -161,6 +174,44 @@ const ProfileModal = () => {
           onBlur={formik.handleBlur}
           renderError={renderError}
         />
+        <SpacingsStack>
+          <TextField
+            key="email"
+            name="email"
+            title="Email"
+            value={formik.values.email}
+            touched={formik.touched.email}
+            errors={
+              TextField.toFieldErrors<TProfileFormValues>(formik.errors).email
+            }
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            renderError={renderError}
+            isReadOnly
+            badge={
+              profile?.email_verified ? (
+                <Stamp
+                  tone="primary"
+                  label="Verified"
+                  icon={<VerifiedIcon size="big" color="info" />}
+                />
+              ) : (
+                <SpacingsInline>
+                  <SendVerificationEmailButton />
+                  <Stamp tone="secondary" label="Not Verified" />
+                </SpacingsInline>
+              )
+            }
+          />
+          <Label>
+            <Link
+              isExternal
+              to={`mailto:${mailToData.email}?subject=${mailToData.company_association_verify_request.subject}&body=${mailToData.company_association_verify_request.body}`}
+            >
+              Please contact us to change your email address.
+            </Link>
+          </Label>
+        </SpacingsStack>
         <TextField
           key="company"
           name="company"
@@ -175,74 +226,34 @@ const ProfileModal = () => {
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}
         />
-        <TextField
-          key="email"
-          name="email"
-          title="Email"
-          description="Please contact us at training@commercetools.com to change your email"
-          value={formik.values.email}
-          touched={formik.touched.email}
-          errors={
-            TextField.toFieldErrors<TProfileFormValues>(formik.errors).email
-          }
-          onChange={formik.handleChange}
-          onBlur={formik.handleBlur}
-          renderError={renderError}
-          isReadOnly
-          badge={
-            profile?.email_verified ? (
-              <Stamp
-                tone="primary"
-                label="Verified"
-                icon={<VerifiedIcon size="big" color="info" />}
-              />
-            ) : (
-              <SpacingsInline>
-                <SendVerificationEmailButton />
-                <Stamp
-                  tone="secondary"
-                  label="Not Verified"
-                  icon={<CheckInactiveIcon size="big" color="info" />}
-                />
-              </SpacingsInline>
-            )
-          }
-        />
-        <TextField
-          key="global_account_name"
-          name="global_account_name"
-          title="Verified Company Association"
-          description={
-            profile?.global_account_name
-              ? 'Please contact us at training@commercetools.com to verify a different company association.'
-              : 'Your company association is not automatically verified. Please contact us at training@commercetools.com to verify it.'
-          }
-          value={formik.values.global_account_name}
-          touched={formik.touched.global_account_name}
-          errors={
-            TextField.toFieldErrors<TProfileFormValues>(formik.errors)
-              .global_account_name
-          }
-          renderError={renderError}
-          onChange={formik.handleChange}
-          onBlur={formik.handleBlur}
-          isReadOnly
-          badge={
-            profile?.global_account_name ? (
-              <Stamp
-                tone="primary"
-                label="Verified"
-                icon={<VerifiedIcon size="big" color="info" />}
-              />
-            ) : (
-              <Stamp
-                tone="secondary"
-                label="Not Verified"
-                icon={<CheckInactiveIcon size="big" color="info" />}
-              />
-            )
-          }
-        />
+        {profile?.global_account_name ? (
+          <SpacingsStack>
+            <FieldLabel title="Verified Company Association" />
+            <Label>
+              Your company association is <b>{profile.global_account_name}</b>{' '}
+              with id <b>{profile.global_account_id}</b>{' '}
+            </Label>
+            <Label>
+              <Link
+                isExternal
+                to={`mailto:${mailToData.email}?subject=${mailToData.company_association_verify_request.subject}&body=${mailToData.company_association_verify_request.body}`}
+              >
+                Please contact us to change it.
+              </Link>
+            </Label>
+          </SpacingsStack>
+        ) : (
+          <Label>
+            Your company association is not verified.{' '}
+            <Link
+              isExternal
+              to={`mailto:${mailToData.email}?subject=${mailToData.company_association_verify_request.subject}&body=${mailToData.company_association_verify_request.body}`}
+            >
+              Please contact us to verify it.
+            </Link>
+          </Label>
+        )}
+
         {error && (
           <ErrorMessage>
             An error occurred while updating your profile, please try again.

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
@@ -2,11 +2,16 @@ import { useFormik } from 'formik';
 import TextField from '@commercetools-uikit/text-field';
 import TextInput from '@commercetools-uikit/text-input';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
+import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import { ErrorMessage } from '@commercetools-uikit/messages';
 import { FormDialog, useModalState } from '@commercetools-docs/ui-kit';
 import { useContext, useEffect } from 'react';
 import { LearningContextApi, LearningContextState } from './learning-context';
 import { useUpdateUser } from '../hooks/use-update-user';
+import { VerifiedIcon, CheckInactiveIcon } from '@commercetools-uikit/icons';
+import SendVerificationEmailButton from './verify-email-button';
+import Stamp from '@commercetools-uikit/stamp';
+
 import ConfigContext, {
   EFeatureFlag,
   isFeatureEnabled,
@@ -16,6 +21,8 @@ export type TProfileFormValues = {
   firstName: string;
   lastName: string;
   company: string;
+  email: string;
+  global_account_name: string;
 };
 
 const ProfileModal = () => {
@@ -33,12 +40,13 @@ const ProfileModal = () => {
     EFeatureFlag.CompleteProfileModal,
     selfLearningFeatures
   );
-
   const formik = useFormik<TProfileFormValues>({
     initialValues: {
       firstName: '',
       lastName: '',
       company: '',
+      email: '',
+      global_account_name: '',
     },
     validate: (formikValues: TProfileFormValues) => {
       const missingFields: Record<string, { missing: boolean }> = {};
@@ -83,6 +91,11 @@ const ProfileModal = () => {
       formik.setFieldValue('firstName', profile?.given_name || '');
       formik.setFieldValue('lastName', profile?.family_name || '');
       formik.setFieldValue('company', profile?.user_metadata?.company || '');
+      formik.setFieldValue('email', profile?.email || '');
+      formik.setFieldValue(
+        'global_account_name',
+        profile?.global_account_name || ''
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profile, isModalOpen]);
@@ -104,7 +117,7 @@ const ProfileModal = () => {
   return (
     <FormDialog
       testid="profile-modal"
-      size="m"
+      size="l"
       title={profileModal?.title || 'Update your profile.'}
       labelPrimary="Save"
       isOpen={isModalOpen}
@@ -161,6 +174,74 @@ const ProfileModal = () => {
           renderError={renderError}
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}
+        />
+        <TextField
+          key="email"
+          name="email"
+          title="Email"
+          description="Please contact us at training@commercetools.com to change your email"
+          value={formik.values.email}
+          touched={formik.touched.email}
+          errors={
+            TextField.toFieldErrors<TProfileFormValues>(formik.errors).email
+          }
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          renderError={renderError}
+          isReadOnly
+          badge={
+            profile?.email_verified ? (
+              <Stamp
+                tone="primary"
+                label="Verified"
+                icon={<VerifiedIcon size="big" color="info" />}
+              />
+            ) : (
+              <SpacingsInline>
+                <SendVerificationEmailButton />
+                <Stamp
+                  tone="secondary"
+                  label="Not Verified"
+                  icon={<CheckInactiveIcon size="big" color="info" />}
+                />
+              </SpacingsInline>
+            )
+          }
+        />
+        <TextField
+          key="global_account_name"
+          name="global_account_name"
+          title="Verified Company Association"
+          description={
+            profile?.global_account_name
+              ? 'Please contact us at training@commercetools.com to verify a different company association.'
+              : 'Your company association is not automatically verified. Please contact us at training@commercetools.com to verify it.'
+          }
+          value={formik.values.global_account_name}
+          touched={formik.touched.global_account_name}
+          errors={
+            TextField.toFieldErrors<TProfileFormValues>(formik.errors)
+              .global_account_name
+          }
+          renderError={renderError}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          isReadOnly
+          badge={
+            profile?.global_account_name ? (
+              <Stamp
+                tone="primary"
+                label="Verified"
+                icon={<VerifiedIcon size="big" color="info" />}
+              />
+            ) : (
+              <Stamp
+                tone="secondary"
+                label="Not Verified"
+                icon={<CheckInactiveIcon size="big" color="info" />}
+              />
+            )
+          }
         />
         {error && (
           <ErrorMessage>

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
@@ -229,8 +229,9 @@ const ProfileModal = () => {
           />
           {profile?.global_account_name ? (
             <Label>
-              Your verified company association is <b>{profile.global_account_name}</b>{' '}
-              with id <b>{profile.global_account_id}</b> <br />
+              Your verified company association is{' '}
+              <b>{profile.global_account_name}</b> with id{' '}
+              <b>{profile.global_account_id}</b> <br />
               <Link
                 isExternal
                 to={`mailto:${mailToData.email}?subject=${mailToData.company_association_verify_request.subject}&body=${mailToData.company_association_verify_request.body}`}

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/profile-modal.tsx
@@ -175,65 +175,62 @@ const ProfileModal = () => {
           renderError={renderError}
         />
         <SpacingsStack>
-          <TextField
-            key="email"
-            name="email"
-            title="Email"
-            value={formik.values.email}
-            touched={formik.touched.email}
-            errors={
-              TextField.toFieldErrors<TProfileFormValues>(formik.errors).email
-            }
-            onChange={formik.handleChange}
-            onBlur={formik.handleBlur}
-            renderError={renderError}
-            isReadOnly
-            badge={
-              profile?.email_verified ? (
-                <Stamp
-                  tone="primary"
-                  label="Verified"
-                  icon={<VerifiedIcon size="big" color="info" />}
-                />
-              ) : (
-                <SpacingsInline>
-                  <SendVerificationEmailButton />
-                  <Stamp tone="secondary" label="Not Verified" />
-                </SpacingsInline>
-              )
-            }
-          />
+          <SpacingsInline alignItems="center">
+            <Label>Email</Label>
+            {profile?.email_verified ? (
+              <Stamp
+                tone="primary"
+                label="Verified"
+                isCondensed
+                icon={<VerifiedIcon size="big" color="info" />}
+              />
+            ) : (
+              <Stamp isCondensed tone="secondary" label="Not Verified" />
+            )}
+          </SpacingsInline>
           <Label>
             <Link
               isExternal
               to={`mailto:${mailToData.email}?subject=${mailToData.email_change_request.subject}&body=${mailToData.email_change_request.body}`}
             >
-              Please contact us to change your email address.
+              Please contact us to change it.
             </Link>
           </Label>
+          <TextInput
+            key="email"
+            name="email"
+            value={formik.values.email}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            isReadOnly
+          />
+          {!profile?.email_verified ? (
+            <SpacingsInline alignItems="flex-end" justifyContent="flex-end">
+              <SendVerificationEmailButton />
+            </SpacingsInline>
+          ) : (
+            ''
+          )}
         </SpacingsStack>
-        <TextField
-          key="company"
-          name="company"
-          title="Company"
-          isRequired
-          value={formik.values.company}
-          touched={formik.touched.company}
-          errors={
-            TextField.toFieldErrors<TProfileFormValues>(formik.errors).company
-          }
-          renderError={renderError}
-          onChange={formik.handleChange}
-          onBlur={formik.handleBlur}
-        />
-        {profile?.global_account_name ? (
-          <SpacingsStack>
-            <FieldLabel title="Verified Company Association" />
+        <SpacingsStack>
+          <TextField
+            key="company"
+            name="company"
+            title="Company"
+            isRequired
+            value={formik.values.company}
+            touched={formik.touched.company}
+            errors={
+              TextField.toFieldErrors<TProfileFormValues>(formik.errors).company
+            }
+            renderError={renderError}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+          />
+          {profile?.global_account_name ? (
             <Label>
               Your company association is <b>{profile.global_account_name}</b>{' '}
-              with id <b>{profile.global_account_id}</b>{' '}
-            </Label>
-            <Label>
+              with id <b>{profile.global_account_id}</b> <br />
               <Link
                 isExternal
                 to={`mailto:${mailToData.email}?subject=${mailToData.company_association_verify_request.subject}&body=${mailToData.company_association_verify_request.body}`}
@@ -241,19 +238,19 @@ const ProfileModal = () => {
                 Please contact us to change it.
               </Link>
             </Label>
-          </SpacingsStack>
-        ) : (
-          <Label>
-            Your company association is not verified.
-            <br />
-            <Link
-              isExternal
-              to={`mailto:${mailToData.email}?subject=${mailToData.company_association_verify_request.subject}&body=${mailToData.company_association_verify_request.body}`}
-            >
-              Please contact us to verify it.
-            </Link>
-          </Label>
-        )}
+          ) : (
+            <Label>
+              Your company association is not verified.
+              <br />
+              <Link
+                isExternal
+                to={`mailto:${mailToData.email}?subject=${mailToData.company_association_verify_request.subject}&body=${mailToData.company_association_verify_request.body}`}
+              >
+                Please contact us to verify it.
+              </Link>
+            </Label>
+          )}
+        </SpacingsStack>
 
         {error && (
           <ErrorMessage>

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/user-profile-init.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/user-profile-init.tsx
@@ -4,6 +4,7 @@ import { LearningContextApi, LearningContextState } from './learning-context';
 import {
   AUTH0_CLAIM_COMPANY,
   AUTH0_CLAIM_GLOBAL_ACCOUNT_NAME,
+  AUTH0_CLAIM_GLOBAL_ACCOUNT_ID,
 } from '../../sso';
 import { isProfileComplete } from './profile.utils';
 import useAuthentication from '../../sso/hooks/use-authentication';
@@ -19,11 +20,11 @@ const contextProfileAdapter = (auth0User: User) => {
   const {
     [AUTH0_CLAIM_COMPANY]: company,
     [AUTH0_CLAIM_GLOBAL_ACCOUNT_NAME]: global_account_name,
+    [AUTH0_CLAIM_GLOBAL_ACCOUNT_ID]: global_account_id,
     user_metadata,
     sub,
     ...rest
   } = auth0User;
-
   return {
     ...rest,
     user_id: sub,
@@ -32,6 +33,7 @@ const contextProfileAdapter = (auth0User: User) => {
       company,
     },
     global_account_name,
+    global_account_id,
   };
 };
 

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/user-profile-init.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/user-profile-init.tsx
@@ -1,7 +1,10 @@
 import { User } from '@auth0/auth0-react';
 import { useContext, useEffect } from 'react';
 import { LearningContextApi, LearningContextState } from './learning-context';
-import { AUTH0_CLAIM_COMPANY } from '../../sso';
+import {
+  AUTH0_CLAIM_COMPANY,
+  AUTH0_CLAIM_GLOBAL_ACCOUNT_NAME,
+} from '../../sso';
 import { isProfileComplete } from './profile.utils';
 import useAuthentication from '../../sso/hooks/use-authentication';
 import useLocalStorageSession from '../../sso/hooks/use-local-storage-session';
@@ -15,6 +18,7 @@ export type TProfileFormValues = {
 const contextProfileAdapter = (auth0User: User) => {
   const {
     [AUTH0_CLAIM_COMPANY]: company,
+    [AUTH0_CLAIM_GLOBAL_ACCOUNT_NAME]: global_account_name,
     user_metadata,
     sub,
     ...rest
@@ -27,6 +31,7 @@ const contextProfileAdapter = (auth0User: User) => {
       ...user_metadata,
       company,
     },
+    global_account_name,
   };
 };
 

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/verify-email-button.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/verify-email-button.tsx
@@ -1,5 +1,4 @@
-import { useContext, useState, useEffect } from 'react';
-import { LearningContextState } from './learning-context';
+import { useState, useEffect } from 'react';
 import PrimaryButton from '@commercetools-uikit/primary-button';
 import { useSendVerificationEmail } from '../hooks/use-send-verification-email';
 import LoadingSpinner from '@commercetools-uikit/loading-spinner';
@@ -8,16 +7,11 @@ import { MailIcon } from '@commercetools-uikit/icons';
 
 const SendVerificationEmailButton = () => {
   const {
-    user: { profile },
-  } = useContext(LearningContextState);
-  const {
     performSendVerificationEmail,
     isLoading,
     sendVerificationEmail,
     error,
-  } = useSendVerificationEmail({
-    userId: profile?.user_id || '',
-  });
+  } = useSendVerificationEmail();
   const [buttonLabel, setButtonLabel] = useState('Send Verification Email');
 
   const handleSendEmail = async () => {

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/verify-email-button.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/verify-email-button.tsx
@@ -12,7 +12,7 @@ const SendVerificationEmailButton = () => {
     sendVerificationEmail,
     error,
   } = useSendVerificationEmail();
-  const [buttonLabel, setButtonLabel] = useState('Send Verification Email');
+  const [buttonLabel, setButtonLabel] = useState('Verify Email');
 
   const handleSendEmail = async () => {
     performSendVerificationEmail();
@@ -30,7 +30,7 @@ const SendVerificationEmailButton = () => {
     <PrimaryButton
       label={buttonLabel}
       onClick={handleSendEmail}
-      size="medium"
+      size="small"
       iconLeft={
         isLoading ? <LoadingSpinner scale="s" /> : <MailIcon size="medium" />
       }

--- a/packages/gatsby-theme-docs/src/modules/self-learning/components/verify-email-button.tsx
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/components/verify-email-button.tsx
@@ -1,0 +1,47 @@
+import { useContext, useState, useEffect } from 'react';
+import { LearningContextState } from './learning-context';
+import PrimaryButton from '@commercetools-uikit/primary-button';
+import { useSendVerificationEmail } from '../hooks/use-send-verification-email';
+import LoadingSpinner from '@commercetools-uikit/loading-spinner';
+
+import { MailIcon } from '@commercetools-uikit/icons';
+
+const SendVerificationEmailButton = () => {
+  const {
+    user: { profile },
+  } = useContext(LearningContextState);
+  const {
+    performSendVerificationEmail,
+    isLoading,
+    sendVerificationEmail,
+    error,
+  } = useSendVerificationEmail({
+    userId: profile?.user_id || '',
+  });
+  const [buttonLabel, setButtonLabel] = useState('Send Verification Email');
+
+  const handleSendEmail = async () => {
+    performSendVerificationEmail();
+  };
+  useEffect(() => {
+    if (sendVerificationEmail) {
+      setButtonLabel('Sent Successfully');
+    }
+    if (error) setButtonLabel('An error occurred, please try again.');
+    if (isLoading) setButtonLabel('Sending email');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error, isLoading, sendVerificationEmail]);
+
+  return (
+    <PrimaryButton
+      label={buttonLabel}
+      onClick={handleSendEmail}
+      size="medium"
+      iconLeft={
+        isLoading ? <LoadingSpinner scale="s" /> : <MailIcon size="medium" />
+      }
+    />
+  );
+};
+
+export default SendVerificationEmailButton;

--- a/packages/gatsby-theme-docs/src/modules/self-learning/hooks/use-send-verification-email.ts
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/hooks/use-send-verification-email.ts
@@ -1,0 +1,102 @@
+import { useState, useContext, useCallback } from 'react';
+import ConfigContext from '../../../components/config-context';
+import type { QuizAttempt } from '../components/quiz';
+import { useAuthToken } from './use-auth-token';
+import { MaintenanceModeError, ServiceDownError } from './use-attempt';
+import { useAsyncComplete } from '../../../hooks/use-async-complete';
+
+type VerificationEmailParams = {
+  userId: string;
+};
+
+export const useSendVerificationEmail = (
+  verificationEmailParams: VerificationEmailParams
+) => {
+  const { learnApiBaseUrl } = useContext(ConfigContext);
+  const { userId } = verificationEmailParams;
+  const { getAuthToken } = useAuthToken();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | undefined>();
+  const [data, setData] = useState<QuizAttempt | undefined>();
+  const [correlationId, setCorrelationId] = useState<string | undefined>();
+  const { setAsyncLoading } = useAsyncComplete(
+    `/api/users/${userId}/send-verify-email`
+  );
+
+  const sendVerificationEmail = useCallback(
+    async (): Promise<Response> => {
+      const apiEndpoint = `${learnApiBaseUrl}/api/users/${userId}/send-verify-email`;
+      const accessToken = await getAuthToken();
+      const data = await fetch(apiEndpoint, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      });
+      return data;
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [userId, getAuthToken, learnApiBaseUrl]
+  );
+
+  const performSendVerificationEmail = useCallback(
+    async () => {
+      try {
+        setIsLoading(true);
+        setAsyncLoading(true);
+        const data = await sendVerificationEmail();
+        const correlationId = data.headers.get('X-Correlation-ID');
+        if (correlationId) {
+          setCorrelationId(correlationId);
+        }
+        if (data.status !== 200) {
+          if (data.status === 403) {
+            throw new MaintenanceModeError(
+              'Our learning management system is currently ongoing scheduled maintenance, please try again later'
+            );
+          }
+          if (data.status === 503) {
+            throw new ServiceDownError(
+              'Our learning management system is currently unavailable'
+            );
+          }
+          throw new Error();
+        } else {
+          const json = await data.json();
+          if (json?.errors?.length > 0) {
+            throw new Error(json?.errors[0].message);
+          }
+          setData(json.result);
+        }
+      } catch (error) {
+        if (
+          error instanceof MaintenanceModeError ||
+          error instanceof ServiceDownError
+        ) {
+          console.error(error.message);
+          setError(error.message);
+        } else {
+          const message = `Error while sending verification email: ${userId}`;
+          console.error(message);
+          setError('Unable to send verification email');
+        }
+      } finally {
+        setAsyncLoading(false);
+        setIsLoading(false);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sendVerificationEmail, userId]
+  );
+
+  return {
+    performSendVerificationEmail,
+    sendVerificationEmail: data,
+    isLoading,
+    error,
+    correlationId,
+  };
+};

--- a/packages/gatsby-theme-docs/src/modules/self-learning/hooks/use-send-verification-email.ts
+++ b/packages/gatsby-theme-docs/src/modules/self-learning/hooks/use-send-verification-email.ts
@@ -5,27 +5,18 @@ import { useAuthToken } from './use-auth-token';
 import { MaintenanceModeError, ServiceDownError } from './use-attempt';
 import { useAsyncComplete } from '../../../hooks/use-async-complete';
 
-type VerificationEmailParams = {
-  userId: string;
-};
-
-export const useSendVerificationEmail = (
-  verificationEmailParams: VerificationEmailParams
-) => {
+export const useSendVerificationEmail = () => {
   const { learnApiBaseUrl } = useContext(ConfigContext);
-  const { userId } = verificationEmailParams;
   const { getAuthToken } = useAuthToken();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | undefined>();
   const [data, setData] = useState<QuizAttempt | undefined>();
   const [correlationId, setCorrelationId] = useState<string | undefined>();
-  const { setAsyncLoading } = useAsyncComplete(
-    `/api/users/${userId}/send-verify-email`
-  );
+  const { setAsyncLoading } = useAsyncComplete(`/api/users/send-verify-email`);
 
   const sendVerificationEmail = useCallback(
     async (): Promise<Response> => {
-      const apiEndpoint = `${learnApiBaseUrl}/api/users/${userId}/send-verify-email`;
+      const apiEndpoint = `${learnApiBaseUrl}/api/users/send-verify-email`;
       const accessToken = await getAuthToken();
       const data = await fetch(apiEndpoint, {
         method: 'POST',
@@ -39,7 +30,7 @@ export const useSendVerificationEmail = (
       return data;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [userId, getAuthToken, learnApiBaseUrl]
+    [getAuthToken, learnApiBaseUrl]
   );
 
   const performSendVerificationEmail = useCallback(
@@ -79,7 +70,7 @@ export const useSendVerificationEmail = (
           console.error(error.message);
           setError(error.message);
         } else {
-          const message = `Error while sending verification email: ${userId}`;
+          const message = `Error while sending verification email`;
           console.error(message);
           setError('Unable to send verification email');
         }
@@ -89,7 +80,7 @@ export const useSendVerificationEmail = (
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [sendVerificationEmail, userId]
+    [sendVerificationEmail]
   );
 
   return {

--- a/packages/gatsby-theme-docs/src/modules/sso/sso.const.ts
+++ b/packages/gatsby-theme-docs/src/modules/sso/sso.const.ts
@@ -1,4 +1,5 @@
 export const AUTH0_CUSTOM_CLAIM_NS = 'https://docs.commercetools.com/';
 export const AUTH0_CLAIM_DISPLAYNAME = `${AUTH0_CUSTOM_CLAIM_NS}display_name`;
 export const AUTH0_CLAIM_GLOBAL_ACCOUNT_NAME = `${AUTH0_CUSTOM_CLAIM_NS}global_account_name`;
+export const AUTH0_CLAIM_GLOBAL_ACCOUNT_ID = `${AUTH0_CUSTOM_CLAIM_NS}global_account_id`;
 export const AUTH0_CLAIM_COMPANY = `${AUTH0_CUSTOM_CLAIM_NS}company`;


### PR DESCRIPTION
This PR covers the following problems and partially addresses commercetools/learning-tech#454 and part of commercetools/learning-tech#429
- Allowing a user to see their email that they logged in with.
- Allowing the user to see whether their account is verified or not and if not to resend a verification email.
- Allowing the user to see whether their company association is verified or not and instructions on how to verify it.

Still missing
- do we need to show anything else to push for email verification ? a notification message/ banner because now it is hidden inside the profile modal only

Some Screenshots how it looks like

![Screenshot 2023-08-16 at 12 26 02 pm](https://github.com/commercetools/commercetools-docs-kit/assets/24246852/ec731e12-e547-4847-acad-ef6c5609fe0b)
![Screenshot 2023-08-16 at 12 26 47 pm](https://github.com/commercetools/commercetools-docs-kit/assets/24246852/3197de14-64bc-4173-b9e6-bc8fbe0c1d6c)
