### PR TITLE
fix: fix clickable items under sidebar shade

### DIFF
--- a/.changeset/late-dolls-occur.md
+++ b/.changeset/late-dolls-occur.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Fix an issue with chapters and menu items not being clickable when they appear under the shadow area at the top of the scrollbar

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -521,6 +521,7 @@ const Sidebar = (props) => {
               nextScrollPosition > scrollFaderHeight / 2
                 ? 0 - scrollFaderHeight - 1
                 : 0 - nextScrollPosition / scrollFaderHeight,
+            'pointer-events': 'none',
           }}
         />
       </SidebarHeader>


### PR DESCRIPTION
Fix the issue reported in here: https://github.com/commercetools/commercetools-docs/pull/3869#issuecomment-1716345333