### PR TITLE
Ga release notes title override

### DIFF
--- a/.changeset/serious-panthers-repeat.md
+++ b/.changeset/serious-panthers-repeat.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': minor
+'@commercetools-website/docs-smoke-test': minor
+---
+
+Add the ability of override sidebar site title href via frontmatter property called `siteTitleHref`

--- a/cypress/e2e/docs-smoke-test/site-overrides.cy.ts
+++ b/cypress/e2e/docs-smoke-test/site-overrides.cy.ts
@@ -1,0 +1,27 @@
+import { URL_DOCS_SMOKE_TEST } from '../../support/urls';
+
+const overridesPageUrl = `${URL_DOCS_SMOKE_TEST}views/overrides`;
+
+describe('Site overrides', () => {
+  beforeEach(() => {
+    cy.visit(overridesPageUrl);
+  });
+  describe('when the page is rendered', () => {
+    it('should render "Custom Site Title" as site title in the sidebar', () => {
+      cy.get('span[id="site-title"]').contains('Custom Site Title');
+      cy.get('span#site-title')
+        .closest('a')
+        .should('have.attr', 'href', '/../views/custom-anchor');
+    });
+    it('should render "Custom Site Title" as site title breadcrumb section', () => {
+      cy.get('div[id="top-menu-switcher"] > div > span').contains(
+        'Custom Site Title'
+      );
+    });
+    it('should render "Custom Breadcrumb" as root breadcrumb', () => {
+      cy.get('div[id="top-menu-switcher"] > div > div').contains(
+        'Custom Breadcrumb'
+      );
+    });
+  });
+});

--- a/cypress/e2e/docs-smoke-test/site-overrides.cy.ts
+++ b/cypress/e2e/docs-smoke-test/site-overrides.cy.ts
@@ -7,11 +7,12 @@ describe('Site overrides', () => {
     cy.visit(overridesPageUrl);
   });
   describe('when the page is rendered', () => {
-    it('should render "Custom Site Title" as site title in the sidebar', () => {
+    it('should render "Custom Site Title" as site title and custom link in the sidebar', () => {
       cy.get('span[id="site-title"]').contains('Custom Site Title');
       cy.get('span#site-title')
         .closest('a')
-        .should('have.attr', 'href', '/../views/custom-anchor');
+        .should('have.attr', 'href')
+        .and('include', '/../views/custom-anchor');
     });
     it('should render "Custom Site Title" as site title breadcrumb section', () => {
       cy.get('div[id="top-menu-switcher"] > div > span').contains(

--- a/cypress/e2e/docs-smoke-test/site-overrides.cy.ts
+++ b/cypress/e2e/docs-smoke-test/site-overrides.cy.ts
@@ -12,7 +12,7 @@ describe('Site overrides', () => {
       cy.get('span#site-title')
         .closest('a')
         .should('have.attr', 'href')
-        .and('include', '/../views/custom-anchor');
+        .and('include', '/views/custom-anchor');
     });
     it('should render "Custom Site Title" as site title breadcrumb section', () => {
       cy.get('div[id="top-menu-switcher"] > div > span').contains(

--- a/packages/gatsby-theme-docs/gatsby-node.mjs
+++ b/packages/gatsby-theme-docs/gatsby-node.mjs
@@ -296,6 +296,9 @@ export const createSchemaCustomization = ({ actions, schema }) => {
           siteTitle: {
             type: `String!`,
           },
+          siteTitleHref: {
+            type: `String!`,
+          },
           siteBreadcrumbs: {
             type: `String!`,
           },
@@ -457,6 +460,9 @@ export const onCreateNode = async (
           : {}),
         ...(node.frontmatter.siteBreadcrumbs
           ? { siteBreadcrumbs: node.frontmatter.siteBreadcrumbs }
+          : {}),
+        ...(node.frontmatter.siteTitleHref
+          ? { siteTitleHref: node.frontmatter.siteTitleHref }
           : {}),
       },
     };

--- a/packages/gatsby-theme-docs/src/layouts/content.js
+++ b/packages/gatsby-theme-docs/src/layouts/content.js
@@ -55,6 +55,7 @@ const LayoutContent = (props) => {
 
   const siteTitle =
     props.pageData?.overrides?.siteTitle || siteData.siteMetadata.title;
+  const siteTitleHref = props.pageData?.overrides?.siteTitleHref;
   useAiAssistant();
 
   return (
@@ -69,6 +70,7 @@ const LayoutContent = (props) => {
         siteTitle={siteTitle}
         isGlobalBeta={siteData.siteMetadata.beta}
         hasReleaseNotes={props.pageContext.hasReleaseNotes}
+        siteTitleHref={siteTitleHref}
       />
       <LayoutMain
         {...layoutState.topMenu}
@@ -170,6 +172,7 @@ LayoutContent.propTypes = {
     overrides: PropTypes.shape({
       siteTitle: PropTypes.string,
       siteBreadcrumbs: PropTypes.string,
+      siteTitleHref: PropTypes.string,
     }),
   }).isRequired,
   children: PropTypes.node.isRequired,

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-sidebar.js
@@ -105,6 +105,7 @@ const LayoutSidebar = (props) => {
                 <SidebarComponent
                   onLinkClick={props.closeSidebarMenu}
                   siteTitle={props.siteTitle}
+                  siteTitleHref={props.siteTitleHref}
                   isGlobalBeta={props.isGlobalBeta}
                   hasReleaseNotes={props.hasReleaseNotes}
                 />
@@ -126,6 +127,7 @@ const LayoutSidebar = (props) => {
       >
         <SidebarComponent
           siteTitle={props.siteTitle}
+          siteTitleHref={props.siteTitleHref}
           isGlobalBeta={props.isGlobalBeta}
           hasReleaseNotes={props.hasReleaseNotes}
         />
@@ -175,6 +177,7 @@ LayoutSidebar.propTypes = {
   isGlobalBeta: PropTypes.bool.isRequired,
   hasReleaseNotes: PropTypes.bool.isRequired,
   isSearchDialogOpen: PropTypes.bool.isRequired,
+  siteTitleHref: PropTypes.string,
 };
 
 export default LayoutSidebar;

--- a/packages/gatsby-theme-docs/src/layouts/internals/self-learning/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/self-learning/sidebar.js
@@ -449,6 +449,7 @@ const Sidebar = (props) => {
   // - initialize the new scroll position
   // - scroll to the previous position in case it was defined
   const nextScrollPosition = useScrollPosition(scrollContainerId);
+  const siteTitleHref = props.siteTitleHref || '/';
 
   return (
     <>
@@ -457,7 +458,7 @@ const Sidebar = (props) => {
         <WebsiteTitle>
           <SpacingsStack scale="xs">
             <div>{props.isGlobalBeta && <BetaTag />}</div>
-            <WebsiteTitleLink as={Link} to="/">
+            <WebsiteTitleLink as={Link} to={siteTitleHref}>
               <span id="site-title">{props.siteTitle}</span>
             </WebsiteTitleLink>
           </SpacingsStack>
@@ -544,6 +545,7 @@ Sidebar.displayName = 'Sidebar';
 Sidebar.propTypes = {
   onLinkClick: PropTypes.func,
   siteTitle: PropTypes.string.isRequired,
+  siteTitleHref: PropTypes.string,
   isGlobalBeta: PropTypes.bool.isRequired,
   hasReleaseNotes: PropTypes.bool.isRequired,
   // from @react/router

--- a/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/sidebar.js
@@ -514,6 +514,7 @@ const Sidebar = (props) => {
   // - initialize the new scroll position
   // - scroll to the previous position in case it was defined
   const nextScrollPosition = useScrollPosition(scrollContainerId);
+  const siteTitleHref = props.siteTitleHref || '/';
 
   return (
     <>
@@ -522,7 +523,7 @@ const Sidebar = (props) => {
         <WebsiteTitle>
           <SpacingsStack scale="xs">
             <div>{props.isGlobalBeta && <BetaTag />}</div>
-            <WebsiteTitleLink as={Link} to="/">
+            <WebsiteTitleLink as={Link} to={siteTitleHref}>
               <span id="site-title">{props.siteTitle}</span>
             </WebsiteTitleLink>
           </SpacingsStack>
@@ -589,6 +590,7 @@ Sidebar.displayName = 'Sidebar';
 Sidebar.propTypes = {
   onLinkClick: PropTypes.func,
   siteTitle: PropTypes.string.isRequired,
+  siteTitleHref: PropTypes.string,
   isGlobalBeta: PropTypes.bool.isRequired,
   hasReleaseNotes: PropTypes.bool.isRequired,
   // from @react/router

--- a/websites/docs-smoke-test/src/content/views/overrides.mdx
+++ b/websites/docs-smoke-test/src/content/views/overrides.mdx
@@ -1,7 +1,7 @@
 ---
 title: Site Overrides
 siteTitle: Custom Site Title
-siteTitleHref: /../views/custom-anchor
+siteTitleHref: /views/custom-anchor
 siteBreadcrumbs: Custom Breadcrumb
 ---
 

--- a/websites/docs-smoke-test/src/content/views/overrides.mdx
+++ b/websites/docs-smoke-test/src/content/views/overrides.mdx
@@ -1,6 +1,7 @@
 ---
 title: Site Overrides
 siteTitle: Custom Site Title
+siteTitleHref: /../views/custom-anchor
 siteBreadcrumbs: Custom Breadcrumb
 ---
 

--- a/websites/documentation/src/content/writing/pages.mdx
+++ b/websites/documentation/src/content/writing/pages.mdx
@@ -62,6 +62,8 @@ We support the following key-value pairs in the frontmatter section:
 
   - `siteTitle` (string): use to override the site title for a specific page. (for example in Glossary page)
 
+  - `siteTitleHref` (string): use to override the href link applied to the site title appearing in the sidebar area. (for example in Release Notes page)
+
   - `siteBreadcrumbs` (string): use to override the site root breadcrumb shown in the header for a specific page.
 
   Example:


### PR DESCRIPTION
Create the possibility of override the sidebar site title link href which by default links to the site root.

Closes [#5358](https://github.com/commercetools/commercetools-docs/issues/5378)

<img width="1058" alt="Screenshot 2024-09-05 at 16 09 12" src="https://github.com/user-attachments/assets/d8848355-7287-4510-95b0-e50b6afc584c">



[DoD guidelines](https://commercetools.atlassian.net/wiki/spaces/ET/pages/738820530/Definition+of+Done)

- [x] user documentation added?
- [ ] stakeholders approve changes? (if needed)
