### PR TITLE
Display multiple scopes in api endpoints in two columns

### DIFF
--- a/.changeset/fair-rockets-fix.md
+++ b/.changeset/fair-rockets-fix.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-api-docs': minor
+'@commercetools-api-specs/test': minor
+---
+
+Add API OAuth scopes columns layout

--- a/api-specs/test/api.raml
+++ b/api-specs/test/api.raml
@@ -68,7 +68,7 @@ uses:
       description: Create or Update (POST) operation to a resource.
       securedBy:
         - oauth_2_0:
-            scopes: ["manage_test:{projectKey}"]
+            scopes: ["manage_test:{projectKey}", "customer_id_test:{id}", "manage_my_profile_test:{projectKey}", "customer_id_test:{id}", "manage_my_profile_test:{projectKey}", "manage_test:{projectKey}", "manage_my_profile_test:{projectKey}", "customer_id_test:{id}", "manage_test:{projectKey}", "manage_my_profile_test:{projectKey}", "customer_id_test:{id}", "manage_my_profile_test:{projectKey}"]
       body:
         type: objects.ObjectTestTypeDraft
         example: !include examples/object-test-type-draft.json

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.js
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.js
@@ -1,19 +1,34 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import { Markdown } from '@commercetools-docs/ui-kit';
 import Title from './title';
+import { css } from '@emotion/react';
+
+const scopesGridStyle = css`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-gap: 0.5rem;
+`;
 
 const Scopes = (props) => {
+  const hasMultiColumnScope = props.scopes.length >= 10;
+  const canAppendComma = (index) =>
+    !hasMultiColumnScope && index < props.scopes.length - 1;
+
   return (
     <SpacingsStack scale="xs">
       <Title>OAuth 2.0 Scopes:</Title>
 
-      <div>
+      <div css={hasMultiColumnScope && scopesGridStyle}>
         {props.scopes.map((scope, index) => (
-          <Markdown.InlineCodeWithoutBox key={scope}>
+          <Markdown.InlineCodeWithoutBox
+            key={scope}
+            css={css`
+              word-break: break-all;
+            `}
+          >
             {scope}
-            {index < props.scopes.length - 1 && ' , '}
+            {canAppendComma(index) && ' , '}
           </Markdown.InlineCodeWithoutBox>
         ))}
       </div>

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.tsx
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.tsx
@@ -2,13 +2,14 @@ import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import { Markdown } from '@commercetools-docs/ui-kit';
 import Title from './title';
 import styled from '@emotion/styled';
+import { dimensions } from '@commercetools-docs/ui-kit/src/design-system';
 
 type ScopesProps = {
   scopes: string[];
 };
 
 const Container = styled.div`
-  @media (min-width: 768px) {
+  @media screen and (${dimensions.viewports.tablet}) {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     grid-gap: 0.5rem;
@@ -19,10 +20,12 @@ const Container = styled.div`
 `;
 
 const Text = styled(Markdown.InlineCodeWithoutBox)`
-  :not(:last-child)&::after {
-    content: ', ';
+  @media screen and (${dimensions.viewports.mobile}) {
+    :not(:last-child)&::after {
+      content: ', ';
+    }
   }
-  @media only screen and (min-width: 768px) {
+  @media screen and (${dimensions.viewports.tablet}) {
     &::after {
       content: ' ';
     }

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.tsx
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import { Markdown } from '@commercetools-docs/ui-kit';
 import Title from './title';
@@ -10,9 +9,13 @@ const scopesGridStyle = css`
   grid-gap: 0.5rem;
 `;
 
-const Scopes = (props) => {
+type ScopesProps = {
+  scopes: string[];
+};
+
+const Scopes = (props: ScopesProps) => {
   const hasMultiColumnScope = props.scopes.length >= 10;
-  const canAppendComma = (index) =>
+  const canAppendComma = (index: number) =>
     !hasMultiColumnScope && index < props.scopes.length - 1;
 
   return (
@@ -34,10 +37,6 @@ const Scopes = (props) => {
       </div>
     </SpacingsStack>
   );
-};
-
-Scopes.propTypes = {
-  scopes: PropTypes.arrayOf(PropTypes.string.isRequired),
 };
 
 export default Scopes;

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.tsx
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.tsx
@@ -1,42 +1,44 @@
 import SpacingsStack from '@commercetools-uikit/spacings-stack';
 import { Markdown } from '@commercetools-docs/ui-kit';
 import Title from './title';
-import { css } from '@emotion/react';
-
-const scopesGridStyle = css`
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  grid-gap: 0.5rem;
-`;
+import styled from '@emotion/styled';
 
 type ScopesProps = {
   scopes: string[];
 };
 
-const Scopes = (props: ScopesProps) => {
-  const hasMultiColumnScope = props.scopes.length >= 10;
-  const canAppendComma = (index: number) =>
-    !hasMultiColumnScope && index < props.scopes.length - 1;
+const Container = styled.div`
+  @media (min-width: 768px) {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 0.5rem;
+    > code {
+      word-break: break-all;
+    }
+  }
+`;
 
-  return (
-    <SpacingsStack scale="xs">
-      <Title>OAuth 2.0 Scopes:</Title>
+const Text = styled(Markdown.InlineCodeWithoutBox)`
+  :not(:last-child)&::after {
+    content: ', ';
+  }
+  @media only screen and (min-width: 768px) {
+    &::after {
+      content: ' ';
+    }
+  }
+`;
 
-      <div css={hasMultiColumnScope && scopesGridStyle}>
-        {props.scopes.map((scope, index) => (
-          <Markdown.InlineCodeWithoutBox
-            key={scope}
-            css={css`
-              word-break: break-all;
-            `}
-          >
-            {scope}
-            {canAppendComma(index) && ' , '}
-          </Markdown.InlineCodeWithoutBox>
-        ))}
-      </div>
-    </SpacingsStack>
-  );
-};
+const Scopes = (props: ScopesProps) => (
+  <SpacingsStack scale="xs">
+    <Title>OAuth 2.0 Scopes:</Title>
+
+    <Container>
+      {props.scopes.map((scope, index) => (
+        <Text key={index}>{scope}</Text>
+      ))}
+    </Container>
+  </SpacingsStack>
+);
 
 export default Scopes;

--- a/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.tsx
+++ b/packages/gatsby-theme-api-docs/src/components/resource/method/scopes.tsx
@@ -9,13 +9,14 @@ type ScopesProps = {
 };
 
 const Container = styled.div`
+  display: grid;
+  grid-gap: 0.5rem;
+
+  @media screen and (${dimensions.viewports.mobile}) {
+    grid-template-columns: 1fr;
+  }
   @media screen and (${dimensions.viewports.tablet}) {
-    display: grid;
     grid-template-columns: repeat(2, 1fr);
-    grid-gap: 0.5rem;
-    > code {
-      word-break: break-all;
-    }
   }
 `;
 


### PR DESCRIPTION
** Description of changes **

** Link original ticket **
closes https://github.com/commercetools/commercetools-docs/issues/4871

** Screenshot of changes (if applicable) **
After:
<img width="816" alt="Screenshot 2024-09-10 at 2 46 02 PM" src="https://github.com/user-attachments/assets/8041bf16-f6cf-4913-876d-e7d5100811db">

Maintaining no column for less than 10 scopes and two columns for more than 10 scopes:
<img width="795" alt="Screenshot 2024-09-10 at 2 46 10 PM" src="https://github.com/user-attachments/assets/f71dbb78-e62e-4246-8c61-7e7688290425">


[DoD guidelines](https://commercetools.atlassian.net/wiki/spaces/ET/pages/738820530/Definition+of+Done)

- [ ] user documentation added?
- [x] stakeholders approve changes? (if needed)
