### PR TITLE
chore: change pagination e2e to avoid img hydration error

### DIFF
--- a/cypress/e2e/docs-smoke-test/pagination.cy.ts
+++ b/cypress/e2e/docs-smoke-test/pagination.cy.ts
@@ -1,13 +1,19 @@
 import { URL_DOCS_SMOKE_TEST } from '../../support/urls';
 
 describe('Pagination', () => {
-  const baseUrl = `${URL_DOCS_SMOKE_TEST}components`;
+  const baseUrl = `${URL_DOCS_SMOKE_TEST}views`;
   const links = [
+    `${baseUrl}/markdown`,
+    `${baseUrl}/empty`,
+    `${baseUrl}/beta`,
+    `${baseUrl}/plan-tag`,
+    `${baseUrl}/nested-headings`,
+    `${baseUrl}/two-level-index-nav`,
+    `${baseUrl}/links`,
     `${baseUrl}/code-blocks`,
     `${baseUrl}/code-examples`,
-    `${baseUrl}/content-notifications`,
-    `${baseUrl}/images`,
-    `${baseUrl}/cards`,
+    `${baseUrl}/custom-anchor`,
+    `${baseUrl}/wide`,
   ];
   links.forEach((url, index) => {
     const nextUrl = links[index + 1];


### PR DESCRIPTION
pagination e2e test was running on `components` folder which includes `images`. This page is thorwing a hydration error which is a know issue but it's not relevant for the e2e test. So I decided to run the same pagination e2e on another folder. The functionality remains the same