### PR TITLE
Add placeholder orderHint in create-release-note script

### DIFF
--- a/packages/gatsby-theme-docs/bin/create-release-note.js
+++ b/packages/gatsby-theme-docs/bin/create-release-note.js
@@ -118,6 +118,7 @@ const selectQuestions = (customizedQuestions) => {
   const template = `---
 date: ${response.date}
 title: ${response.title}
+orderHint: 20
 description: |
   ${response.description}
 type: ${response.type}


### PR DESCRIPTION
Updates the create-release-note script to include a placeholder `orderHint` value.

As it appeared to be a quick change, I skipped creating an issue.

As nothing major is being changed, I did not feel necessary to add a changeset.