### PR TITLE
Add TBC, and TO-DO for incomplete writing style checks

### DIFF
--- a/.changeset/grumpy-dingos-attend.md
+++ b/.changeset/grumpy-dingos-attend.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/writing-style": patch
+---
+
+Add TBC, and TO-DO for 'Incomplete' writing style checks

--- a/packages/writing-style/styles/commercetools/Incomplete.yml
+++ b/packages/writing-style/styles/commercetools/Incomplete.yml
@@ -6,5 +6,7 @@ tokens:
   - XXX
   - FIXME
   - TODO
+  - TO-DO
   - TBD
+  - TBC
   - NOTE


### PR DESCRIPTION
This PR extends the writing style checks for 'Incomplete' to add TBC and TO-DO.