### PR TITLE
Adds 'closed beta' to Vale wordlist

### DIFF
--- a/.changeset/honest-guests-double.md
+++ b/.changeset/honest-guests-double.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-docs/writing-style": patch
+---
+
+Adds 'early access' to Vale wordlist

--- a/packages/writing-style/styles/commercetools/WordList.yml
+++ b/packages/writing-style/styles/commercetools/WordList.yml
@@ -12,6 +12,7 @@ swap:
   '(?:kill|terminate|abort)': stop|exit|cancel|end|deactivate|turn off
   'un(?:check|select)': clear
   '(?:ecommerce|e-commerce)': commerce
+  '(?:closed beta)': early access
   # above: preceding|over|this # note NK: I tried to change a few places and it did rather get cumbersome. I don't think it's worth the efforts.
   account name: username
   approx\.: approximately


### PR DESCRIPTION
** Description of changes **: Closed Beta features would now be called Early Access features. As an extension to the primary changes made on https://github.com/commercetools/commercetools-docs/pull/5398, I have now added the 'closed beta' to the word list to minimize accidental usage of the old term.