### PR TITLE
chore: fix incorrect information in the docs

### DIFF
--- a/websites/documentation/src/content/writing/pages.mdx
+++ b/websites/documentation/src/content/writing/pages.mdx
@@ -58,13 +58,11 @@ We support the following key-value pairs in the frontmatter section:
 
 - `products` (array of string): if defined in a page, it overrides the site wide `products` setting which affects the [algolia search indexer](/configuration/algolia-search#per-site-tags-configuration). This setting is useful for helping indexing correctly specific pages that are part of a site but their focus is on different products.
 
-- `overrides` (an object) with the following properties:
+- `siteTitle` (string): use to override the site title for a specific page. (for example in Glossary page)
 
-  - `siteTitle` (string): use to override the site title for a specific page. (for example in Glossary page)
+- `siteTitleHref` (string): use to override the href link applied to the site title appearing in the sidebar area. (for example in Release Notes page)
 
-  - `siteTitleHref` (string): use to override the href link applied to the site title appearing in the sidebar area. (for example in Release Notes page)
-
-  - `siteBreadcrumbs` (string): use to override the site root breadcrumb shown in the header for a specific page.
+- `siteBreadcrumbs` (string): use to override the site root breadcrumb shown in the header for a specific page.
 
   Example:
 


### PR DESCRIPTION
Fix an incorrect information in the documentation site regarding site overrides in the frontmatter section of each page. Thanks @mar-gil for pointing that out