### PR TITLE
Fix comments color when highlighted

### DIFF
--- a/.changeset/chilly-pillows-remain.md
+++ b/.changeset/chilly-pillows-remain.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/ui-kit': patch
+---
+
+Fix color issue with comments in code examples when they are highlighted.

--- a/packages/ui-kit/src/components/code-block.tsx
+++ b/packages/ui-kit/src/components/code-block.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import Tooltip from '@commercetools-uikit/tooltip';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
 import { ClipboardIcon } from '@commercetools-uikit/icons';
-import { Highlight } from 'prism-react-renderer';
+import { Highlight, Token } from 'prism-react-renderer';
 import {
   colors,
   dimensions,
@@ -102,6 +102,19 @@ const getLineStyles = (options: {
     `;
   }
   return [promptLineStyles, highlightLineStyles];
+};
+
+const getTokenStyles = (options: {
+  token: Token;
+  shouldHighlightLine: boolean;
+}) => {
+  if (options.token.types.includes('comment') && options.shouldHighlightLine) {
+    return {
+      color: colors.light.textInverted,
+    };
+  }
+
+  return {};
 };
 
 /**
@@ -285,7 +298,17 @@ const CodeBlock = (props: CodeBlockProps) => {
                       })}
                     >
                       {line.map((token, key) => (
-                        <span key={key} {...getTokenProps({ token, key })} />
+                        <span
+                          key={key}
+                          {...getTokenProps({
+                            token,
+                            key,
+                            style: getTokenStyles({
+                              token,
+                              shouldHighlightLine,
+                            }),
+                          })}
+                        />
                       ))}
                     </div>
                   );

--- a/websites/docs-smoke-test/src/content/views/code-blocks.mdx
+++ b/websites/docs-smoke-test/src/content/views/code-blocks.mdx
@@ -37,9 +37,9 @@ curl -sH "Authorization: Bearer ACCESS_TOKEN" https://api.sphere.io/PROJECT_KEY/
 
 # Javascript
 
-Passing the option `highlightLines="2,5-7,11..16`.
+Passing the option `highlightLines="1-2,5-7,11..16`.
 
-```javascript highlightLines="2,5-7,11..16"
+```javascript highlightLines="1-2,5-7,11..16"
 // Constructor
 var anObject = new Object();
 


### PR DESCRIPTION
closes #1332

This PR is a proposal to fix a problem we have with comments in code examples when they are part of a highlighted section since currently they are not visible in that situation.

Check the first line of the following example:

**BEFORE**
![Screenshot 2023-10-18 at 10 29 45](https://github.com/commercetools/commercetools-docs-kit/assets/97907068/cdb36b00-0327-41fe-9fd3-771aab2c962a)

**AFTER**
![Screenshot 2023-10-18 at 10 28 58](https://github.com/commercetools/commercetools-docs-kit/assets/97907068/910e0191-e938-4473-a0c5-ed4ed5e46471)
