### PR TITLE
Adjust modal component for the chat modal

### DIFF
--- a/.changeset/three-jobs-greet.md
+++ b/.changeset/three-jobs-greet.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/ui-kit': patch
+---
+
+Adjust the FormDialog component for the chat assistant

--- a/packages/ui-kit/src/components/dialogs/internals/dialog-container.tsx
+++ b/packages/ui-kit/src/components/dialogs/internals/dialog-container.tsx
@@ -117,6 +117,7 @@ const DialogContainer = (props: Props) => (
                 flex-direction: column;
                 pointer-events: auto;
                 min-height: 0;
+                ${sizeStyles(props)}
               }
             `}
           >

--- a/packages/ui-kit/src/components/dialogs/internals/dialog-content.tsx
+++ b/packages/ui-kit/src/components/dialogs/internals/dialog-content.tsx
@@ -18,6 +18,7 @@ const getBorderCss = (props: DialogContentProps) => {
 // The overflow should be "auto", to make the container scrollable
 const DialogContent = styled.div`
   ${(props: DialogContentProps) => getBorderCss(props)}
+  padding-top: ${designTokens.spacingS};
   flex: 1;
   overflow: auto;
 `;

--- a/packages/ui-kit/src/components/dialogs/internals/dialog-content.tsx
+++ b/packages/ui-kit/src/components/dialogs/internals/dialog-content.tsx
@@ -18,7 +18,6 @@ const getBorderCss = (props: DialogContentProps) => {
 // The overflow should be "auto", to make the container scrollable
 const DialogContent = styled.div`
   ${(props: DialogContentProps) => getBorderCss(props)}
-  padding: ${designTokens.spacingM} 0 ${designTokens.spacingS};
   flex: 1;
   overflow: auto;
 `;


### PR DESCRIPTION
Fixes the height of the modal for `size=scale` and removes extra padding at the top and bottom.