### PR TITLE
fix: bug in crawler selector to capture subtitle data while crawling

### DIFF
--- a/algolia-crawler.js
+++ b/algolia-crawler.js
@@ -93,7 +93,7 @@ new Crawler({
               // Not Records (not indexed at all):
               // - code examples
               // - API docs: oauth scopes of endpoints, URL of endpoints
-              '#body-content :not([data-search-key="embedded-api-description"]):not(li):not(dd):not(dt):not(td):not(blockquote) > p, #body-content h6, #body-content :not(li) > ul:not([data-search-key="cards-container"]), #body-content :not(li) > ol, #body-content :not(li) > blockquote, #body-content dl, #body-content figure, #body-content .lead, #body-content table',
+              '#body-content :not([data-search-key="embedded-api-description"]):not(li):not(dd):not(dt):not(td):not(blockquote) > p, #body-content h6, #body-content :not(li) > ul:not([data-search-key="cards-container"]), #body-content :not(li) > ol, #body-content :not(li) > blockquote, #body-content dl, #body-content figure, #body-content .section-lead, #body-content table',
           },
           indexHeadings: true,
         });


### PR DESCRIPTION
 **Description of changes** 

adjusted the crawler file (also in algolia) to properly crawl the subtitle of a page.

 **Link original ticket** 

https://github.com/commercetools/commercetools-docs/issues/3227

**Link to test the change**
https://docs-kit.commercetools.vercel.app/docs-smoke-test/

 **Screenshot of changes (if applicable)** 

<img width="925" alt="Screenshot 2024-07-08 at 2 16 44 PM" src="https://github.com/commercetools/commercetools-docs-kit/assets/24246852/8efc4114-9b7b-4b38-9e3d-94c194bb72b8">



[DoD guidelines](https://commercetools.atlassian.net/wiki/spaces/ET/pages/738820530/Definition+of+Done)

- [ ] user documentation added?
- [x] stakeholders approve changes? (if needed)
