### PR TITLE
chore: change footer links hover state color to match the other links…

### DIFF
--- a/.changeset/heavy-dodos-love.md
+++ b/.changeset/heavy-dodos-love.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+---
+
+change footer links hover color to match other links' color

--- a/packages/gatsby-theme-docs/src/components/global-navigation-link.js
+++ b/packages/gatsby-theme-docs/src/components/global-navigation-link.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/react';
 import { designSystem } from '@commercetools-docs/ui-kit';
 import Link from './link';
@@ -13,10 +12,10 @@ const linkStyles = css`
   }
 
   :hover {
-    color: ${designSystem.colors.light.linkNavigation} !important;
+    color: ${designSystem.colors.light.linkHover} !important;
 
     svg {
-      fill: ${designSystem.colors.light.linkNavigation} !important;
+      fill: ${designSystem.colors.light.linkHover} !important;
     }
   }
 `;


### PR DESCRIPTION
** Description of changes **
Hover state color for footer links is now matching the color of other links. This change was made to ensure consistency in the design of the links across the site.

** Link original ticket **
Closes #5213

** Screenshot of changes (if applicable) **
<img width="821" alt="Screenshot 2024-07-29 at 09 01 31" src="https://github.com/user-attachments/assets/b809f031-516d-4e11-9798-c8f1f5605521">


[DoD guidelines](https://commercetools.atlassian.net/wiki/spaces/ET/pages/738820530/Definition+of+Done)

- [ ] user documentation added?
- [ ] stakeholders approve changes? (if needed)
