### PR TITLE
Improve chat dialog spacing and layout

### DIFF
--- a/packages/gatsby-theme-docs/src/modules/ai-assistant/components/chat-modal-css-components.js
+++ b/packages/gatsby-theme-docs/src/modules/ai-assistant/components/chat-modal-css-components.js
@@ -3,17 +3,20 @@ import { designSystem } from '@commercetools-docs/ui-kit';
 
 export const ChatContainer = styled.div`
   height: 100%;
+  max-width: ${designSystem.dimensions.widths.pageContentWithMarginsAndPageNavigation};
+  margin: auto;
+  margin-top -8px; /* hack: take back the full content area, the basic dialog has two spacings configured at the top */
   display: grid;
   grid-template-columns: auto;
   grid-template-areas: 'chat';
 
   @media screen and (${designSystem.dimensions.viewports.tablet}) {
-    grid-template-columns: auto 25%;
+    grid-template-columns: auto 30%;
     grid-template-areas: 'chat references';
   }
 
   @media screen and (${designSystem.dimensions.viewports.largeDesktop}) {
-    grid-template-columns: 15% auto 25% 15%;
+    grid-template-columns: 15% auto 30% 15%;
     grid-template-areas: 'left-blank chat references right-blank';
   }
 `;
@@ -49,7 +52,7 @@ export const ChatMessagesWrapper = styled.div`
 
 export const ChatInputBox = styled.div`
   padding: ${designSystem.dimensions.spacings.m}
-    ${designSystem.dimensions.spacings.m} ${designSystem.dimensions.spacings.l}
+    ${designSystem.dimensions.spacings.m} 0
     ${designSystem.dimensions.spacings.m};
 `;
 
@@ -62,7 +65,7 @@ export const ResetButtonBox = styled.div`
 export const RestartButtonBox = styled.div`
   display: flex;
   justify-content: center;
-  padding-top: ${designSystem.dimensions.spacings.m};
+  padding-top: ${designSystem.dimensions.spacings.s};
 `;
 
 export const LockedChatFooterContainer = styled.div`
@@ -77,7 +80,7 @@ export const CubeContainer = styled.div`
 `;
 
 export const ChatSideArea = styled.div`
-  padding: 0px ${designSystem.dimensions.spacings.s};
+  padding: 0px ${designSystem.dimensions.spacings.m};
   grid-area: references;
   display: flex;
   flex-direction: column;
@@ -106,9 +109,7 @@ export const SubmitButtonBox = styled.div`
 
 export const ChatBottomContainer = styled.div`
   margin-top: auto;
-  padding: ${designSystem.dimensions.spacings.m}
-    ${designSystem.dimensions.spacings.m} ${designSystem.dimensions.spacings.l}
-    ${designSystem.dimensions.spacings.m};
+  padding-top: ${designSystem.dimensions.spacings.m};
 `;
 
 export const SideTopContainer = styled.div`
@@ -117,6 +118,9 @@ export const SideTopContainer = styled.div`
   flex-grow: 1;
   overflow-y: auto;
   padding: 0px ${designSystem.dimensions.spacings.m};
+  border: 1px solid ${designSystem.colors.light.borderPrimary};
+  background-color: ${designSystem.colors.light.surfacePrimary};
+  border-radius: 4px;
 `;
 
 export const BackgroundWrapper = styled.div`

--- a/packages/gatsby-theme-docs/src/modules/ai-assistant/components/chat-modal.jsx
+++ b/packages/gatsby-theme-docs/src/modules/ai-assistant/components/chat-modal.jsx
@@ -552,7 +552,7 @@ const ChatModal = () => {
                     placeholder={
                       currentChatMode?.key === DEV_TOOLING_MODE
                         ? 'Specify your use case to generate the code.'
-                        : 'Use complete sentences for the best help.'
+                        : 'Use complete sentences best results'
                     }
                     value={formik.values.chatInput}
                     touched={formik.touched.chatInput}

--- a/packages/gatsby-theme-docs/src/modules/ai-assistant/components/chat-references-list.jsx
+++ b/packages/gatsby-theme-docs/src/modules/ai-assistant/components/chat-references-list.jsx
@@ -8,10 +8,7 @@ import { createReferenceGroup } from './chat.utils';
 const ReferenceContainer = styled.div`
   height: fit-content;
   width: 100%;
-  background-color: ${designSystem.colors.light.surfacePrimary};
-  border: 1px solid ${designSystem.colors.light.borderPrimary};
-  border-radius: 4px;
-  padding: ${designSystem.dimensions.spacings.m};
+  padding: ${designSystem.dimensions.spacings.m} 0;
   font-size: ${designSystem.typography.fontSizes.small};
   overflow: hidden;
 


### PR DESCRIPTION
The chat dialog's slightly unpolished look has always bugged my given the eyes that are currently on it.  

Here's a few tweaks that adress my personal main scratch points

- sligthly wider right hand column,  it turns out we have to give it more focus because users start using the AI instead of search 
-  remove duplicated spacing in the resources list 
-  make the resources list scroll inside the rounded box, not the rounded box scroll inside an invisible box (not sure why this slipped through initially)
- align the bottom content elements with the invisible dialog content area (no extra bottom spacing on top of the dialog's own spacing)
- take back 8px of duplicate spacing at the top (not sure why the dialog has its spacing and then another spacing on top of the dialog - hack through negative margin, did not want to touch the dialog proper
-