### PR TITLE
fix: scroll to anchor not working when navigating to a different page

### DIFF
--- a/.changeset/khaki-ghosts-know.md
+++ b/.changeset/khaki-ghosts-know.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-docs/gatsby-theme-docs': patch
+'@commercetools-website/docs-smoke-test': patch
+---
+
+Fix anchor navigation between pages

--- a/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
+++ b/packages/gatsby-theme-docs/src/layouts/internals/layout-application.js
@@ -13,6 +13,9 @@ const Root = styled.div`
   position: relative;
   width: 100vw;
   height: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch; /* enables "momentum" style scrolling */
 
   scroll-padding-top: ${(props) =>
     props.isGlobalNotificationVisible

--- a/websites/docs-smoke-test/src/content/views/links.mdx
+++ b/websites/docs-smoke-test/src/content/views/links.mdx
@@ -71,12 +71,12 @@ timeToRead: 5
 ### Link to another page on this site with a specific anchor a page on this site
 
 ```md
-[Link](/#links)
+[Link](/views/markdown#subsection-first-level)
 ```
 
 | Link            | Type          | Expected outcome                                                                                  |
 | --------------- | ------------- | ------------------------------------------------------------------------------------------------- |
-| [Link](/#links) | `gatsby-link` | It should be a Gatsby link, history navigation, and directly jump to the anchor element position. |
+| [Link](/views/markdown#subsection-first-level) | `gatsby-link` | It should be a Gatsby link, history navigation, and directly jump to the anchor element position. |
 
 ### Link to another page on this site using a relative upwards traversal path
 


### PR DESCRIPTION
** Description of changes **
Fix the normal scroll to anchor behaviour which appeared to be broken by [this PR](https://github.com/commercetools/commercetools-docs-kit/pull/2031/files).
Reverting this change will disable the [highlighting of search results in the scrollbar](https://github.com/commercetools/commercetools-docs-kit/issues/1606).

I think at the moment is better to prioritise a core functionality such as the scrolling to anchor over the highlighting of search results in the scrollbar.

** Link original ticket **
Closes https://github.com/commercetools/commercetools-docs/issues/5484

The issue can be checked here:
https://docskit-ga-broken-anchor-scroll.commercetools.vercel.app/docs-smoke-test/views/links#link-to-another-page-on-this-site-with-a-specific-anchor-a-page-on-this-site


- [ ] user documentation added?
- [ ] stakeholders approve changes? (if needed)
