### PR TITLE
[release notes] Further adjustments that need to go into the next release

### DIFF
--- a/.changeset/afraid-moose-tell.md
+++ b/.changeset/afraid-moose-tell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+Don't show product and productArea labels on release notes when the value is the Same. Adjusts the hover colors on release notes

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note-body.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note-body.js
@@ -65,7 +65,7 @@ const ReleaseNoteBody = (props) => {
                 <span>{product}</span>
               </CustomStamp>
             )}
-            {/* If product and productArea has the same value, we only want to show it once. */}
+            {/* If product and productArea have the same value, we only want to show it once. */}
             {productArea && productArea !== product && (
               <CustomStamp>
                 <span>{productArea}</span>

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note-body.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note-body.js
@@ -65,7 +65,8 @@ const ReleaseNoteBody = (props) => {
                 <span>{product}</span>
               </CustomStamp>
             )}
-            {productArea && (
+            {/* If product and productArea has the same value, we only want to show it once. */}
+            {productArea && productArea !== product && (
               <CustomStamp>
                 <span>{productArea}</span>
               </CustomStamp>

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-release-note.js
@@ -12,7 +12,7 @@ const linkStyles = css`
   color: ${designSystem.colors.light.textPrimary} !important;
 
   :hover {
-    color: ${designSystem.colors.light.linkNavigation} !important;
+    color: ${designSystem.colors.light.linkHover} !important;
   }
 `;
 

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -487,6 +487,9 @@ const Sidebar = (props) => {
   const isReleasePage = props.location.pathname.startsWith(
     withPrefix('/releases')
   );
+  const releaseNotesIconHoverStyle = isReleasePage
+    ? designSystem.colors.light.linkNavigation
+    : designSystem.colors.light.linkHover;
   const shouldRenderLinkToReleaseNotes = props.hasReleaseNotes;
   const shouldRenderBackToDocsLink = props.hasReleaseNotes && isReleasePage;
   // Restore scroll position
@@ -545,7 +548,7 @@ const Sidebar = (props) => {
                   color: ${designSystem.colors.light.linkHover} !important;
                   svg {
                     * {
-                      fill: ${designSystem.colors.light.linkHover};
+                      fill: ${releaseNotesIconHoverStyle};
                     }
                   }
                 }

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -112,10 +112,9 @@ const linkStyles = css`
 
   :hover {
     color: ${designSystem.colors.light.linkHover} !important;
-
     svg {
       * {
-        fill: ${designSystem.colors.light.linkHover};
+        fill: ${designSystem.colors.light.linkHover} !important;
       }
     }
   }
@@ -488,9 +487,6 @@ const Sidebar = (props) => {
   const isReleasePage = props.location.pathname.startsWith(
     withPrefix('/releases')
   );
-  const releaseNotesIconHoverStyle = isReleasePage
-    ? designSystem.colors.light.linkNavigation
-    : designSystem.colors.light.linkHover;
   const shouldRenderLinkToReleaseNotes = props.hasReleaseNotes;
   const shouldRenderBackToDocsLink = props.hasReleaseNotes && isReleasePage;
   // Restore scroll position
@@ -549,7 +545,7 @@ const Sidebar = (props) => {
                   color: ${designSystem.colors.light.linkHover} !important;
                   svg {
                     * {
-                      fill: ${releaseNotesIconHoverStyle};
+                      fill: ${designSystem.colors.light.linkHover};
                     }
                   }
                 }

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -112,6 +112,7 @@ const linkStyles = css`
 
   :hover {
     color: ${designSystem.colors.light.linkHover} !important;
+
     svg {
       * {
         fill: ${designSystem.colors.light.linkHover};

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -114,7 +114,7 @@ const linkStyles = css`
     color: ${designSystem.colors.light.linkHover} !important;
     svg {
       * {
-        fill: ${designSystem.colors.light.linkHover} !important;
+        fill: ${designSystem.colors.light.linkHover};
       }
     }
   }

--- a/websites/docs-smoke-test/src/releases/release-note-with-index-frontmatters.mdx
+++ b/websites/docs-smoke-test/src/releases/release-note-with-index-frontmatters.mdx
@@ -11,8 +11,8 @@ type:
   - deprecation
 topics:
   - Settings
-product: Composable Commerce
-productArea: HTTP APIs
+product: Connect
+productArea: Connect
 ---
 
 FooBar Intro Line: What this is good for (like description)


### PR DESCRIPTION
**Fixes**
- hover colors on release notes (discussed with @zbalek )
- show the `productArea` label only if `product` has not the same value already (see connect or checkout)