### PR TITLE
Add 'commerce' to Vale word list

### DIFF
--- a/.changeset/lazy-years-end.md
+++ b/.changeset/lazy-years-end.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/writing-style': minor
+---
+
+Adds commerce to word list

--- a/packages/writing-style/styles/commercetools/WordList.yml
+++ b/packages/writing-style/styles/commercetools/WordList.yml
@@ -11,6 +11,7 @@ swap:
   '(?:file ?path|path ?name)': path
   '(?:kill|terminate|abort)': stop|exit|cancel|end|deactivate|turn off
   'un(?:check|select)': clear
+  '(?:ecommerce|e-commerce)': commerce
   # above: preceding|over|this # note NK: I tried to change a few places and it did rather get cumbersome. I don't think it's worth the efforts.
   account name: username
   approx\.: approximately


### PR DESCRIPTION
In [docs ticket #4905](https://github.com/commercetools/commercetools-docs/pull/4905) we changed all instances of ecommerce/e-commerce to commerce. This PR is to update the Vale wordlist to reflect this.